### PR TITLE
Remove some side-effecting asserts

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -109,10 +109,13 @@ int main( int argc, char *argv[] )
   /* don't let signals kill us */
   sigset_t signals_to_block;
 
-  assert( sigemptyset( &signals_to_block ) == 0 );
-  assert( sigaddset( &signals_to_block, SIGHUP ) == 0 );
-  assert( sigaddset( &signals_to_block, SIGPIPE ) == 0 );
-  assert( sigprocmask( SIG_BLOCK, &signals_to_block, NULL ) == 0 );
+  if ( sigemptyset( &signals_to_block )
+       || sigaddset( &signals_to_block, SIGHUP )
+       || sigaddset( &signals_to_block, SIGPIPE )
+       || sigprocmask( SIG_BLOCK, &signals_to_block, NULL ) ) {
+    perror( "blocking signals" );
+    exit( 1 );
+  }
 
   struct termios child_termios;
 
@@ -153,8 +156,11 @@ int main( int argc, char *argv[] )
 
     /* unblock signals */
     sigset_t signals_to_block;
-    assert( sigemptyset( &signals_to_block ) == 0 );
-    assert( sigprocmask( SIG_SETMASK, &signals_to_block, NULL ) == 0 );
+    if ( sigemptyset( &signals_to_block )
+         || sigprocmask( SIG_SETMASK, &signals_to_block, NULL ) ) {
+      perror( "unblocking signals" );
+      exit( 1 );
+    }
 
     /* set TERM */
     if ( setenv( "TERM", "xterm", true ) < 0 ) {
@@ -235,8 +241,11 @@ void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &network
     return;
   }
 
-  assert( selfpipe_trap( SIGTERM ) == 0 );
-  assert( selfpipe_trap( SIGINT ) == 0 );
+  if ( selfpipe_trap( SIGTERM )
+       || selfpipe_trap( SIGINT ) ) {
+    perror( "selfpipe_trap" );
+    return;
+  }
 
   /* prepare to poll for events */
   struct pollfd pollfds[ 3 ];

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -111,13 +111,16 @@ void STMClient::main_init( void )
     return;
   }
 
-  assert( selfpipe_trap( SIGWINCH ) == 0 );
-  assert( selfpipe_trap( SIGTERM ) == 0 );
-  assert( selfpipe_trap( SIGINT ) == 0 );
-  assert( selfpipe_trap( SIGHUP ) == 0 );
-  assert( selfpipe_trap( SIGPIPE ) == 0 );
-  assert( selfpipe_trap( SIGTSTP ) == 0 );
-  assert( selfpipe_trap( SIGCONT ) == 0 );
+  if ( selfpipe_trap( SIGWINCH )
+       || selfpipe_trap( SIGTERM )
+       || selfpipe_trap( SIGINT )
+       || selfpipe_trap( SIGHUP )
+       || selfpipe_trap( SIGPIPE )
+       || selfpipe_trap( SIGTSTP )
+       || selfpipe_trap( SIGCONT ) ) {
+    perror( "selfpipe_trap" );
+    return;
+  }
 
   /* get initial window size */
   if ( ioctl( STDIN_FILENO, TIOCGWINSZ, &window_size ) < 0 ) {


### PR DESCRIPTION
If someone built Mosh with -DNDEBUG, these effects would go away.
