### PR TITLE
Display::Display: Fix undefined pointer comparison

### DIFF
--- a/src/terminal/terminaldisplayinit.cc
+++ b/src/terminal/terminaldisplayinit.cc
@@ -54,7 +54,9 @@ Display::Display( bool use_environment )
 
     char ech_name[] = "ech";
     char *val = tigetstr( ech_name );
-    if ( val <= 0 ) {
+    if ( val == (char *)-1 )
+      throw std::string( "Invalid terminfo string capability " ) + ech_name;
+    if ( val == 0 ) {
       has_ech = false;
     }
   }


### PR DESCRIPTION
“If two pointers p and q of the same type point to different that are
not members of the same object or elements of the same array or to
different functions, or if only one of them is null, the results of
p<q, p>q, p<=q, and p>=q are unspecified.”

Signed-off-by: Anders Kaseorg andersk@mit.edu
