### PR TITLE
AX_CHECK_LIBRARY: Do not use m4_ifnblank

### DIFF
--- a/m4/ax_check_library.m4
+++ b/m4/ax_check_library.m4
@@ -90,6 +90,6 @@ AC_DEFUN([AX_CHECK_LIBRARY], [
 
   AS_IF([test "$]AS_TR_SH([ax_cv_have_]$1)[" = "yes"],
     AC_DEFINE([HAVE_]$1, [1], [Define to 1 if ]$1[ is found])
-      m4_ifnblank([$4], [$4]),
-    m4_ifnblank([$5], [$5]))
+    [$4],
+    [$5])
 ])


### PR DESCRIPTION
m4_ifnblank requires autoconf 2.64, and doesn’t seem necessary here.

Submitted upstream to autoconf-archive (no response yet):
https://savannah.gnu.org/patch/?7741

Signed-off-by: Anders Kaseorg andersk@mit.edu
