### PR TITLE
Explicitly disable dumping core

### DIFF
--- a/src/crypto/crypto.cc
+++ b/src/crypto/crypto.cc
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <sys/resource.h>
 
 #include "byteorder.h"
 #include "crypto.h"
@@ -245,4 +246,18 @@ Message Session::decrypt( string ciphertext )
   free( body );
 
   return ret;
+}
+
+/* Disable dumping core, as a precaution to avoid saving sensitive data
+   to disk. */
+void Crypto::disable_dumping_core( void ) {
+  struct rlimit limit;
+  limit.rlim_cur = 0;
+  limit.rlim_max = 0;
+  if ( 0 != setrlimit( RLIMIT_CORE, &limit ) ) {
+    /* We don't throw CryptoException because this is called very early
+       in main(), outside of 'try'. */
+    perror( "setrlimit(RLIMIT_CORE)" );
+    exit( 1 );
+  }
 }

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -84,6 +84,8 @@ namespace Crypto {
     Session( const Session & );
     Session & operator=( const Session & );
   };
+
+  void disable_dumping_core( void );
 }
 
 #endif

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -54,6 +54,9 @@ void print_colorcount( void )
 
 int main( int argc, char *argv[] )
 {
+  /* For security, make sure we don't dump core */
+  Crypto::disable_dumping_core();
+
   /* Get arguments */
   int opt;
   while ( (opt = getopt( argc, argv, "c" )) != -1 ) {

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -97,6 +97,9 @@ string get_SSH_IP( void )
 
 int main( int argc, char *argv[] )
 {
+  /* For security, make sure we don't dump core */
+  Crypto::disable_dumping_core();
+
   char *desired_ip = NULL;
   char *desired_port = NULL;
   char **command = NULL;


### PR DESCRIPTION
This is a precaution to avoid saving sensitive data to disk, e.g. session keys. We expect that corefiles are not world readable, but they're still sitting on the physical disk and it's safer just to disable creating them.

GitHub issue #71 deals with a similar concern.
