### PR TITLE
Added missing flags in src/statesync/Makefile.am

### DIFF
--- a/src/statesync/Makefile.am
+++ b/src/statesync/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I$(srcdir)/../util -I$(srcdir)/../terminal -I../protobufs $(BOOST_CPPFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/../util -I$(srcdir)/../terminal -I../protobufs $(BOOST_CPPFLAGS) $(protobuf_CFLAGS)
 AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) -fno-default-inline -pipe
 
 noinst_LIBRARIES = libmoshstatesync.a


### PR DESCRIPTION
Some missing flags needed to build for iOS.
