### PR TITLE
Fix getopt usage on FreeBSD

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -131,7 +131,7 @@ int main( int argc, char *argv[] )
        && (strcmp( argv[ 1 ], "new" ) == 0) ) {
     /* new option syntax */
     int opt;
-    while ( (opt = getopt( argc, argv, "i:p:c:s" )) != -1 ) {
+    while ( (opt = getopt( argc - 1, argv + 1, "i:p:c:s" )) != -1 ) {
       switch ( opt ) {
       case 'i':
 	desired_ip = optarg;


### PR DESCRIPTION
IMO 'new' should be dropped entirely since it's not optional and 'new' is the only choice.

If it does end up being an option then it could be done either like..

mosh-server -s -c 8 -p 12345 new -- some_command

or

mosh-server -t new -s -c 8 -p 12345 -- some_command
