### PR TITLE
Find ncurses from pkg-config if possible, and prefer separate libtinfo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,7 +107,7 @@ AS_IF([test x"$with_skalibs" != xno],
    AC_SUBST([STDDJB_LDFLAGS], ["$SKALIBS_LDFLAGS -lstddjb"])])
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h curses.h fcntl.h langinfo.h limits.h locale.h netinet/in.h stddef.h stdint.h inttypes.h stdlib.h string.h sys/ioctl.h sys/resource.h sys/socket.h sys/time.h term.h termios.h unistd.h wchar.h wctype.h], [], [AC_MSG_ERROR([Missing required header file.])])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h langinfo.h limits.h locale.h netinet/in.h stddef.h stdint.h inttypes.h stdlib.h string.h sys/ioctl.h sys/resource.h sys/socket.h sys/time.h term.h termios.h unistd.h wchar.h wctype.h], [], [AC_MSG_ERROR([Missing required header file.])])
 
 AC_CHECK_HEADERS([pty.h util.h libutil.h])
 AC_CHECK_HEADERS([endian.h sys/endian.h])
@@ -133,7 +133,15 @@ AC_CHECK_FUNCS([gettimeofday setrlimit inet_ntoa iswprint memchr memset nl_langi
 
 AC_SEARCH_LIBS([clock_gettime], [rt], [AC_DEFINE([HAVE_CLOCK_GETTIME], [1], [Define if clock_gettime is available.])])
 
-AC_CHECK_LIB([ncurses], [setupterm], [], [AC_MSG_ERROR([Missing ncurses.])])
+PKG_CHECK_MODULES([TINFO], [tinfo], ,
+  [PKG_CHECK_MODULES([TINFO], [ncurses], ,
+     [AX_CHECK_LIBRARY([TINFO], [curses.h], [tinfo],
+        [AC_SUBST([TINFO_CFLAGS], ["$TINFO_CPPFLAGS"])
+         AC_SUBST([TINFO_LIBS], ["$TINFO_LDFLAGS -ltinfo"])],
+        [AX_CHECK_LIBRARY([TINFO], [curses.h], [ncurses], ,
+           [AC_SUBST([TINFO_CFLAGS], ["$TINFO_CPPFLAGS"])
+            AC_SUBST([TINFO_LIBS], ["$TINFO_LDFLAGS -lncurses"])],
+           [AC_MSG_ERROR([Unable to find libtinfo or libncurses])])])])])
 
 AC_ARG_VAR([poll_CFLAGS], [C compiler flags for poll])
 AC_ARG_VAR([poll_LIBS], [linker flags for poll])

--- a/src/examples/Makefile.am
+++ b/src/examples/Makefile.am
@@ -19,7 +19,7 @@ parse_LDADD = ../terminal/libmoshterminal.a ../util/libmoshutil.a -lutil $(BOOST
 
 termemu_SOURCES = termemu.cc
 termemu_CPPFLAGS = -I$(srcdir)/../terminal -I$(srcdir)/../util -I$(srcdir)/../statesync -I../protobufs $(poll_CFLAGS)
-termemu_LDADD = ../terminal/libmoshterminal.a ../util/libmoshutil.a ../statesync/libmoshstatesync.a ../protobufs/libmoshprotos.a -lutil $(BOOST_LDFLAGS) $(protobuf_LIBS) $(poll_LIBS)
+termemu_LDADD = ../terminal/libmoshterminal.a ../util/libmoshutil.a ../statesync/libmoshstatesync.a ../protobufs/libmoshprotos.a -lutil $(BOOST_LDFLAGS) $(TINFO_LIBS) $(protobuf_LIBS) $(poll_LIBS)
 if COND_THIRD_LIBSTDDJB
   termemu_CPPFLAGS += -I$(top_srcdir)/third/libstddjb
   termemu_LDADD += $(top_builddir)/third/libstddjb/libstddjb.a
@@ -34,7 +34,7 @@ ntester_LDADD = ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ..
 
 benchmark_SOURCES = benchmark.cc
 benchmark_CPPFLAGS = -I$(srcdir)/../util -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I../protobufs -I$(srcdir)/../frontend -I$(srcdir)/../crypto $(BOOST_CPPFLAGS) -I$(srcdir)/../network $(poll_CFLAGS)
-benchmark_LDADD = ../frontend/terminaloverlay.o ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../protobufs/libmoshprotos.a ../network/libmoshnetwork.a ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(poll_LIBS) -lutil -lm $(BOOST_LDFLAGS) $(protobuf_LIBS)
+benchmark_LDADD = ../frontend/terminaloverlay.o ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../protobufs/libmoshprotos.a ../network/libmoshnetwork.a ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(poll_LIBS) -lutil -lm $(BOOST_LDFLAGS) $(TINFO_LIBS) $(protobuf_LIBS)
 if COND_THIRD_LIBSTDDJB
   benchmark_CPPFLAGS += -I$(top_srcdir)/third/libstddjb
   benchmark_LDADD += $(top_builddir)/third/libstddjb/libstddjb.a

--- a/src/frontend/Makefile.am
+++ b/src/frontend/Makefile.am
@@ -1,6 +1,6 @@
-AM_CPPFLAGS = -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I$(srcdir)/../network -I$(srcdir)/../crypto -I../protobufs -I$(srcdir)/../util $(BOOST_CPPFLAGS) $(protobuf_CFLAGS) $(poll_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I$(srcdir)/../network -I$(srcdir)/../crypto -I../protobufs -I$(srcdir)/../util $(BOOST_CPPFLAGS) $(TINFO_CFLAGS) $(protobuf_CFLAGS) $(poll_CFLAGS)
 AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) -fno-default-inline -pipe
-LDADD = ../crypto/libmoshcrypto.a ../network/libmoshnetwork.a ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../util/libmoshutil.a ../protobufs/libmoshprotos.a $(poll_LIBS) -lm $(protobuf_LIBS)
+LDADD = ../crypto/libmoshcrypto.a ../network/libmoshnetwork.a ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../util/libmoshutil.a ../protobufs/libmoshprotos.a $(poll_LIBS) -lm $(TINFO_LIBS) $(protobuf_LIBS)
 if COND_THIRD_LIBSTDDJB
   AM_CPPFLAGS += -I$(top_srcdir)/third/libstddjb
   LDADD += $(top_builddir)/third/libstddjb/libstddjb.a

--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I$(srcdir)/../util $(BOOST_CPPFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/../util $(BOOST_CPPFLAGS) $(TINFO_CFLAGS)
 AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) -fno-default-inline -pipe
 
 noinst_LIBRARIES = libmoshterminal.a


### PR DESCRIPTION
Recent ncurses can be configured --with-termlib, which splits out the
terminfo-level functions from libncurses into a separate libtinfo.
This allows us to avoid an unnecessary dependency on libncurses.  (We
already avoided this on distributions that link with -Wl,--as-needed.)

Signed-off-by: Anders Kaseorg andersk@mit.edu
