### PR TITLE
Patch parse_params() to deal with BSD strtol()

### DIFF
--- a/src/terminal/terminaldispatcher.cc
+++ b/src/terminal/terminaldispatcher.cc
@@ -85,7 +85,7 @@ void Dispatcher::parse_params( void )
     if ( endptr == segment_begin ) {
       val = -1;
     }
-    if ( errno == 0 ) {
+    if ( errno == 0 || segment_begin == endptr ) {
       parsed_params.push_back( val );
     }
 
@@ -99,7 +99,7 @@ void Dispatcher::parse_params( void )
   if ( endptr == segment_begin ) {
     val = -1;
   }
-  if ( errno == 0 ) {
+  if ( errno == 0 || segment_begin == endptr ) {
     parsed_params.push_back( val );
   }
 


### PR DESCRIPTION
strtol(3) can optionally set errno to EINVAL if no conversion could be
performed and FreeBSD (at least) implements thin behaviour.  Add an
explicit test to detect this situation in Dispatcher::parse_params().
(This behaviour difference is not relevant to other uses of strtol()).

This corrects the mishandling of (eg) "CSI m" on FreeBSD.
