### PR TITLE
configure.ac: Fix protoc check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,9 @@ AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_RANLIB
-AC_PATH_PROG([PROTOC], [protoc], [AC_MSG_ERROR([protoc is not found])])
+AC_PATH_PROG([PROTOC], [protoc], [])
+AS_IF([test x"$PROTOC" = x],
+  [AC_MSG_ERROR([cannot find protoc, the Protocol Buffers compiler])])
 
 WARNING_CXXFLAGS=""
 PICKY_CXXFLAGS=""


### PR DESCRIPTION
`AC_MSG_ERROR` inside the variable assignment doesn't work properly.  We get output like

```
checking for protoc... ./configure: line 4524: is: command not found
no
```

and then the build continues (and fails) with `PROTOC=""`.
