### PR TITLE
Augment Ubuntu PPA installation instructions. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Getting Mosh
 
   * [Ubuntu][], through a PPA
 
+        sudo apt-get install python-software-properties
         sudo add-apt-repository ppa:keithw/mosh
         sudo apt-get update
         sudo apt-get install mosh


### PR DESCRIPTION
Ubuntu 10.04 does not recognise `sudo add-apt-repository ppa:blah` out of the box.
