### PR TITLE
AX_CHECK_LIBRARY: Bump serial to match upstream

### DIFF
--- a/m4/ax_check_library.m4
+++ b/m4/ax_check_library.m4
@@ -60,7 +60,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 3
+#serial 4
 
 AC_DEFUN([AX_CHECK_LIBRARY], [
   AC_ARG_VAR($1[_CPPFLAGS], [C preprocessor flags for ]$1[ headers])


### PR DESCRIPTION
The m4_ifnblank patch was accepted upstream as
http://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=commitdiff;h=7ea1d1b18e5c1c3300936dd89c3e55b5b370ae72

Signed-off-by: Anders Kaseorg andersk@mit.edu
