### PR TITLE
scripts/mosh: Add --ssh flag

### DIFF
--- a/scripts/mosh
+++ b/scripts/mosh
@@ -33,21 +33,27 @@ my $predict = undef;
 
 my $port_request = undef;
 
+my $ssh = 'ssh';
+
 my $help = undef;
 my $version = undef;
 
 my $usage =
 qq{Usage: $0 [options] [--] [user@]host [command...]
         --client=PATH        mosh client on local machine
-                                (default: "mosh-client")
+                                (default: mosh-client)
         --server=PATH        mosh server on remote machine
-                                (default: "mosh-server")
+                                (default: mosh-server)
 
         --predict=adaptive   local echo for slower links [default]
 -a      --predict=always     use local echo even on fast links
 -n      --predict=never      never use local echo
 
 -p NUM  --port=NUM           server-side UDP port
+
+        --ssh=COMMAND        ssh command to run when setting up session
+                                (example: "ssh -p 2222")
+                                (default: "ssh")
 
         --help               this message
         --version            version and copyright information
@@ -79,6 +85,7 @@ GetOptions( 'client=s' => \$client,
 	    'a' => sub { $predict = 'always' },
 	    'n' => sub { $predict = 'never' },
 	    'p=i' => \$port_request,
+            'ssh=s' => \$ssh,
 	    'help' => \$help,
 	    'version' => \$version,
 	    'fake-proxy!' => \my $fake_proxy ) or die $usage;
@@ -201,7 +208,8 @@ if ( $pid == 0 ) { # child
   }
 
   my $quoted_self = shell_quote( $0 );
-  exec 'ssh', '-S', 'none', '-o', "ProxyCommand=$quoted_self --fake-proxy -- %h %p", '-t', $userhost, '--', "$server " . shell_quote( @server );
+  exec $ssh . " -S none -o " . shell_quote( "ProxyCommand=$quoted_self --fake-proxy -- %h %p" ) . " -t " .
+       shell_quote( $userhost ) . " -- " . shell_quote( $server ) . " " . shell_quote( @server );
   die "Cannot exec ssh: $!\n";
 } else { # server
   my ( $ip, $port, $key );


### PR DESCRIPTION
Let users specify an ssh outside their PATH, or extra flags like -p or -i.

Modify the usage message to describe this feature and hint at the semantic difference viz. --client=path\ to\ client vs --ssh="path\ to\ ssh".

Closes #53
