### PR TITLE
Don't leak utmpx entries on shutdown.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ AC_ARG_WITH([utempter],
   [with_utempter="$withval"],
   [with_utempter="check"])
 AS_IF([test x"$with_utempter" != xno],
-  [AC_SEARCH_LIBS([utempter_remove_added_record], [utempter],
+  [AC_SEARCH_LIBS([utempter_remove_record], [utempter],
     [AC_DEFINE([HAVE_UTEMPTER], [1], [Define if libutempter is available.])],
     [AS_IF([test x"$with_utempter" = xcheck],
       [AC_MSG_WARN([Unable to find libutempter; utmp entries will not be made.])],

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -349,14 +349,14 @@ int run_server( const char *desired_ip, const char *desired_port,
 	       e.text.c_str() );
     }
 
+    #ifdef HAVE_UTEMPTER
+    utempter_remove_record( master );
+    #endif
+
     if ( close( master ) < 0 ) {
       perror( "close" );
       exit( 1 );
     }
-
-    #ifdef HAVE_UTEMPTER
-    utempter_remove_added_record();
-    #endif
   }
 
   printf( "\n[mosh-server is exiting.]\n" );
@@ -469,7 +469,7 @@ void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &network
 	  /* update utmp entry if we have become "connected" */
 	  if ( (!connected_utmp)
 	       || ( saved_addr.s_addr != network.get_remote_ip().s_addr ) ) {
-	    utempter_remove_added_record();
+	    utempter_remove_record( host_fd );
 
 	    saved_addr = network.get_remote_ip();
 
@@ -566,7 +566,7 @@ void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &network
       /* update utmp if has been more than 10 seconds since heard from client */
       if ( connected_utmp ) {
 	if ( time_since_remote_state > 10000 ) {
-	  utempter_remove_added_record();
+	  utempter_remove_record( host_fd );
 
 	  char tmp[ 64 ];
 	  snprintf( tmp, 64, "mosh [%d]", getpid() );


### PR DESCRIPTION
As far as I know, for all implementations of libutempter, the
utempter_remove_added_record() function depends on the file descriptor
passed to utempter_add_record() to still be valid. The reason for this,
is that this file descriptor is propagated to the setuid utility that is
responsible for modifying utmpx.

Modify the code to remove the utmpx entry before closing the
pseudo-terminal master device. While there, simply use
utempter_remove_record(), which takes the file descriptor explicitly.
The advantage is that this prevents potential foot-shooting in the
future. Visual inspection of the source code will make it more obvious
that utempter depends on the file descriptor.
