### PR TITLE
mosh-client: Return true for still_connecting if !network

### DIFF
--- a/src/frontend/stmclient.h
+++ b/src/frontend/stmclient.h
@@ -53,7 +53,11 @@ private:
 
   void output_new_frame( void );
 
-  bool still_connecting( void ) { return (network->get_remote_state_num() == 0); }
+  bool still_connecting( void )
+  {
+    /* Initially, network == NULL */
+    return ( !network ) || ( network->get_remote_state_num() == 0 );
+  }
 
 public:
   STMClient( const char *s_ip, int s_port, const char *s_key, const char *predict_mode )


### PR DESCRIPTION
Fixes:

```
$ MOSH_KEY=foo ./mosh-client 127.0.0.1 60010
Crypto exception: Key must be 22 letters long.
Segmentation fault
```

Now we get

```
Crypto exception: Key must be 22 letters long.
mosh did not make a successful connection to 127.0.0.1:60010.
Please verify that UDP port 60010 is not firewalled and can reach the server.

(By default, mosh uses a UDP port between 60000 and 61000. The -p option
selects a specific UDP port number.)

[mosh is exiting.]
```

which is still confusing, but maybe ok.
