### PR TITLE
Hardcode the terminals which accept "set window title"

### DIFF
--- a/src/terminal/terminaldisplay.cc
+++ b/src/terminal/terminaldisplay.cc
@@ -42,9 +42,10 @@ std::string Display::new_frame( bool initialized, const Framebuffer &last, const
   }
 
   /* has icon name or window title changed? */
-  if ( (!initialized)
-       || (f.get_icon_name() != frame.last_frame.get_icon_name())
-       || (f.get_window_title() != frame.last_frame.get_window_title()) ) {
+  if ( has_title &&
+       ( (!initialized)
+         || (f.get_icon_name() != frame.last_frame.get_icon_name())
+         || (f.get_window_title() != frame.last_frame.get_window_title()) ) ) {
       /* set icon name and window title */
     if ( f.get_icon_name() == f.get_window_title() ) {
       /* write combined Icon Name and Window Title */

--- a/src/terminal/terminaldisplay.h
+++ b/src/terminal/terminaldisplay.h
@@ -56,6 +56,8 @@ namespace Terminal {
 
     bool has_bce; /* erases result in cell filled with background color */
 
+    bool has_title; /* supports window title and icon name */
+
     int posterize_colors; /* downsample input colors >8 to [0..7] */
 
     void put_cell( bool initialized, FrameState &frame, const Framebuffer &f ) const;


### PR DESCRIPTION
terminfo does not have reliable information on this, so we hardcode a whitelist of terminal type prefixes.  This is the list from Debian's default screenrc, plus "screen" itself (which also covers tmux).

Tested on rxvt and Linux console vt.

Closes #172.
