### PR TITLE
Disable dpkg-based setting of stack protector flags

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,10 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+# Through Autoconf we set hardening flags that are actually more aggressive
+# than the Ubuntu defaults, but they conflict with same.
+export DEB_BUILD_HARDENING_STACKPROTECTOR=0
+
 %:
 	dh $@ --with autoreconf
 


### PR DESCRIPTION
Through Autoconf we set hardening flags that are actually more aggressive than the Ubuntu defaults, but they conflict with same.

Should fix #203; I'll close that ticket manually if we get a good result from the buildds.
