### PR TITLE
Add version check for automake to autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,13 @@
 #!/bin/sh
 
+# Major version number has been 1 forever, only compare minor
+version=`aclocal --version | head -n1 | grep -Eo '[0-9.]+'`
+if [ `echo $version | cut -d'.' -f2` -lt 10 ]; then
+	cat << EOF
+Mosh requires automake version >= 1.10 (detected version $version) as it uses
+the --install flag to aclocal. Exiting...
+EOF
+	exit 1
+fi
+
 exec autoreconf -fi


### PR DESCRIPTION
Mosh requires aclocal to support the --install flag, which wasn't added until
automake version 1.10*. Since all of the version checking (AC_PREREQ and such)
is performed by aclocal itself, checking to see if install is supported must be
done before aclocal itself is called.

Ideally the restriction would be lifted in the future, but for now at least
supply users with a less cryptic message than 'unrecognized option --install'

*source: http://git.savannah.gnu.org/cgit/automake.git/tree/NEWS?id=v1.11.1&h=next&=switch

Signed-off-by: Pat Pannuto pat.pannuto@gmail.com
