### PR TITLE
Fix libutil.h test under FreeBSD 7.x/8.x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -244,7 +244,8 @@ PKG_CHECK_MODULES([TINFO], [tinfo], ,
 AC_CHECK_DECL([forkpty],
   [AC_DEFINE([FORKPTY_IN_LIBUTIL], [1],
      [Define if libutil.h necessary for forkpty().])],
-  , [[#include <libutil.h>]])
+  , [[#include <sys/types.h>
+  #include <libutil.h>]])
 
 AC_ARG_VAR([poll_CFLAGS], [C compiler flags for poll])
 AC_ARG_VAR([poll_LIBS], [linker flags for poll])


### PR DESCRIPTION
The conftest.c program generated lacks an include for sys/types.h.  Under FreeBSD 7.x/8.x, this causes the test to fail, even though it should succeed.

This should fix the issue listed here https://github.com/keithw/mosh/issues/136
