### PR TITLE
Define PROG, for newer versions of skalibs

### DIFF
--- a/src/examples/benchmark.cc
+++ b/src/examples/benchmark.cc
@@ -46,6 +46,11 @@
 #include "locale_utils.h"
 #include "fatal_assert.h"
 
+/* For newer skalibs */
+extern "C" {
+  const char *PROG = "benchmark";
+}
+
 const int ITERATIONS = 100000;
 
 using namespace Terminal;

--- a/src/examples/termemu.cc
+++ b/src/examples/termemu.cc
@@ -52,6 +52,11 @@
 #include "locale_utils.h"
 #include "sigfd.h"
 
+/* For newer skalibs */
+extern "C" {
+  const char *PROG = "termemu";
+}
+
 const size_t buf_size = 16384;
 
 void emulate_terminal( int fd );

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -30,6 +30,11 @@
 #include <curses.h>
 #include <term.h>
 
+/* For newer skalibs */
+extern "C" {
+  const char *PROG = "mosh-client";
+}
+
 void usage( const char *argv0 ) {
   fprintf( stderr, "mosh-client (%s)\n", PACKAGE_STRING );
   fprintf( stderr, "Copyright 2012 Keith Winstein <mosh-devel@mit.edu>\n" );

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -68,6 +68,11 @@
 
 #include "networktransport.cc"
 
+/* For newer skalibs */
+extern "C" {
+  const char *PROG = "mosh-server";
+}
+
 typedef Network::Transport< Terminal::Complete, Network::UserStream > ServerConnection;
 
 void serve( int host_fd,


### PR DESCRIPTION
Needed to build from our source tarball on some Gentoo systems.

Closes #239.
