### PR TITLE
Only use AM_PROG_AR if it’s defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,8 +18,7 @@ AS_IF([test x"$PROTOC" = x],
   [AC_MSG_ERROR([cannot find protoc, the Protocol Buffers compiler])])
 
 # automake 1.12 seems to require this, but automake 1.11 doesn't recognize it
-m4_pattern_allow([AM_PROG_AR])
-AM_PROG_AR
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
 WARNING_CXXFLAGS=""
 PICKY_CXXFLAGS=""


### PR DESCRIPTION
Fixes

```
aclocal:configure.ac:22: warning: macro `AM_PROG_AR' not found in library
```

and

```
./configure: line 4024: AM_PROG_AR: command not found
```

with old automake.

(Someone should probably test this with automake 1.12 first.)
