### PR TITLE
UDP hole punching for partly firewalled servers

### DIFF
--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -111,7 +111,16 @@ int main( int argc, char *argv[] )
   /* Read prediction preference */
   char *predict_mode = getenv( "MOSH_PREDICTION_DISPLAY" );
   /* can be NULL */
+  
+  int cport=0; 
+  char *client_port = getenv( "MOSH_CLIENT_PORT" );
+  if ( client_port )
+    cport=myatoi( client_port );
 
+  char* fw_hole_command = getenv( "MOSH_FW_HOLE_COMMAND" );
+  //turns out std::string handles NULL really badly
+  if (!fw_hole_command)
+    fw_hole_command="";
   char *key = strdup( env_key );
   if ( key == NULL ) {
     perror( "strdup" );
@@ -127,7 +136,7 @@ int main( int argc, char *argv[] )
   set_native_locale();
 
   try {
-    STMClient client( ip, port, key, predict_mode );
+    STMClient client( ip, port, key, predict_mode, cport, fw_hole_command );
     client.init();
 
     try {

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -151,7 +151,7 @@ void STMClient::main_init( void )
   Network::UserStream blank;
   Terminal::Complete local_terminal( window_size.ws_col, window_size.ws_row );
   network = new Network::Transport< Network::UserStream, Terminal::Complete >( blank, local_terminal,
-									       key.c_str(), ip.c_str(), port );
+									       key.c_str(), ip.c_str(), port, client_port );
 
   network->set_send_delay( 1 ); /* minimal delay on outgoing keystrokes */
 

--- a/src/frontend/stmclient.h
+++ b/src/frontend/stmclient.h
@@ -33,7 +33,8 @@ private:
   std::string ip;
   int port;
   std::string key;
-
+  int client_port;
+  std::string fw_hole_command;
   struct termios saved_termios, raw_termios;
 
   struct winsize window_size;
@@ -61,8 +62,10 @@ private:
   }
 
 public:
-  STMClient( const char *s_ip, int s_port, const char *s_key, const char *predict_mode )
+STMClient( const char *s_ip, int s_port, const char *s_key, const char *predict_mode,
+	   int s_client_port, char* s_fw_hole_command )
     : ip( s_ip ), port( s_port ), key( s_key ),
+      client_port( s_client_port ), fw_hole_command( s_fw_hole_command ),
       saved_termios(), raw_termios(),
       window_size(),
       local_framebuffer( NULL ),

--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -122,6 +122,7 @@ void Connection::setup( void )
   }
 }
 
+
 Connection::Connection( const char *desired_ip, const char *desired_port ) /* server */
   : sock( -1 ),
     has_remote_addr( false ),
@@ -231,7 +232,7 @@ bool Connection::try_bind( int socket, uint32_t s_addr, int port )
   return false;
 }
 
-Connection::Connection( const char *key_str, const char *ip, int port ) /* client */
+Connection::Connection( const char *key_str, const char *ip, int port, int client_port ) /* client */
   : sock( -1 ),
     has_remote_addr( false ),
     remote_addr(),
@@ -260,6 +261,10 @@ Connection::Connection( const char *key_str, const char *ip, int port ) /* clien
     char buffer[ 2048 ];
     snprintf( buffer, 2048, "Bad IP address (%s)", ip );
     throw NetworkException( buffer, saved_errno );
+  }
+
+  if ( client_port ) {
+    try_bind( sock, INADDR_ANY, client_port );
   }
 
   has_remote_addr = true;

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -50,6 +50,8 @@ namespace Network {
     TO_CLIENT = 1
   };
 
+  void make_firewall_hole(int signum);
+
   class Packet {
   public:
     uint64_t seq;
@@ -76,7 +78,7 @@ namespace Network {
 
     static const int PORT_RANGE_LOW  = 60001;
     static const int PORT_RANGE_HIGH = 60999;
-
+    
     static bool try_bind( int socket, uint32_t s_addr, int port );
 
     int sock;
@@ -111,7 +113,7 @@ namespace Network {
 
   public:
     Connection( const char *desired_ip, const char *desired_port ); /* server */
-    Connection( const char *key_str, const char *ip, int port ); /* client */
+    Connection( const char *key_str, const char *ip, int port, int client_port ); /* client */
     ~Connection();
 
     void send( string s );
@@ -125,7 +127,7 @@ namespace Network {
 
     uint64_t timeout( void ) const;
     double get_SRTT( void ) const { return SRTT; }
-
+    
     const struct in_addr & get_remote_ip( void ) const { return remote_addr.sin_addr; }
 
     const NetworkException *get_send_exception( void ) const

--- a/src/network/networktransport.cc
+++ b/src/network/networktransport.cc
@@ -40,8 +40,9 @@ Transport<MyState, RemoteState>::Transport( MyState &initial_state, RemoteState 
 
 template <class MyState, class RemoteState>
 Transport<MyState, RemoteState>::Transport( MyState &initial_state, RemoteState &initial_remote,
-					    const char *key_str, const char *ip, int port )
-  : connection( key_str, ip, port ),
+					    const char *key_str, const char *ip, int port,
+					    int client_port )
+  : connection( key_str, ip, port, client_port ),
     sender( &connection, initial_state ),
     received_states( 1, TimestampedState<RemoteState>( timestamp(), 0, initial_remote ) ),
     last_receiver_state( initial_remote ),

--- a/src/network/networktransport.h
+++ b/src/network/networktransport.h
@@ -54,7 +54,7 @@ namespace Network {
     Transport( MyState &initial_state, RemoteState &initial_remote,
 	       const char *desired_ip, const char *desired_port );
     Transport( MyState &initial_state, RemoteState &initial_remote,
-	       const char *key_str, const char *ip, int port );
+	       const char *key_str, const char *ip, int port, int client_port );
 
     /* Send data or an ack if necessary. */
     void tick( void ) { sender.tick(); }


### PR DESCRIPTION
Hi Keith, I finally managed to get github to generate a pull request. 

Most of the changes should already be described in my mail, I also added a string fw_hole_command which is read from some environment variable and meant to contain a shell line to get the server to dispatch another hole punching packet after client IP changes. (It is not used yet -- I'm not sure if it should be automatically run on some conditions or bound to a keyboard shortcut.)

I did not adapt the perl script yet but just wrote a minimal wrapper shell script (also included in the mail) to use the new hole-punching features. 
