### PR TITLE
Fix FTBFS on ARM on GCC 4.7.0 (Fedora 17)

### DIFF
--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -73,7 +73,8 @@ string Packet::tostring( Session *session )
 {
   uint64_t direction_seq = (uint64_t( direction == TO_CLIENT ) << 63) | (seq & SEQUENCE_MASK);
 
-  uint16_t ts_net[ 2 ] = { htobe16( timestamp ), htobe16( timestamp_reply ) };
+  uint16_t ts_net[ 2 ] = { static_cast<uint16_t>( htobe16( timestamp ) ),
+                           static_cast<uint16_t>( htobe16( timestamp_reply ) ) };
 
   string timestamps = string( (char *)ts_net, 2 * sizeof( uint16_t ) );
 


### PR DESCRIPTION
GCC v4.7.0, as found in Fedora 17 and newer, fails to build mosh on
ARM because of a narrowing warning, which is then promoted to an error
by -Werror.  This error message is new, and did not occur under
previous versions of GCC.

This patch corrects this error by explicitly casting to the desired
datatype the return value of the offending code, the result of a macro
from glibc to implement htobe16().
