### PR TITLE
Issue #300: Setting PERL_UNICODE breaks everything

### DIFF
--- a/scripts/mosh
+++ b/scripts/mosh
@@ -140,6 +140,9 @@ if ( defined $fake_proxy ) {
 				    PeerPort => $port,
 				    Proto => "tcp" )
     or die "$0: connect to host $ip port $port: $!\n";
+  binmode($sock);
+  binmode(STDIN);
+  binmode(STDOUT);
 
   sub cat {
     my ( $from, $to ) = @_;


### PR DESCRIPTION
Mark all file descriptors involved in raw ssh traffic as binary/raw
