### PR TITLE
Avoid null pointer dereference in mosh-server.cc

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -747,7 +747,7 @@ void chdir_homedir( void )
   struct passwd *pw = getpwuid( geteuid() );
   if ( pw == NULL ) {
     perror( "getpwuid" );
-    /* non-fatal */
+    return; /* non-fatal */
   }
 
   if ( chdir( pw->pw_dir ) < 0 ) {


### PR DESCRIPTION
Return if `pw` is NULL, to avoid dereferencing it at `pw->pw_dir`.
