### PR TITLE
Invalidate iterator if modifying this

### DIFF
--- a/src/statesync/user.cc
+++ b/src/statesync/user.cc
@@ -43,9 +43,15 @@ using namespace ClientBuffers;
 
 void UserStream::subtract( const UserStream *prefix )
 {
+  // if we are subtracting ourself from ourself, just clear the deque
+  if ( this == prefix ) {
+    actions.clear();
+    return;
+  }
   for ( deque<UserEvent>::const_iterator i = prefix->actions.begin();
 	i != prefix->actions.end();
 	i++ ) {
+    assert( this != prefix );
     assert( !actions.empty() );
     assert( *i == actions.front() );
     actions.pop_front();


### PR DESCRIPTION
If subtract is called on itself, prefix and this is the same and the
iterator is invalid after modifying the underlaying object.
