### PR TITLE
Use the right term.h

### DIFF
--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -53,18 +53,22 @@
 
 #if defined HAVE_NCURSESW_CURSES_H
 #  include <ncursesw/curses.h>
+#  include <ncursesw/term.h>
 #elif defined HAVE_NCURSESW_H
 #  include <ncursesw.h>
+#  include <term.h>
 #elif defined HAVE_NCURSES_CURSES_H
 #  include <ncurses/curses.h>
+#  include <ncurses/term.h>
 #elif defined HAVE_NCURSES_H
 #  include <ncurses.h>
+#  include <term.h>
 #elif defined HAVE_CURSES_H
 #  include <curses.h>
+#  include <term.h>
 #else
 #  error "SysV or X/Open-compatible Curses header file required"
 #endif
-#include <term.h>
 
 void usage( const char *argv0 ) {
   fprintf( stderr, "mosh-client (%s)\n", PACKAGE_STRING );

--- a/src/terminal/terminaldisplayinit.cc
+++ b/src/terminal/terminaldisplayinit.cc
@@ -40,18 +40,22 @@
 
 #if defined HAVE_NCURSESW_CURSES_H
 #  include <ncursesw/curses.h>
+#  include <ncursesw/term.h>
 #elif defined HAVE_NCURSESW_H
 #  include <ncursesw.h>
+#  include <term.h>
 #elif defined HAVE_NCURSES_CURSES_H
 #  include <ncurses/curses.h>
+#  include <ncurses/term.h>
 #elif defined HAVE_NCURSES_H
 #  include <ncurses.h>
+#  include <term.h>
 #elif defined HAVE_CURSES_H
 #  include <curses.h>
+#  include <term.h>
 #else
 #  error "SysV or X/Open-compatible Curses header file required"
 #endif
-#include <term.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
When ncurses is in a separate include dir, we need to take the term.h
from there to match with the [n]curses.h
