### PR TITLE
Don't keep sending state data to unresponsive clients

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -714,7 +714,10 @@ void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &network
         break;
       }
 
-      network.tick();
+      /* don't keep sending data to the client if we haven't heard back for more than 30 seconds */
+      if ( !time_since_remote_state > 30000 ) {
+        network.tick();
+      }
     } catch ( const Network::NetworkException& e ) {
       fprintf( stderr, "%s: %s\n", e.function.c_str(), strerror( e.the_errno ) );
       spin();


### PR DESCRIPTION
Don't continue sending state data or empty acks to the client if we haven't received a state update for more than 30 seconds.

This simple change prevents mosh-server from continuing to send UDP traffic to the last know client IP when the client becomes unresponsive, state updates are resumed when the client becomes responsive again. It saves unnecessary network traffic and prevents excessive battery-drain on mobile devices where the mosh client process can been killed/suspended silently in the background, but the server continues to send UDP traffic to the device. The traffic keeps the radio interfaces awake and the mobile device must waste time processing it. This affects the iSSH mosh implementation on iOS and causes significant battery drain, see https://groups.google.com/forum/?fromgroups=#!topic/issh/N42AM5LZO48
