### PR TITLE
Dup to pty to prevent ssh from reading our stdin

### DIFF
--- a/scripts/mosh
+++ b/scripts/mosh
@@ -222,9 +222,9 @@ my $pid = fork;
 die "$0: fork: $!\n" unless ( defined $pid );
 if ( $pid == 0 ) { # child
   $pty->close_slave();
-  $pty->set_raw();
   open STDOUT, ">&", $pty or die;
   open STDERR, ">&", $pty or die;
+  open STDIN, "<&", $pty or die;
 
   my @server = ( 'new', '-s' );
 


### PR DESCRIPTION
Dup the pty to STDIN to prevent hour the exec'ed ssh from consuming our
early input.
Due to the fact that mosh-server copies the pty settings from the pty it
as when starting, we can't set that one to a raw.

This are probably a combination of effects cased by fcc629ac and
18dc967c.

This fixes #366
