### PR TITLE
fix a perror() message in mosh-server

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -403,7 +403,7 @@ int run_server( const char *desired_ip, const char *desired_port,
 
     nullfd = open( "/dev/null", O_RDWR );
     if ( nullfd == -1 ) {
-      perror( "dup2" );
+      perror( "open" );
       exit( 1 );
     }
 


### PR DESCRIPTION
A perror() message flanking an open() call was reading "dup2" where it
should read "open".
