### PR TITLE
Fix lingering issues from #137

### DIFF
--- a/src/terminal/terminaldisplay.cc
+++ b/src/terminal/terminaldisplay.cc
@@ -56,7 +56,7 @@ std::string Display::new_frame( bool initialized, const Framebuffer &last, const
   }
 
   /* has icon name or window title changed? */
-  if ( has_title &&
+  if ( has_title && f.is_title_initialized() &&
        ( (!initialized)
          || (f.get_icon_name() != frame.last_frame.get_icon_name())
          || (f.get_window_title() != frame.last_frame.get_window_title()) ) ) {

--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -68,7 +68,7 @@ DrawState::DrawState( int s_width, int s_height )
 }
 
 Framebuffer::Framebuffer( int s_width, int s_height )
-  : rows( s_height, Row( s_width, 0 ) ), icon_name(), window_title(), bell_count( 0 ), ds( s_width, s_height )
+  : rows( s_height, Row( s_width, 0 ) ), icon_name(), window_title(), bell_count( 0 ), title_initialized( false ), ds( s_width, s_height )
 {
   assert( s_height > 0 );
   assert( s_width > 0 );

--- a/src/terminal/terminalframebuffer.h
+++ b/src/terminal/terminalframebuffer.h
@@ -248,6 +248,7 @@ namespace Terminal {
     std::deque<wchar_t> icon_name;
     std::deque<wchar_t> window_title;
     unsigned int bell_count;
+    bool title_initialized; /* true if the window title has been set via an OSC */
 
     Row newrow( void ) { return Row( ds.get_width(), ds.get_background_rendition() ); }
 
@@ -311,6 +312,8 @@ namespace Terminal {
     void reset( void );
     void soft_reset( void );
 
+    void set_title_initialized( void ) { title_initialized = true; }
+    bool is_title_initialized( void ) const { return title_initialized; }
     void set_icon_name( const std::deque<wchar_t> &s ) { icon_name = s; }
     void set_window_title( const std::deque<wchar_t> &s ) { window_title = s; }
     const std::deque<wchar_t> & get_icon_name( void ) const { return icon_name; }

--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -544,6 +544,7 @@ void Dispatcher::OSC_dispatch( const Parser::OSC_End *act, Framebuffer *fb )
     bool set_icon = (cmd_num == 0 || cmd_num == 1);
     bool set_title = (cmd_num == 0 || cmd_num == 2);
     if ( set_icon || set_title ) {
+      fb->set_title_initialized();
       std::deque<wchar_t> newtitle( OSC_string.begin() + offset, OSC_string.end() );
       if ( set_icon )  { fb->set_icon_name( newtitle ); }
       if ( set_title ) { fb->set_window_title( newtitle ); }


### PR DESCRIPTION
1) Allow mosh to support OSC sequences of the form ESC];foo^G, interpreting them the same as ESC]0;foo^G

2) Avoid changing the window title of the client if the title has never been set upstream.

(I made the changes you requested, osc_received is now title_initialized and I signed off the commits).
