### PR TITLE
Cancel menu mode on Ctrl-^ Esc

### DIFF
--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -286,6 +286,7 @@ bool STMClient::process_user_input( int fd )
 	} else if ( the_byte == '^' ) {
 	  /* Emulation sequence to type Ctrl-^ is Ctrl-^ ^ */
 	  network->get_current_state().push_back( Parser::UserByte( 0x1E ) );
+	} else if ( the_byte == 0x1b ) { /* Ctrl-^ Esc cancels menu mode */
 	} else {
 	  /* Ctrl-^ followed by anything other than . and ^ gets sent literally */
 	  network->get_current_state().push_back( Parser::UserByte( 0x1E ) );


### PR DESCRIPTION
Previously there was no way to get out of menu mode without taking some action (such as sending a keypress through).

Bikeshedding of UI details is welcome.
