### PR TITLE
Work around automake bug that dropped portability warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.61])
 AC_INIT([mosh], [1.2.4a], [mosh-devel@mit.edu])
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_SRCDIR([src/frontend/mosh-client.cc])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
There’s a [bug](http://debbugs.gnu.org/cgi-bin/bugreport.cgi?bug=7669) in automake ≥ 1.10, < 1.12 where `-Wall foreign` incorrectly turns off warnings about portability issues.  To get consistent results across automake versions, use `foreign -Wall` instead.
