### PR TITLE
perl-wrapper: add --bind-ip option

### DIFF
--- a/man/mosh.1
+++ b/man/mosh.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH MOSH 1 "October 2012"
+.TH MOSH 1 "Apil 2013"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -127,6 +127,14 @@ for example, if this is the
 only port that is forwarded through a firewall to the
 server. Otherwise, \fBmosh\fP will choose a port between 60000 and
 61000.
+
+.TP
+.B \-\-bind\-ip={ssh|\fIIP\fP}
+Bind the server to the ip of the ssh client or to IP by passing either the -s
+switch (default) or -i IP to \fBmosh-server\fP. This is useful when the login
+happens from an address different from the one used by the \fBmosh-client\fP.
+For example, if ssh is served through \fBsslh\fP, \fBSSH_CONNECTION\fP might be
+set to 127.0.0.1, but \fBmosh-server\fP can still be bound to 0.0.0.0.
 
 .TP
 .B \-\-no\-init

--- a/scripts/mosh
+++ b/scripts/mosh
@@ -44,6 +44,8 @@ my $server = 'mosh-server';
 
 my $predict = undef;
 
+my $bind_ip = undef;
+
 my $port_request = undef;
 
 my $ssh = 'ssh';
@@ -69,6 +71,9 @@ qq{Usage: $0 [options] [--] [user@]host [command...]
 
 -p PORT[:PORT2]
         --port=PORT[:PORT2]  server-side UDP port or range
+        --bind-ip={ssh|IP}   bind the server to the ip of the ssh client or to IP
+                                (example: "0.0.0.0")
+                                (default: "ssh")
 
         --ssh=COMMAND        ssh command to run when setting up session
                                 (example: "ssh -p 2222")
@@ -111,7 +116,8 @@ GetOptions( 'client=s' => \$client,
 	    'init!' => \$term_init,
 	    'help' => \$help,
 	    'version' => \$version,
-	    'fake-proxy!' => \my $fake_proxy ) or die $usage;
+	    'fake-proxy!' => \my $fake_proxy,
+        'bind-ip=s' => \$bind_ip) or die $usage;
 
 die $usage if ( defined $help );
 die $version_message if ( defined $version );
@@ -227,9 +233,15 @@ if ( $pid == 0 ) { # child
   close $p_write;
   close $p_read;
 
-  my @server = ( 'new', '-s' );
+  my @server = ( 'new' );
 
   push @server, ( '-c', $colors );
+
+  if ( not defined $bind_ip or $bind_ip =~ 'ssh' ) {
+      push @server , '-s';
+  } else {
+      push @server, ('-i', "$bind_ip");
+  }
 
   if ( defined $port_request ) {
     push @server, ( '-p', $port_request );


### PR DESCRIPTION
Allow overriding the switch passed to mosh-server from -s to -i IP.

Signed-off-by: Philipp Haselwarter philipp@haselwarter.org
