### PR TITLE
Provide an alternative mechanism for extracting the server IP address

### DIFF
--- a/scripts/mosh
+++ b/scripts/mosh
@@ -247,7 +247,7 @@ if ( $pid == 0 ) { # child
   exec "$ssh " . shell_quote( '-S', 'none', '-o', "ProxyCommand=$quoted_self --fake-proxy -- %h %p", '-n', '-tt', $userhost, '--', "$server " . shell_quote( @server ) );
   die "Cannot exec ssh: $!\n";
 } else { # parent
-  my ( $ip, $port, $key );
+  my ( $ip, $ssh_ip, $port, $key );
   my $bad_udp_port_warning = 0;
   close $p_write;
   LINE: while ( <$p_read> ) {
@@ -257,6 +257,11 @@ if ( $pid == 0 ) { # child
 	die "$0 error: detected attempt to redefine MOSH IP.\n";
       }
       ( $ip ) = m{^MOSH IP (\S+)\s*$} or die "Bad MOSH IP string: $_\n";
+    } elsif ( m{^MOSH SSHIP } ) {
+      if ( defined $ssh_ip ) {
+	die "$0 error: detected attempt to redefine MOSH SSHIP.\n";
+      }
+      ( $ssh_ip ) = m{^MOSH SSHIP (\S+)\s*$} or die "Bad MOSH SSHIP string: $_\n";
     } elsif ( m{^MOSH CONNECT } ) {
       if ( ( $port, $key ) = m{^MOSH CONNECT (\d+?) ([A-Za-z0-9/+]{22})\s*$} ) {
 	last LINE;
@@ -273,6 +278,7 @@ if ( $pid == 0 ) { # child
   waitpid $pid, 0;
   close $p_read;
 
+  $ip ||= $ssh_ip;
   if ( not defined $ip ) {
       die "$0: Did not find remote IP address (is SSH ProxyCommand disabled?).\n";
   }

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -350,7 +350,7 @@ int run_server( const char *desired_ip, const char *desired_port,
     network->set_verbose();
   }
 
-  printf( "\nMOSH CONNECT %d %s\n", network->port(), network->get_key().c_str() );
+  printf( "\nMOSH SSHIP %s\nMOSH CONNECT %d %s\n", get_SSH_IP().c_str(), network->port(), network->get_key().c_str() );
   fflush( stdout );
 
   /* don't let signals kill us */


### PR DESCRIPTION
On some installations of ssh, overriding ProxyCommand is forbidden,
which means that the fake proxy won't work.   Instead, have mosh-server
report the local address in SSH_CONNECTION, which will be used if
the fake proxy doesn't report an address.