### PR TITLE
Implement alternate screen

### DIFF
--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -68,7 +68,7 @@ DrawState::DrawState( int s_width, int s_height )
 }
 
 Framebuffer::Framebuffer( int s_width, int s_height )
-  : rows( s_height, Row( s_width, 0 ) ), icon_name(), window_title(), bell_count( 0 ), title_initialized( false ), ds( s_width, s_height )
+  : rows( s_height, Row( s_width, 0 ) ), icon_name(), window_title(), bell_count( 0 ), title_initialized( false ), saved_rows( s_height, Row( s_width, 0 ) ), saved_ds( s_width, s_height ), ds( s_width, s_height )
 {
   assert( s_height > 0 );
   assert( s_width > 0 );
@@ -314,6 +314,8 @@ void Framebuffer::reset( void )
   rows = std::deque<Row>( height, newrow() );
   window_title.clear();
   /* do not reset bell_count */
+  saved_rows = std::deque<Row>( height, newrow() );
+  saved_ds = DrawState( width, height );
 }
 
 void Framebuffer::soft_reset( void )
@@ -613,4 +615,20 @@ bool Cell::compare( const Cell &other ) const
   }
 
   return ret;
+}
+
+void Framebuffer::save_screen( void )
+{
+  saved_rows = rows;
+  saved_ds = ds;
+}
+
+void Framebuffer::restore_screen( void )
+{
+  int width = ds.get_width(), height = ds.get_height();
+
+  rows = saved_rows;
+  ds = saved_ds;
+
+  resize(width, height);
 }

--- a/src/terminal/terminalframebuffer.h
+++ b/src/terminal/terminalframebuffer.h
@@ -249,6 +249,8 @@ namespace Terminal {
     std::deque<wchar_t> window_title;
     unsigned int bell_count;
     bool title_initialized; /* true if the window title has been set via an OSC */
+    rows_type saved_rows;
+    DrawState saved_ds;
 
     Row newrow( void ) { return Row( ds.get_width(), ds.get_background_rendition() ); }
 
@@ -330,6 +332,9 @@ namespace Terminal {
 
     void ring_bell( void ) { bell_count++; }
     unsigned int get_bell_count( void ) const { return bell_count; }
+
+    void save_screen( void );
+    void restore_screen( void );
 
     bool operator==( const Framebuffer &x ) const
     {

--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -246,7 +246,7 @@ void CSI_TBC( Framebuffer *fb, Dispatcher *dispatch )
 /* TBC preserves wrap state */
 static Function func_CSI_TBC( CSI, "g", CSI_TBC, false );
 
-static bool *get_DEC_mode( int param, Framebuffer *fb ) {
+static bool *get_DEC_mode( int param, Framebuffer *fb, bool flag ) {
   switch ( param ) {
   case 1: /* cursor key mode */
     return &(fb->ds.application_mode_cursor_keys);
@@ -268,6 +268,11 @@ static bool *get_DEC_mode( int param, Framebuffer *fb ) {
     return &(fb->ds.auto_wrap_mode);
   case 25:
     return &(fb->ds.cursor_visible);
+  case 47:
+  case 1047:
+  case 1049:
+    flag ? fb->save_screen() : fb->restore_screen();
+    return NULL;
   }
   return NULL;
 }
@@ -276,7 +281,7 @@ static bool *get_DEC_mode( int param, Framebuffer *fb ) {
 void CSI_DECSM( Framebuffer *fb, Dispatcher *dispatch )
 {
   for ( int i = 0; i < dispatch->param_count(); i++ ) {
-    bool *mode = get_DEC_mode( dispatch->getparam( i, 0 ), fb );
+    bool *mode = get_DEC_mode( dispatch->getparam( i, 0 ), fb, true );
     if ( mode ) {
       *mode = true;
     }
@@ -287,7 +292,7 @@ void CSI_DECSM( Framebuffer *fb, Dispatcher *dispatch )
 void CSI_DECRM( Framebuffer *fb, Dispatcher *dispatch )
 {
   for ( int i = 0; i < dispatch->param_count(); i++ ) {
-    bool *mode = get_DEC_mode( dispatch->getparam( i, 0 ), fb );
+    bool *mode = get_DEC_mode( dispatch->getparam( i, 0 ), fb, false );
     if ( mode ) {
       *mode = false;
     }


### PR DESCRIPTION
Make it possible for Framebuffer to save and restore the current state of the screen. get_DEC_mode() in terminalfunctions.cc also needs to be patched to know the requested operation.
