### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET so that older macs can run the mosh binaries

### DIFF
--- a/macosx/build.sh
+++ b/macosx/build.sh
@@ -10,6 +10,8 @@ PREFIX_x86_64=`pwd`/prefix_x86_64
 #PREFIX_ppc=`pwd`/prefix_ppc
 #PREFIX_ppc64=`pwd`/prefix_ppc64
 
+export MACOSX_DEPLOYMENT_TARGET=10.6
+
 mkdir -p "$PREFIX"
 mkdir -p "$PREFIX_i386"
 mkdir -p "$PREFIX_x86_64"


### PR DESCRIPTION
This is a fix for #421

Here's the relevant section from the Apple GCC man page:

---

**-mmacosx-version-min**=version
    The earliest version of MacOS X that this executable will run on is version.  Typical values of version include 10.1, 10.2, and 10.3.9.

This value can also be set with the MACOSX_DEPLOYMENT_TARGET environment variable.  If both the command-line option is specified and the environment variable is set, the command-line option will take precedence.

If the compiler was built to use the system's headers by default, then the default for this option is the system version on which the compiler is running, otherwise the default is to make choices which are compatible with as many systems and code bases as possible.

This value is not set by default for ARM targets.
