### PR TITLE
Implement bracketed paste mode

### DIFF
--- a/src/terminal/terminaldisplay.cc
+++ b/src/terminal/terminaldisplay.cc
@@ -286,6 +286,12 @@ std::string Display::new_frame( bool initialized, const Framebuffer &last, const
     frame.current_rendition = f.ds.get_renditions();
   }
 
+  /* has bracketed paste mode changed? */
+  if ( (!initialized)
+       || (f.ds.bracketed_paste != frame.last_frame.ds.bracketed_paste) ) {
+    frame.append( f.ds.bracketed_paste ? "\033[?2004h" : "\033[?2004l" );
+  }
+
   return frame.str;
 }
 

--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -62,7 +62,7 @@ DrawState::DrawState( int s_width, int s_height )
     renditions( 0 ), save(),
     next_print_will_wrap( false ), origin_mode( false ), auto_wrap_mode( true ),
     insert_mode( false ), cursor_visible( true ), reverse_video( false ),
-    application_mode_cursor_keys( false )
+    bracketed_paste( false ), application_mode_cursor_keys( false )
 {
   reinitialize_tabs( 0 );
 }

--- a/src/terminal/terminalframebuffer.h
+++ b/src/terminal/terminalframebuffer.h
@@ -189,6 +189,7 @@ namespace Terminal {
     bool insert_mode;
     bool cursor_visible;
     bool reverse_video;
+    bool bracketed_paste;
 
     bool application_mode_cursor_keys;
 
@@ -237,7 +238,8 @@ namespace Terminal {
       /* only compare fields that affect display */
       return ( width == x.width ) && ( height == x.height ) && ( cursor_col == x.cursor_col )
 	&& ( cursor_row == x.cursor_row ) && ( cursor_visible == x.cursor_visible ) &&
-	( reverse_video == x.reverse_video ) && ( renditions == x.renditions );
+	( reverse_video == x.reverse_video ) && ( renditions == x.renditions ) &&
+  ( bracketed_paste == x.bracketed_paste );
     }
   };
 

--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -268,6 +268,8 @@ static bool *get_DEC_mode( int param, Framebuffer *fb ) {
     return &(fb->ds.auto_wrap_mode);
   case 25:
     return &(fb->ds.cursor_visible);
+  case 2004: /* bracketed paste */
+    return &(fb->ds.bracketed_paste);
   }
   return NULL;
 }


### PR DESCRIPTION
A fix for #427.

Allow bracketed paste mode-setting control sequences to be passed to the outer terminal.
