### PR TITLE
mosh-client: Print exceptions after the client is shut down

### DIFF
--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -176,11 +176,11 @@ int main( int argc, char *argv[] )
     try {
       client.main();
     } catch ( const Network::NetworkException &e ) {
-      fprintf( stderr, "Network exception: %s: %s\r\n",
-	       e.function.c_str(), strerror( e.the_errno ) );
+      client.shutdown();
+      throw e;
     } catch ( const Crypto::CryptoException &e ) {
-      fprintf( stderr, "Crypto exception: %s\r\n",
-	       e.text.c_str() );
+      client.shutdown();
+      throw e;
     }
 
     client.shutdown();


### PR DESCRIPTION
Otherwise the printed exception may be immediately hidden when the terminal exits alternate screen mode.
