### PR TITLE
issue #470 - close old socket before its is overwritten before assignmen...

### DIFF
--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -576,26 +576,25 @@ uint64_t Connection::timeout( void ) const
 
 Connection::Socket::~Socket()
 {
-  if ( close( _fd ) < 0 ) {
-    throw NetworkException( "close", errno );
+  if ( _fd != -1 && close( _fd ) < 0 ) {
+    // Avoid throw from a destructor
+    perror( "close ( fd )" );
   }
 }
 
 Connection::Socket::Socket( const Socket & other )
-  : _fd( dup( other._fd ) )
+  : _fd( other._fd )
 {
-  if ( _fd < 0 ) {
-    throw NetworkException( "socket", errno );
-  }
+  other._fd = -1;
 }
 
 Connection::Socket & Connection::Socket::operator=( const Socket & other )
 {
-  _fd = dup( other._fd );
-  
-  if ( _fd < 0 ) {
-    throw NetworkException( "socket", errno );
+  if ( _fd != -1 && close( _fd ) < 0 ) {
+    throw NetworkException( "close", errno );
   }
+  _fd = other._fd;
+  other._fd = -1;
 
   return *this;
 }

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -106,7 +106,9 @@ namespace Network {
     class Socket
     {
     private:
-      int _fd;
+      // To implement move, not copy semantics for _fd in the copy constructor
+      // and assignment the field must be writable even for const instances.
+      mutable int _fd;
 
     public:
       int fd( void ) const { return _fd; }


### PR DESCRIPTION
...t.

The patch also changes socket copy constructor and assignment of Socket to simply clear the _fd field in the copy source to avoid the need for calling dup - move semantic fot _fd is sufficient.
