### PR TITLE
More correct fix for mosh-server startup segfault

### DIFF
--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -286,7 +286,7 @@ bool Connection::try_bind( const char *addr, int port_low, int port_high )
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_DGRAM;
   hints.ai_flags = AI_PASSIVE | AI_NUMERICHOST | AI_NUMERICSERV;
-  AddrInfo ai( addr, 0, &hints );
+  AddrInfo ai( addr, "0", &hints );
 
   Addr local_addr;
   socklen_t local_addr_len = ai.res->ai_addrlen;


### PR DESCRIPTION
Commit 578db45fbf65d4e90bba371fe8d55f0455193a27 is wrong for the IPv6 case. I really did mean `NULL` and not `"0"` for `node` (see getaddrinfo(3)). Here’s a better fix.
