### PR TITLE
Timestamp: integer overflow in freeze_timestamp on Darwin PPC 32-bit

### DIFF
--- a/src/util/timestamp.cc
+++ b/src/util/timestamp.cc
@@ -79,7 +79,7 @@ void freeze_timestamp( void )
 
   // NB: mach_absolute_time() returns "absolute time units"
   // We need to apply a conversion to get milliseconds.
-  millis_cache = ((mach_absolute_time() * s_timebase_info.numer) / (1000000 * s_timebase_info.denom));
+  millis_cache = ((mach_absolute_time() * s_timebase_info.numer) / (uint64_t( 1000000 ) * s_timebase_info.denom));
   return;								    
 #elif HAVE_GETTIMEOFDAY
   // NOTE: If time steps backwards, timeouts may be confused.


### PR DESCRIPTION
This branch removes the Darwin-specific timestamp code.

`freeze_timestamp()` was previously using the `mach_absolute_time()` function on Darwin to calculate timestamps. This isn't really necessary, since Darwin also supports `gettimeofday()`, the case immediately afterwards.

This also happens to fix #479. There was an endian bug in the timestamp calculation that caused implausible timestamps on PowerPC, which is easily fixed but doesn't happen with `gettimeofday()` anyway.

(I'm assuming here the mach code was just supposed to be for OS X/iOS.)
