### PR TITLE
--no-ssh-pty option

### DIFF
--- a/man/mosh.1
+++ b/man/mosh.1
@@ -115,6 +115,12 @@ OpenSSH command to remotely execute mosh-server on remote machine (default: "ssh
 An alternate ssh port can be specified with, \fIe.g.\fP, \-\-ssh="ssh \-p 2222".
 
 .TP
+.B \-\-ssh-pty\fP
+.B \-\-no-ssh-pty\fP
+Enable or disable ssh's use of a pty when connecting to a remote host.
+The default is disabled.
+
+.TP
 .B \-\-predict=\fIWHEN\fP
 Controls use of speculative local echo. WHEN defaults to `adaptive'
 (show predictions on slower links and to smooth out network glitches)

--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -72,6 +72,8 @@ my $term_init = 1;
 
 my $localhost = undef;
 
+my $ssh_pty = 0;
+
 my $help = undef;
 my $version = undef;
 
@@ -103,6 +105,8 @@ qq{Usage: $0 [options] [--] [user@]host [command...]
         --ssh=COMMAND        ssh command to run when setting up session
                                 (example: "ssh -p 2222")
                                 (default: "ssh")
+
+        --no-ssh-pty         do not allocate a pseudo tty on ssh connection
 
         --no-init            do not send terminal initialization string
 
@@ -147,6 +151,7 @@ GetOptions( 'client=s' => \$client,
 	    '6' => sub { $family = 'inet6' },
 	    'p=s' => \$port_request,
 	    'ssh=s' => sub { @ssh = shellwords($_[1]); },
+	    'ssh-pty!' => \$ssh_pty,
 	    'init!' => \$term_init,
 	    'local' => \$localhost,
 	    'help' => \$help,
@@ -325,7 +330,10 @@ die "$0: fork: $!\n" unless ( defined $pid );
 if ( $pid == 0 ) { # child
   open(STDERR, ">&STDOUT") or die;
 
-  my @sshopts = ( '-n', '-tt' );
+  my @sshopts = ( '-n' );
+  if ($ssh_pty) {
+      push @sshopts, '-tt';
+  }
 
   my $ssh_connection = "";
   if ( $use_remote_ip eq 'remote' ) {

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -192,7 +192,7 @@ int main( int argc, char *argv[] )
     success = false;
   }
 
-  printf( "\n[mosh is exiting.]\n" );
+  printf( "[mosh is exiting.]\n" );
 
   free( key );
 

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -388,8 +388,6 @@ static int run_server( const char *desired_ip, const char *desired_port,
   if ( ioctl( STDIN_FILENO, TIOCGWINSZ, &window_size ) < 0 ||
        window_size.ws_col == 0 ||
        window_size.ws_row == 0 ) {
-    fprintf( stderr, "Server started without pseudo-terminal. Opening 80x24 terminal.\n" );
-
     /* Fill in sensible defaults. */
     /* They will be overwritten by client on first connection. */
     memset( &window_size, 0, sizeof( window_size ) );

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -406,7 +406,15 @@ static int run_server( const char *desired_ip, const char *desired_port,
     network->set_verbose();
   }
 
-  printf( "\nMOSH CONNECT %s %s\n", network->port().c_str(), network->get_key().c_str() );
+  /*
+   * If mosh-server is run on a pty, then typeahead may echo and break mosh.pl's
+   * detection of the MOSH CONNECT message.  Print it on a new line to bodge
+   * around that.
+   */
+  if ( isatty( STDIN_FILENO ) ) {
+    puts( "\r\n" );
+  }
+  printf( "MOSH CONNECT %s %s\n", network->port().c_str(), network->get_key().c_str() );
   fflush( stdout );
 
   /* don't let signals kill us */


### PR DESCRIPTION
This adds a --no-ssh-pty option to mosh.  I think this should probably be the default, actually.  I coded this up for an old Linux laptop with dropbear installed, but its network card stopped working shortly after I got this coded up, so it's lightly tested.  Resolves #464, probably.
