### PR TITLE
Made it easier to have multiple MOSHable hosts behind a NAT firewall

### DIFF
--- a/man/mosh-server.1
+++ b/man/mosh-server.1
@@ -39,7 +39,17 @@ establish a connection. It will exit if no client has contacted
 it within 60 seconds.
 
 By default, \fBmosh-server\fP binds to a port between 60000 and
-61000 and executes the user's login shell.
+61000 and executes the user's login shell.  A port or port-range 
+can be specified with the environment variable MOSH_SERVER_PORT.
+This allows the UDP port range to be set eg. in the 
+.BR .ssh/authorized_keys
+file.  That way the port range is configured on the server rather than
+the client, which is useful when multiple mosh-accessible servers
+are used through the same NAT firewall.  An example line in 
+\fB.ssh/authorized_keys\fP might start with
+\fBenvironment="MOSH_SERVER_PORT=60100:60200"\fP.  See
+.BR sshd(8) 
+for details.
 
 On platforms with \fButempter\fP, \fBmosh-server\fP maintains an entry
 in the
@@ -70,7 +80,8 @@ IP address of the local interface to bind (for multihomed hosts)
 
 .TP
 .B \-p \fIPORT\fP[:\fIPORT2\fP]
-UDP port number or port-range to bind
+UDP port number or port-range to bind.  Overrides environment variable
+MOSH_SERVER_PORT.
 
 .TP
 .B \-c \fICOLORS\fP

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -169,6 +169,9 @@ int main( int argc, char *argv[] )
   /* Will cause mosh-server not to correctly detach on old versions of sshd. */
   list<string> locale_vars;
 
+  char *env_sport = getenv( "MOSH_SERVER_PORT" );
+  if (env_sport != NULL) desired_port = env_sport;
+
   /* strip off command */
   for ( int i = 0; i < argc; i++ ) {
     if ( 0 == strcmp( argv[ i ], "--" ) ) { /* -- is mandatory */


### PR DESCRIPTION
In my use case, I have several servers behind the same NAT firewall, and it becomes difficult to remember on the client side what is the correct UDP port range forwarded to each server.  So I added a simple check in mosh-server for the MOSH_SERVER_PORT environment variable and I set the correct port range in my authorized_keys file.  Now, regardless of where I connect from, my mosh client is given an appropriate UDP port. 
