### PR TITLE
Allow non-inserting prediction (experimental).

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -42,6 +42,8 @@ my $server = 'mosh-server';
 
 my $predict = undef;
 
+my $overwrite = 0;
+
 my $bind_ip = undef;
 
 my $family = 'inet';
@@ -67,6 +69,8 @@ qq{Usage: $0 [options] [--] [user@]host [command...]
 -a      --predict=always        use local echo even on fast links
 -n      --predict=never         never use local echo
         --predict=experimental  aggressively echo even when incorrect
+
+-o      --overwrite             prediction overwrites instead of inserting
 
 -4      --family=inet        use IPv4 only [default]
 -6      --family=inet6       use IPv6 only
@@ -108,6 +112,7 @@ sub predict_check {
 GetOptions( 'client=s' => \$client,
 	    'server=s' => \$server,
 	    'predict=s' => \$predict,
+	    'overwrite|o!' => \$overwrite,
 	    'port=s' => \$port_request,
 	    'a' => sub { $predict = 'always' },
 	    'n' => sub { $predict = 'never' },
@@ -133,6 +138,10 @@ if ( defined $predict ) {
 } else {
   $predict = 'adaptive';
   predict_check( $predict, 0 );
+}
+
+if ( $overwrite ) {
+    $ENV{ "MOSH_PREDICTION_OVERWRITE" } = "yes";
 }
 
 if ( defined $port_request ) {

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -149,6 +149,10 @@ int main( int argc, char *argv[] )
   char *predict_mode = getenv( "MOSH_PREDICTION_DISPLAY" );
   /* can be NULL */
 
+  /* Read prediction insertion preference */
+  char *predict_overwrite = getenv( "MOSH_PREDICTION_OVERWRITE" );
+  /* can be NULL */
+
   char *key = strdup( env_key );
   if ( key == NULL ) {
     perror( "strdup" );
@@ -164,7 +168,7 @@ int main( int argc, char *argv[] )
   set_native_locale();
 
   try {
-    STMClient client( ip, desired_port, key, predict_mode );
+    STMClient client( ip, desired_port, key, predict_mode, predict_overwrite );
     client.init();
 
     try {

--- a/src/frontend/stmclient.h
+++ b/src/frontend/stmclient.h
@@ -83,7 +83,7 @@ private:
   void resume( void ); /* restore state after SIGCONT */
 
 public:
-  STMClient( const char *s_ip, const char *s_port, const char *s_key, const char *predict_mode )
+  STMClient( const char *s_ip, const char *s_port, const char *s_key, const char *predict_mode, const char *predict_overwrite )
     : ip( s_ip ), port( s_port ), key( s_key ),
     escape_key( 0x1E ), escape_pass_key( '^' ), escape_pass_key2( '^' ),
     escape_requires_lf( false ), escape_key_help( L"?" ),
@@ -114,6 +114,9 @@ public:
 	exit( 1 );
       }
     }
+    if ( predict_overwrite && !strcmp( predict_overwrite, "yes" ) ) {
+      overlays.get_prediction_engine().set_predict_overwrite( true );
+    } 
   }
 
   void init( void );

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -692,7 +692,7 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer &fb )
 	//	fprintf( stderr, "Backspace.\n" );
 	ConditionalOverlayRow &the_row = get_or_make_row( cursor().row, fb.ds.get_width() );
 
-	if ( cursor().col > 0 ) {
+	if ( !predict_overwrite && cursor().col > 0 ) {
 	  cursor().col--;
 	  cursor().expire( local_frame_sent + 1, now );
 
@@ -744,7 +744,8 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer &fb )
 	}
 
 	/* do the insert */
-	for ( int i = fb.ds.get_width() - 1; i > cursor().col; i-- ) {
+	int rightmost_column = predict_overwrite ? cursor().col + 1 : fb.ds.get_width() - 1;
+	for ( int i = rightmost_column; i > cursor().col; i-- ) {
 	  ConditionalOverlayCell &cell = the_row.overlay_cells[ i ];
 	  cell.reset_with_orig();
 	  cell.active = true;

--- a/src/frontend/terminaloverlay.h
+++ b/src/frontend/terminaloverlay.h
@@ -263,6 +263,7 @@ namespace Overlay {
 
   private:
     DisplayPreference display_preference;
+    bool predict_overwrite;
 
     bool active( void ) const;
 
@@ -273,6 +274,7 @@ namespace Overlay {
 
   public:
     void set_display_preference( DisplayPreference s_pref ) { display_preference = s_pref; }
+    void set_predict_overwrite( bool overwrite ) { predict_overwrite = overwrite; }
 
     void apply( Framebuffer &fb ) const;
     void new_user_byte( char the_byte, const Framebuffer &fb );
@@ -303,7 +305,8 @@ namespace Overlay {
 			       last_quick_confirmation( 0 ),
 			       send_interval( 250 ),
 			       last_height( 0 ), last_width( 0 ),
-			       display_preference( Adaptive )
+			       display_preference( Adaptive ),
+			       predict_overwrite( false )
     {
     }
   };


### PR DESCRIPTION
This adds an --overwrite option which disables prediction's visually-noisy insert/delete behavior right of the cursor, and instead relies on the server to update that text eventually.  It's not a finished work.  I spent about 5 seconds on coming up with the questionable name "overwrite" (and so I haven't documented anything yet), prediction gets turned off frequently and doesn't work as well with vertically-split windows, the update behavior on backspace is sometimes weird, etc etc.  But if people like this, all these things can be fixed.  I think it's sometimes a decent improvement, myself.
