### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - protobuf-compiler
+    - libprotobuf-dev
+    - libutempter-dev
+
+before_install:
+  - git fetch --tags --unshallow
+
+script:
+  - ./autogen.sh
+  - ./configure --enable-compile-warnings=error --enable-examples
+  - make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,7 @@ SUBDIRS = src scripts man conf
 EXTRA_DIST = autogen.sh ocb-license.html README.md COPYING.iOS
 BUILT_SOURCES = version.h
 CLANG_SCAN_BUILD = scan-build
+AM_DISTCHECK_CONFIGURE_FLAGS = --enable-compile-warnings=error --enable-examples
 
 .PHONY:	VERSION
 


### PR DESCRIPTION
Do not pull this until Travis is enabled for this repository. Here’s the [Travis log from my own repository](https://travis-ci.org/andersk/mosh/builds/73101675).

The `git fetch --tags --unshallow` is necessary to satisfy the `VERSION` generating code.