### PR TITLE
Specify syntax = "proto2" to silence warning with protobuf 3

### DIFF
--- a/src/protobufs/hostinput.proto
+++ b/src/protobufs/hostinput.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 option optimize_for = LITE_RUNTIME;
 
 package HostBuffers;

--- a/src/protobufs/transportinstruction.proto
+++ b/src/protobufs/transportinstruction.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 option optimize_for = LITE_RUNTIME;
 
 package TransportBuffers;

--- a/src/protobufs/userinput.proto
+++ b/src/protobufs/userinput.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 option optimize_for = LITE_RUNTIME;
 
 package ClientBuffers;


### PR DESCRIPTION
`[libprotobuf WARNING google/protobuf/compiler/parser.cc:491] No syntax specified for the proto file. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)`

The release notes say a future release will turn this warning into an error.