### PR TITLE
Validate bind-server option for both IPv4/6

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -162,12 +162,8 @@ if ( not defined $bind_ip or $bind_ip =~ m{^ssh$}i ) {
   push @bind_arguments, '-s';
 } elsif ( $bind_ip =~ m{^any$}i ) {
   # do nothing
-} elsif ( $bind_ip =~ m{^[0-9\.]+$} ) {
-  push @bind_arguments, ('-i', "$bind_ip");
 } else {
-  print STDERR qq{$0: Unknown server binding option: $bind_ip\n};
-
-  die $usage;
+  push @bind_arguments, ('-i', "$bind_ip");
 }
 
 if ( defined $fake_proxy ) {


### PR DESCRIPTION
bind-server option needs to support both IPv4 and IPv6 addresses, as it
previously only tried to detect IPv4 addresses. Now uses regex to
validate the addresses fully, including support for scoped IPv6
link-local in validating the IPv6 address.

Fixes: 669
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>