### PR TITLE
Switch to Nettle crypto lib-- trial balloon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,7 +243,7 @@ AC_CHECK_FUNCS(m4_normalize([
 
 AC_SEARCH_LIBS([clock_gettime], [rt], [AC_DEFINE([HAVE_CLOCK_GETTIME], [1], [Define if clock_gettime is available.])])
 
-PKG_CHECK_MODULES([OPENSSL], [openssl])
+PKG_CHECK_MODULES([NETTLE], [nettle])
 
 # Start by trying to find the needed tinfo parts by pkg-config
 PKG_CHECK_MODULES([TINFO], [tinfo],

--- a/src/crypto/Makefile.am
+++ b/src/crypto/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I$(srcdir)/../util $(OPENSSL_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/../util $(NETTLE_CFLAGS)
 AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) $(HARDEN_CFLAGS) $(MISC_CXXFLAGS)
 
 noinst_LIBRARIES = libmoshcrypto.a

--- a/src/crypto/base64.cc
+++ b/src/crypto/base64.cc
@@ -31,103 +31,64 @@
 */
 
 #include <string.h>
-#include <openssl/bio.h>
-#include <openssl/evp.h>
+#include <stdlib.h>
 
 #include "fatal_assert.h"
 #include "base64.h"
 
-bool base64_decode( const char *b64, const size_t b64_len,
-		    char *raw, size_t *raw_len )
-{
-  bool ret = false;
+static const char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
+bool base64_decode( const char *b64, const size_t b64_len,
+		    uint8_t *raw, size_t *raw_len )
+{
   fatal_assert( b64_len == 24 ); /* only useful for Mosh keys */
   fatal_assert( *raw_len == 16 );
 
-  /* initialize input/output */
-  BIO_METHOD *b64_method = BIO_f_base64();
-  fatal_assert( b64_method );
-
-  BIO *b64_bio = BIO_new( b64_method );
-  fatal_assert( b64_bio );
-
-  BIO_set_flags( b64_bio, BIO_FLAGS_BASE64_NO_NL );
-
-  BIO *mem_bio = BIO_new_mem_buf( (void *) b64, b64_len );
-  fatal_assert( mem_bio );
-
-  BIO *combined_bio = BIO_push( b64_bio, mem_bio );
-  fatal_assert( combined_bio );
-
-  fatal_assert( 1 == BIO_flush( combined_bio ) );
-  
-  /* read the string */
-  int bytes_read = BIO_read( combined_bio, raw, *raw_len );
-  if ( bytes_read <= 0 ) {
-    goto end;
+  uint32_t bytes = 0;
+  for (int i = 0; i < 22; i++) {
+    const char *match = strchr(table, *(b64++)); /* Yes.  Inefficient.  It doesn't matter. */
+    if (!match) {
+      return false;
+    }
+    bytes <<= 6;
+    bytes += match - table;
+    /* write groups of 3 */
+    if (i % 4 == 3) {
+      raw[0] = bytes >> 16;
+      raw[1] = bytes >> 8;
+      raw[2] = bytes;
+      raw += 3;
+      bytes = 0;
+    }
   }
-
-  if ( bytes_read != (int)*raw_len ) {
-    goto end;
+  /* last byte of output */
+  *(raw++) = bytes >> 4;
+  if (*(b64++) != '=' || *(b64++) != '=') {
+    return false;
   }
-
-  fatal_assert( 1 == BIO_flush( combined_bio ) );
-
-  /* check if there is more to read */
-  char extra[ 256 ];
-  bytes_read = BIO_read( combined_bio, extra, 256 );
-  if ( bytes_read > 0 ) {
-    goto end;
-  }
-
-  /* check if mem buf is empty */
-  if ( !BIO_eof( mem_bio ) ) {
-    goto end;
-  }
-
-  ret = true;
- end:
-  BIO_free_all( combined_bio );
-  return ret;
+  return true;
 }
 
-void base64_encode( const char *raw, const size_t raw_len,
+void base64_encode( const uint8_t *raw, const size_t raw_len,
 		    char *b64, const size_t b64_len )
 {
   fatal_assert( b64_len == 24 ); /* only useful for Mosh keys */
   fatal_assert( raw_len == 16 );
 
-  /* initialize input/output */
-  BIO_METHOD *b64_method = BIO_f_base64(), *mem_method = BIO_s_mem();
-  fatal_assert( b64_method );
-  fatal_assert( mem_method );
-
-  BIO *b64_bio = BIO_new( b64_method ), *mem_bio = BIO_new( mem_method );
-  fatal_assert( b64_bio );
-  fatal_assert( mem_bio );
-
-  BIO_set_flags( b64_bio, BIO_FLAGS_BASE64_NO_NL );
-
-  BIO *combined_bio = BIO_push( b64_bio, mem_bio );
-  fatal_assert( combined_bio );
+  /* first 15 bytes of input */
+  for (int i = 0; i < 5; i++) {
+    uint32_t bytes = (raw[0] << 16) | (raw[1] << 8) | raw[2];
+    b64[0] = table[(bytes >> 18) & 0x3f];
+    b64[1] = table[(bytes >> 12) & 0x3f];
+    b64[2] = table[(bytes >> 6) & 0x3f];
+    b64[3] = table[(bytes) & 0x3f];
+    raw += 3;
+    b64 += 4;
+  }
   
-  /* write the string */
-  int bytes_written = BIO_write( combined_bio, raw, raw_len  );
-  fatal_assert( bytes_written >= 0 );
-
-  fatal_assert( bytes_written == (int)raw_len );
-
-  fatal_assert( 1 == BIO_flush( combined_bio ) );
-
-  /* check if mem buf has desired length */
-  fatal_assert( BIO_pending( mem_bio ) == (int)b64_len );
-
-  char *mem_ptr;
-
-  BIO_get_mem_data( mem_bio, &mem_ptr );
-
-  memcpy( b64, mem_ptr, b64_len );
-
-  BIO_free_all( combined_bio );
+  /* last byte of input */
+  *(b64++) = table[*raw >> 2];
+  *(b64++) = table[(*raw << 4) & 0x3f];
+  *(b64++) = '=';
+  *(b64++) = '=';
 }

--- a/src/crypto/base64.h
+++ b/src/crypto/base64.h
@@ -30,8 +30,10 @@
     also delete it here.
 */
 
-bool base64_decode( const char *b64, const size_t b64_len,
-		    char *raw, size_t *raw_len );
+#include <stdint.h>
 
-void base64_encode( const char *raw, const size_t raw_len,
+bool base64_decode( const char *b64, const size_t b64_len,
+		    uint8_t *raw, size_t *raw_len );
+
+void base64_encode( const uint8_t *raw, const size_t raw_len,
 		    char *b64, const size_t b64_len );

--- a/src/crypto/crypto.cc
+++ b/src/crypto/crypto.cc
@@ -105,7 +105,7 @@ Base64Key::Base64Key( string printable_key )
   string base64 = printable_key + "==";
 
   size_t len = 16;
-  if ( !base64_decode( base64.data(), 24, (char *)&key[ 0 ], &len ) ) {
+  if ( !base64_decode( base64.data(), 24, &key[ 0 ], &len ) ) {
     throw CryptoException( "Key must be well-formed base64." );
   }
 
@@ -128,7 +128,7 @@ string Base64Key::printable_key( void ) const
 {
   char base64[ 24 ];
   
-  base64_encode( (char *)key, 16, base64, 24 );
+  base64_encode( key, 16, base64, 24 );
 
   if ( (base64[ 23 ] != '=')
        || (base64[ 22 ] != '=') ) {

--- a/src/examples/Makefile.am
+++ b/src/examples/Makefile.am
@@ -7,11 +7,11 @@ endif
 
 encrypt_SOURCES = encrypt.cc
 encrypt_CPPFLAGS = -I$(srcdir)/../crypto
-encrypt_LDADD = ../crypto/libmoshcrypto.a $(OPENSSL_LIBS)
+encrypt_LDADD = ../crypto/libmoshcrypto.a $(NETTLE_LIBS)
 
 decrypt_SOURCES = decrypt.cc
 decrypt_CPPFLAGS = -I$(srcdir)/../crypto
-decrypt_LDADD = ../crypto/libmoshcrypto.a $(OPENSSL_LIBS)
+decrypt_LDADD = ../crypto/libmoshcrypto.a $(NETTLE_LIBS)
 
 parse_SOURCES = parse.cc
 parse_CPPFLAGS = -I$(srcdir)/../terminal -I$(srcdir)/../util
@@ -23,8 +23,8 @@ termemu_LDADD = ../terminal/libmoshterminal.a ../util/libmoshutil.a ../statesync
 
 ntester_SOURCES = ntester.cc
 ntester_CPPFLAGS = -I$(srcdir)/../util -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I$(srcdir)/../network -I$(srcdir)/../crypto -I../protobufs $(protobuf_CFLAGS)
-ntester_LDADD = ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../network/libmoshnetwork.a ../crypto/libmoshcrypto.a ../protobufs/libmoshprotos.a ../util/libmoshutil.a $(LIBUTIL) -lm $(protobuf_LIBS)  $(OPENSSL_LIBS)
+ntester_LDADD = ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../network/libmoshnetwork.a ../crypto/libmoshcrypto.a ../protobufs/libmoshprotos.a ../util/libmoshutil.a $(LIBUTIL) -lm $(protobuf_LIBS)  $(NETTLE_LIBS)
 
 benchmark_SOURCES = benchmark.cc
 benchmark_CPPFLAGS = -I$(srcdir)/../util -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I../protobufs -I$(srcdir)/../frontend -I$(srcdir)/../crypto -I$(srcdir)/../network $(protobuf_CFLAGS)
-benchmark_LDADD = ../frontend/terminaloverlay.o ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../protobufs/libmoshprotos.a ../network/libmoshnetwork.a ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(STDDJB_LDFLAGS) $(LIBUTIL) -lm $(TINFO_LIBS) $(protobuf_LIBS) $(OPENSSL_LIBS)
+benchmark_LDADD = ../frontend/terminaloverlay.o ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../protobufs/libmoshprotos.a ../network/libmoshnetwork.a ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(STDDJB_LDFLAGS) $(LIBUTIL) -lm $(TINFO_LIBS) $(protobuf_LIBS) $(NETTLE_LIBS)

--- a/src/frontend/Makefile.am
+++ b/src/frontend/Makefile.am
@@ -1,7 +1,7 @@
-AM_CPPFLAGS = -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I$(srcdir)/../network -I$(srcdir)/../crypto -I../protobufs -I$(srcdir)/../util $(TINFO_CFLAGS) $(protobuf_CFLAGS) $(OPENSSL_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I$(srcdir)/../network -I$(srcdir)/../crypto -I../protobufs -I$(srcdir)/../util $(TINFO_CFLAGS) $(protobuf_CFLAGS) $(NETTLE_CFLAGS)
 AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) $(HARDEN_CFLAGS) $(MISC_CXXFLAGS)
 AM_LDFLAGS  = $(HARDEN_LDFLAGS)
-LDADD = ../crypto/libmoshcrypto.a ../network/libmoshnetwork.a ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../util/libmoshutil.a ../protobufs/libmoshprotos.a -lm $(TINFO_LIBS) $(protobuf_LIBS) $(OPENSSL_LIBS)
+LDADD = ../crypto/libmoshcrypto.a ../network/libmoshnetwork.a ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../util/libmoshutil.a ../protobufs/libmoshprotos.a -lm $(TINFO_LIBS) $(protobuf_LIBS) $(NETTLE_LIBS)
 
 mosh_server_LDADD = $(LDADD) $(LIBUTIL)
 

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -6,8 +6,8 @@ TESTS = ocb-aes encrypt-decrypt
 
 ocb_aes_SOURCES = ocb-aes.cc test_utils.cc test_utils.h
 ocb_aes_CPPFLAGS = -I$(srcdir)/../crypto -I$(srcdir)/../util
-ocb_aes_LDADD = ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(OPENSSL_LIBS)
+ocb_aes_LDADD = ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(NETTLE_LIBS)
 
 encrypt_decrypt_SOURCES = encrypt-decrypt.cc test_utils.cc test_utils.h
 encrypt_decrypt_CPPFLAGS = -I$(srcdir)/../crypto -I$(srcdir)/../util
-encrypt_decrypt_LDADD = ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(OPENSSL_LIBS)
+encrypt_decrypt_LDADD = ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(NETTLE_LIBS)


### PR DESCRIPTION
This was motivated by pain on OS X 10.11's dropping OpenSSL headers but not dylib.
This would probably want to be a configurable option, but it demonstrates that it's fairly easy for Mosh to switch crypto libraries.  There's also the idea of using Apple's Common Crypto on OS X.
