### PR TITLE
Fix link URLs in patent grant

### DIFF
--- a/ocb-license.html
+++ b/ocb-license.html
@@ -25,11 +25,11 @@ licensing for software not distributed under the GNU General Public License.
 
 
 <ul>
-<li> <a href="http://appft1.uspto.gov/netacgi/nph-Parser?Sect1=PTO2&Sect2=HITOFF&p=1&u=%2Fnetahtml%2FPTO%2Fsearch-bool.html&r=2&f=G&l=50&co1=AND&d=PG01&s1=rogaway.IN.&OS=IN/rogaway&RS=IN/rogaway">
+<li> <a href="http://appft1.uspto.gov/netacgi/nph-Parser?Sect1=PTO2&amp;Sect2=HITOFF&amp;p=1&amp;u=%2Fnetahtml%2FPTO%2Fsearch-bool.html&amp;r=2&amp;f=G&amp;l=50&amp;co1=AND&amp;d=PG01&amp;s1=rogaway.IN.&amp;OS=IN/rogaway&amp;RS=IN/rogaway">
 09/918,615</a>  -
 Method and Apparatus for Facilitating Efficient Authenticated Encryption.
 
-<li> <a href="http://appft1.uspto.gov/netacgi/nph-Parser?Sect1=PTO2&Sect2=HITOFF&p=1&u=%2Fnetahtml%2FPTO%2Fsearch-bool.html&r=3&f=G&l=50&co1=AND&d=PG01&s1=rogaway.IN.&OS=IN/rogaway&RS=IN/rogaway">
+<li> <a href="http://appft1.uspto.gov/netacgi/nph-Parser?Sect1=PTO2&amp;Sect2=HITOFF&amp;p=1&amp;u=%2Fnetahtml%2FPTO%2Fsearch-bool.html&amp;r=3&amp;f=G&amp;l=50&amp;co1=AND&amp;d=PG01&amp;s1=rogaway.IN.&amp;OS=IN/rogaway&amp;RS=IN/rogaway">
 09/948,084</a> - 
 Method and Apparatus for Realizing a Parallelizable Variable-Input-Length 
 Pseudorandom Function. 


### PR DESCRIPTION
Ampersands (&) need to be replaced with `&amp;` to be valid HTML, even in link targets.