### PR TITLE
mosh-server: Fix hang with ^S on OS X and FreeBSD.

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -577,6 +577,46 @@ static void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &
       now = Network::timestamp();
       uint64_t time_since_remote_state = now - network.get_latest_remote_state().timestamp;
 
+      /*
+       * Read from the terminal first.  On BSD pty implementations, writing \013 to the pty
+       * can make formerly-available data unavailable.  Mosh used to operate
+       * in this order:
+       *
+       * sel.select()
+       * network.read(), possibly with pty write()
+       * pty read()
+       *
+       * If select returned read status for both the network socket
+       * and the pty, and the incoming packet delivered a ^S, mosh
+       * would deadlock in read() with the pty driver, waiting for
+       * output, which of course won't appear until the pty is
+       * unblocked with a ^Q or equivalent ioctl.
+       */
+      if ( (!network.shutdown_in_progress()) && sel.read( host_fd ) ) {
+	/* input from the host needs to be fed to the terminal */
+	const int buf_size = 16384;
+	char buf[ buf_size ];
+	
+	/* fill buffer if possible */
+	ssize_t bytes_read = read( host_fd, buf, buf_size );
+
+        /* If the pty slave is closed, reading from the master can fail with
+           EIO (see #264).  So we treat errors on read() like EOF. */
+        if ( bytes_read <= 0 ) {
+	  network.start_shutdown();
+	} else {
+	  string terminal_to_host = terminal.act( string( buf, bytes_read ) );
+	
+	  /* update client with new state of terminal */
+	  network.set_current_state( terminal );
+
+	  /* write any writeback octets back to the host */
+	  if ( swrite( host_fd, terminal_to_host.c_str(), terminal_to_host.length() ) < 0 ) {
+	    break;
+	  }
+	}
+      }
+
       if ( sel.read( network_fd ) ) {
 	/* packet received from the network */
 	network.recv();
@@ -654,31 +694,6 @@ static void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &
 	}
       }
       
-      if ( (!network.shutdown_in_progress()) && sel.read( host_fd ) ) {
-	/* input from the host needs to be fed to the terminal */
-	const int buf_size = 16384;
-	char buf[ buf_size ];
-	
-	/* fill buffer if possible */
-	ssize_t bytes_read = read( host_fd, buf, buf_size );
-
-        /* If the pty slave is closed, reading from the master can fail with
-           EIO (see #264).  So we treat errors on read() like EOF. */
-        if ( bytes_read <= 0 ) {
-	  network.start_shutdown();
-	} else {
-	  string terminal_to_host = terminal.act( string( buf, bytes_read ) );
-	
-	  /* update client with new state of terminal */
-	  network.set_current_state( terminal );
-
-	  /* write any writeback octets back to the host */
-	  if ( swrite( host_fd, terminal_to_host.c_str(), terminal_to_host.length() ) < 0 ) {
-	    break;
-	  }
-	}
-      }
-
       if ( sel.any_signal() ) {
 	/* shutdown signal */
 	if ( network.has_remote_addr() && (!network.shutdown_in_progress()) ) {

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -12,6 +12,7 @@ displaytests = \
 	emulation-80th-column.test \
 	emulation-back-tab.test \
 	emulation-multiline-scroll.test \
+	pty-deadlock.test \
 	window-resize.test \
 	unicode-combine-fallback-assert.test \
 	unicode-later-combining.test

--- a/src/tests/pty-deadlock.test
+++ b/src/tests/pty-deadlock.test
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+#
+# This is a regression test for a BSD pty bug in Mosh.  On
+# FreeBSD/OpenBSD/OS X, a pty master can block on read() after
+# select() has informed us that there is data available, if a ^S is
+# written to the pty master between the select() and the read().
+#
+# Unfortunately, everything attached to the pty gets stuck when this
+# happens.  If this tests fails, you will need to do some manual
+# cleanup with kill -9.
+#
+
+
+fail()
+{
+    printf "$@" 2>&1
+    exit 99
+}
+
+
+
+PATH=$PATH:.:$srcdir
+# Top-level wrapper.
+if [ $# -eq 0 ]; then
+    e2e-test $0 tmux baseline post
+    exit
+fi
+
+tmux_commands()
+{
+    # An interactive shell is waiting for us in the mosh session.
+    # Start test...
+    printf "send-keys 0x0d\n"
+    sleep 1
+    # Stop output...
+    printf "send-keys 0x13\n"
+    sleep 2
+    # Restart output...
+    printf "send-keys 0x11\n"
+    sleep 2
+    # And stop the test script, so it produces its exit messge.
+    printf "send-keys 0x0d\n"
+    # need to sleep extra long here, to let child commands complete,
+    # and not have tmux exit prematurely
+    sleep 5
+}
+
+tmux_stdin()
+{
+    tmux_commands | "$@"
+    exit
+}
+
+baseline()
+{
+    # Make a lot of noise on stdout to keep mosh busy, and exit
+    # with a distinctive message when we get a CR.  Exit after 10s in any case.
+    trap "exit 1" TERM
+    (sleep 10; kill $$) &
+    killpid=$!
+    read x
+    # very, very old school way to get non-blocking reads in shell
+    tty=$(stty -g)
+    trap "stty $tty" EXIT
+    stty -icanon min 0 time 0
+    while ! read x; do
+	printf 'a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\nq\nr\ns\nt\nu\nv\nw\nx\ny\nz\n'
+    done
+    printf "=== normal exit ===\n"
+    # Kill the killer and exit normally.
+    kill $killpid
+}
+
+post()
+{
+    if grep -q '=== normal exit ===' $(basename $0).d/baseline.capture; then
+	exit 0
+    fi
+    exit 1
+}
+
+case $1 in
+    tmux)
+	shift;
+	tmux_stdin "$@";;
+    baseline)
+	baseline;;
+    post)
+	post;;
+    *)
+	fail "unknown test argument %s\n" $1;;
+esac


### PR DESCRIPTION
Fixes #692.  See that for fuller explanation.  This reorders some code in mosh-server's main loop and adds a regression test.