### PR TITLE
Debian package updates

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,8 @@ Maintainer: Keith Winstein <keithw@mit.edu>
 Build-Depends: debhelper (>= 7.0.50), autotools-dev, protobuf-compiler, libprotobuf-dev, dh-autoreconf, pkg-config, libutempter-dev, zlib1g-dev, libncurses5-dev, libssl-dev, bash-completion
 Standards-Version: 3.9.6.1
 Homepage: http://mosh.mit.edu
-Vcs-Git: git://github.com/keithw/mosh.git
-Vcs-Browser: https://github.com/keithw/mosh
+Vcs-Git: https://github.com/mobile-shell/mosh.git
+Vcs-Browser: https://github.com/mobile-shell/mosh
 
 Package: mosh
 Architecture: any

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: mosh
-Source: http://github.com/keithw/mosh
+Source: https://github.com/mobile-shell/mosh
 
 Files: *
 Copyright: 2012 Keith Winstein <mosh-devel@mit.edu>

--- a/debian/mosh.maintscript
+++ b/debian/mosh.maintscript
@@ -1,1 +1,1 @@
-rm_conffile /etc/bash_completion.d/mosh 1.2.5~ -- "$@"
+rm_conffile /etc/bash_completion.d/mosh 1.2.5~

--- a/debian/rules
+++ b/debian/rules
@@ -23,3 +23,7 @@ override_dh_auto_configure:
 		--enable-ufw \
 		--enable-completion \
 		--enable-compile-warnings=error
+
+override_dh_perl:
+	# mosh only uses Perl modules in perl-base.
+	dh_perl -d

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=-stackprotector
 -include /usr/share/dpkg/buildflags.mk
 
 %:
-	dh $@ --with autoreconf
+	dh $@ --parallel --with autoreconf
 
 override_dh_auto_configure:
 	dh_auto_configure -- \

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,2 @@
 version=3
-https://github.com/keithw/mosh/tags .*/mosh-(\d[\d\.]+)\.tar\.gz
+https://github.com/mobile-shell/mosh/tags .*/mosh-(\d[\d\.]+)\.tar\.gz


### PR DESCRIPTION
Removes an extra `-- "$@"` from debian/mosh.maintscript that was causing errors; silences a warning about unused `${perl:Depends}`; and allows building in parallel.