### PR TITLE
Cygwin fixes

### DIFF
--- a/src/examples/ntester.cc
+++ b/src/examples/ntester.cc
@@ -153,10 +153,6 @@ int main( int argc, char *argv[] )
 	    /* we only read one socket each run */
 	    network_ready_to_read = true;
 	  }
-
-	  if ( sel.error( *it ) ) {
-	    break;
-	  }
 	}
 
 	if ( network_ready_to_read ) {

--- a/src/examples/parse.cc
+++ b/src/examples/parse.cc
@@ -158,8 +158,6 @@ static void emulate_terminal( int fd )
       if ( vt_parser( fd, &parser ) < 0 ) {
 	return;
       }
-    } else if ( sel.error( STDIN_FILENO ) || sel.error( fd ) ) {
-      return;
     } else {
       fprintf( stderr, "select mysteriously woken up\n" );
     }

--- a/src/examples/termemu.cc
+++ b/src/examples/termemu.cc
@@ -311,8 +311,6 @@ static void emulate_terminal( int fd )
 	perror( "ioctl TIOCSWINSZ" );
 	return;
       }
-    } else if ( sel.error( STDIN_FILENO ) || sel.error( fd ) ) {
-      break;
     }
 
     Terminal::Framebuffer new_frame( complete.get_fb() );

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -765,16 +765,6 @@ static void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &
 	}
       }
       
-      if ( sel.error( network_fd ) ) {
-	/* network problem */
-	break;
-      }
-
-      if ( (!network.shutdown_in_progress()) && sel.error( host_fd ) ) {
-	/* host problem */
-	network.start_shutdown();
-      }
-
       /* quit if our shutdown has been acknowledged */
       if ( network.shutdown_in_progress() && network.shutdown_acknowledged() ) {
 	break;

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -448,11 +448,6 @@ bool STMClient::main( void )
 	  /* we only read one socket each run */
 	  network_ready_to_read = true;
 	}
-
-	if ( sel.error( *it ) ) {
-	  /* network problem */
-	  break;
-	}
       }
 
       if ( network_ready_to_read ) {
@@ -491,16 +486,6 @@ bool STMClient::main( void )
           overlays.get_notification_engine().set_notification_string( wstring( L"Signal received, shutting down..." ), true );
           network->start_shutdown();
         }
-      }
-
-      if ( sel.error( STDIN_FILENO ) ) {
-	/* user problem */
-	if ( !network->has_remote_addr() ) {
-	  break;
-	} else if ( !network->shutdown_in_progress() ) {
-	  overlays.get_notification_engine().set_notification_string( wstring( L"Exiting..." ), true );
-	  network->start_shutdown();
-	}
       }
 
       /* quit if our shutdown has been acknowledged */

--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -387,7 +387,7 @@ Connection::Connection( const char *key_str, const char *ip, const char *port ) 
   hints.ai_socktype = SOCK_DGRAM;
   hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
   AddrInfo ai( ip, port, &hints );
-  fatal_assert( ai.res->ai_addrlen <= sizeof( remote_addr ) );
+  fatal_assert( static_cast<size_t>( ai.res->ai_addrlen ) <= sizeof( remote_addr ) );
   remote_addr_len = ai.res->ai_addrlen;
   memcpy( &remote_addr.sa, ai.res->ai_addr, remote_addr_len );
 

--- a/src/tests/prediction-unicode.test
+++ b/src/tests/prediction-unicode.test
@@ -110,8 +110,10 @@ tmux_commands()
 	done
 	printf "send-keys 0x0d\n"
     done
+    printf "send-keys 0x0d\n"
+    sleep 1
     printf "send-keys 0x04\n"
-    sleep 5
+    sleep 10
 } 
 
 tmux_stdin()

--- a/src/tests/print-exitstatus
+++ b/src/tests/print-exitstatus
@@ -18,4 +18,5 @@ if ($? == 0) {
     $rc = ($? & 127) | 128;
 }
 print STDERR "%%% exitstatus: ${rc} %%%\n";
+sleep 1;
 exit $rc;

--- a/src/tests/pty-deadlock.test
+++ b/src/tests/pty-deadlock.test
@@ -31,6 +31,7 @@ tmux_commands()
 {
     # An interactive shell is waiting for us in the mosh session.
     # Start test...
+    sleep 2
     printf "send-keys 0x0d\n"
     sleep 1
     # Stop output...
@@ -41,9 +42,9 @@ tmux_commands()
     sleep 2
     # And stop the test script, so it produces its exit messge.
     printf "send-keys 0x0d\n"
-    # need to sleep extra long here, to let child commands complete,
-    # and not have tmux exit prematurely
-    sleep 5
+    # need to sleep extra long here, to let child commands complete
+    # and buffers drain, and not have tmux exit prematurely
+    sleep 10
 }
 
 tmux_stdin()
@@ -56,18 +57,21 @@ baseline()
 {
     # Make a lot of noise on stdout to keep mosh busy, and exit
     # with a distinctive message when we get a CR.  Exit after 10s in any case.
-    trap "exit 1" TERM
-    (sleep 10; kill $$) &
+    read x
+    while true; do
+	printf 'a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\nq\nr\ns\nt\nu\nv\nw\nx\ny\nz\n'
+    done &
+    printpid=$!
+    (sleep 30; kill $$ $printpid) &
     killpid=$!
     read x
-    # very, very old school way to get non-blocking reads in shell
-    tty=$(stty -g)
-    trap "stty $tty" EXIT
-    stty -icanon min 0 time 0
-    while ! read x; do
-	printf 'a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\nq\nr\ns\nt\nu\nv\nw\nx\ny\nz\n'
-    done
-    printf "=== normal exit ===\n"
+    kill $printpid
+    # Try and make sure the printer stops writing before the following printf
+    sleep 1
+    printf "\n=== normal exit ===\n"
+    # Let tty queues drain, so the exit message gets to mosh-client
+    # before we exit
+    sleep 4
     # Kill the killer and exit normally.
     kill $killpid
 }

--- a/src/util/select.h
+++ b/src/util/select.h
@@ -62,12 +62,10 @@ private:
        here to appease -Weffc++. */
     , all_fds( dummy_fd_set )
     , read_fds( dummy_fd_set )
-    , error_fds( dummy_fd_set )
     , empty_sigset( dummy_sigset )
   {
     FD_ZERO( &all_fds );
     FD_ZERO( &read_fds );
-    FD_ZERO( &error_fds );
 
     clear_got_signal();
     fatal_assert( 0 == sigemptyset( &empty_sigset ) );
@@ -120,7 +118,6 @@ public:
   int select( int timeout )
   {
     memcpy( &read_fds,  &all_fds, sizeof( read_fds  ) );
-    memcpy( &error_fds, &all_fds, sizeof( error_fds ) );
     clear_got_signal();
 
 #ifdef HAVE_PSELECT
@@ -133,7 +130,7 @@ public:
       tsp = &ts;
     }
 
-    int ret = ::pselect( max_fd + 1, &read_fds, NULL, &error_fds, tsp, &empty_sigset );
+    int ret = ::pselect( max_fd + 1, &read_fds, NULL, NULL, tsp, &empty_sigset );
 #else
     struct timeval tv;
     struct timeval *tvp = NULL;
@@ -147,7 +144,7 @@ public:
 
     int ret = sigprocmask( SIG_SETMASK, &empty_sigset, &old_sigset );
     if ( ret != -1 ) {
-      ret = ::select( max_fd + 1, &read_fds, NULL, &error_fds, tvp );
+      ret = ::select( max_fd + 1, &read_fds, NULL, NULL, tvp );
       sigprocmask( SIG_SETMASK, &old_sigset, NULL );
     }
 #endif
@@ -155,7 +152,6 @@ public:
     if ( ( ret == -1 ) && ( errno == EINTR ) ) {
       /* The user should process events as usual. */
       FD_ZERO( &read_fds );
-      FD_ZERO( &error_fds );
       ret = 0;
     }
 
@@ -171,15 +167,6 @@ public:
   {
     assert( FD_ISSET( fd, &all_fds ) );
     return FD_ISSET( fd, &read_fds );
-  }
-
-  bool error( int fd )
-#if FD_ISSET_IS_CONST
-    const
-#endif
-  {
-    assert( FD_ISSET( fd, &all_fds ) );
-    return FD_ISSET( fd, &error_fds );
   }
 
   /* This method consumes a signal notification. */
@@ -214,7 +201,7 @@ private:
      concurrent signal handlers. */
   int got_signal[ MAX_SIGNAL_NUMBER + 1 ];
 
-  fd_set all_fds, read_fds, error_fds;
+  fd_set all_fds, read_fds;
 
   sigset_t empty_sigset;
 

--- a/src/util/select.h
+++ b/src/util/select.h
@@ -149,7 +149,15 @@ public:
     }
 #endif
 
-    if ( ( ret == -1 ) && ( errno == EINTR ) ) {
+    if ( ret == 0 || ( ret == -1 && errno == EINTR ) ) {
+      /* Look for and report Cygwin select() bug. */
+      if ( ret == 0 ) {
+	for ( int fd = 0; fd <= max_fd; fd++ ) {
+	  if ( FD_ISSET( fd, &read_fds ) ) {
+	    fprintf( stderr, "select(): nfds = 0 but read fd %d is set\n", fd );
+	  }
+	}
+      }
       /* The user should process events as usual. */
       FD_ZERO( &read_fds );
       ret = 0;


### PR DESCRIPTION
These commits do 3 things:
* Remove our use of exceptional fdsets with `select()`, which is meaningless since our usage of `select()` will never see exceptions.
* Workaround a Cygwin bug in `select()` (see #705)
* Improve test compatibility with Cygwin
