### PR TITLE
Remove mutable for handled field in Action

### DIFF
--- a/src/terminal/parseraction.h
+++ b/src/terminal/parseraction.h
@@ -46,7 +46,7 @@ namespace Parser {
   public:
     wchar_t ch;
     bool char_present;
-    mutable bool handled;
+    bool handled;
 
     std::string str( void );
 


### PR DESCRIPTION
Having a field be public mutable is very confusing and error-prone for new developers reading the code in the project. If the field is public, it should not be mutable and all methods that mutate it should be through non-const methods. As it currently stands const methods modify this field and should probably be refactored.