### PR TITLE
Display original command line argv via no-op flag.

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -422,7 +422,7 @@ if ( $pid == 0 ) { # child
   $ENV{ 'MOSH_KEY' } = $key;
   $ENV{ 'MOSH_PREDICTION_DISPLAY' } = $predict;
   $ENV{ 'MOSH_NO_TERM_INIT' } = '1' if !$term_init;
-  exec {$client} ("$client @cmdline |", $ip, $port);
+  exec {$client} ("$client", "-# @cmdline |", $ip, $port);
 }
 
 sub shell_quote { join ' ', map {(my $a = $_) =~ s/'/'\\''/g; "'$a'"} @_ }

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -75,7 +75,7 @@ static void usage( const char *argv0 ) {
   fprintf( stderr, "Copyright 2012 Keith Winstein <mosh-devel@mit.edu>\n" );
   fprintf( stderr, "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n\n" );
 
-  fprintf( stderr, "Usage: %s IP PORT\n       %s -c\n", argv0, argv0 );
+  fprintf( stderr, "Usage: %s [-# 'ARGS'] IP PORT\n       %s -c\n", argv0, argv0 );
 }
 
 static void print_colorcount( void )
@@ -107,8 +107,11 @@ int main( int argc, char *argv[] )
 
   /* Get arguments */
   int opt;
-  while ( (opt = getopt( argc, argv, "c" )) != -1 ) {
+  while ( (opt = getopt( argc, argv, "#:c" )) != -1 ) {
     switch ( opt ) {
+    case '#':
+      // Ignore the original arguments to mosh wrapper
+      break;
     case 'c':
       print_colorcount();
       exit( 0 );


### PR DESCRIPTION
Improves 679b819216e1946ebe3a6f920c0fbf61d61ab47e (for #117) to make it simpler to ignore mosh-client from OS X Terminal.app's "Ask before closing" process list. (See: http://superuser.com/a/254647)

Moreover, the command displayed from ps is a completely functional one, which was not the case in the previous approach, that mangles `argv[0]`.