### PR TITLE
GCC 6 fixes.

### DIFF
--- a/src/protobufs/Makefile.am
+++ b/src/protobufs/Makefile.am
@@ -1,7 +1,7 @@
 source = userinput.proto hostinput.proto transportinstruction.proto
 
 AM_CPPFLAGS = $(protobuf_CFLAGS)
-AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(HARDEN_CFLAGS) $(MISC_CXXFLAGS)
+AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(HARDEN_CFLAGS) $(MISC_CXXFLAGS) -Wno-error
 
 SUFFIXES = .proto .pb.cc
 

--- a/src/tests/encrypt-decrypt.cc
+++ b/src/tests/encrypt-decrypt.cc
@@ -54,7 +54,7 @@ const size_t NUM_SESSIONS         = 64;
 
 bool verbose = false;
 
-#define NONCE_FMT "%016"PRIx64
+#define NONCE_FMT "%016" PRIx64
 
 static std::string random_payload( void ) {
   const size_t len = prng.uint32() % MESSAGE_SIZE_MAX;


### PR DESCRIPTION
Should resolve #719 and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811579

This is my current thinking for the `-Wmisleading-indentation -Werror` issue revealed there.  Unfortunately, gcc 4.2.1 does not support `-Wno-error=misleading-indentation` (because it doesn't have `-Wmisleading-indentation`), and other non-GCC compilers may also get upset about it (clang is OK though).  The C++ code in this directory is all generated, not hand-authored, and `-Wno-error` seems an acceptable compromise to me.  If anyone else has better ideas, or wants to contribute `autoconf`-fu to this problem, speak up!