### PR TITLE
Make OS X mDNS/Bonjour .local IPv6 addresses work.

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -242,7 +242,7 @@ if ( ! defined $fake_proxy ) {
 				  PeerHost => $addr_string,
 				  PeerPort => $port,
 				  Proto => 'tcp' )) {
-      print STDERR 'MOSH IP ', $sock->peerhost, "\n";
+      print STDERR 'MOSH IP ', $addr_string, "\n";
       last;
     } else {
       $err = $@;


### PR DESCRIPTION
OS X advertises IPv6 link-local addresses for .local hostnames.
getaddrinfo() correctly reports interface identifiers for these, but we
were discarding them by using the socket peer host address instead.