### PR TITLE
Add options to prefer v4 or v6 on connect; make prefer-inet the default.

### DIFF
--- a/man/mosh.1
+++ b/man/mosh.1
@@ -143,23 +143,32 @@ Only use IPv4 for the SSH connection and Mosh session.
 .TP
 .B \-\-family=inet6
 Only use IPv6 for the SSH connection and Mosh session.  This and the
-following two dual-stack modes require Perl's IO::Socket::IP or
-IO::Socket::INET6 modules.
-
-.TP
-.B \-\-family=all
-Choose an address from all available IPv4 or IPv6 address, even for
-dual-stack hosts.  This is the most convenient option, but requires
-dual-stack connectivity when roaming with dual-stack servers.  This is
-the default.
+following modes require Perl's IO::Socket::IP or IO::Socket::INET6
+modules.
 
 .TP
 .B \-\-family=auto
 Autodetect IPv4 or IPv6 for hosts that only have addresses
 in a single family.  Hosts with both IPv4 and IPv6 addresses will
 raise an error, and require re-invocation of \fBmosh\fP with another
-.B \-\-family
-option.
+\fB\-\-family\fP option.
+
+.TP
+.B \-\-family=all
+Choose an address from all available IPv4 or IPv6 address, even for
+dual-stack hosts.  This is the most convenient option, but requires
+dual-stack connectivity, and Mosh 1.2.5 or later on the server, when
+roaming with dual-stack servers.
+
+.TP
+.B \-\-family=prefer-inet
+Similar to \fB\-\-family=all\fP, but attempt connects to the IPv4
+addresses first.  This is the default.
+
+.TP
+.B \-\-family=prefer-inet6
+Similar to \fB\-\-family=all\fP, but attempt connects to the IPv6
+addresses first.
 
 .TP
 .B \-4


### PR DESCRIPTION
This is an attempt to resolve #764 most of the time, while still preserving automatic connection to systems reachable via IPv6 only.
With this change, Mosh defaults to preferring IPv4 to IPv6 when both are available.  This means that dual-stack servers with IPv4-only `mosh-server` will still fail with the error seen in #764, but only when they are reachable only via IPv6.  I think it also means that Mosh will not get a lot of IPv6 use, since most servers with IPv6 will be dual-stack.  But I don't see a better way to handle this, if anybody else does please speak up.
On the plus side, I think this is also better for users connecting to dual-stack servers and then roaming or using VPNs, because IPv6 connectivity is a lot less universal than IPv4.
