### PR TITLE
1.2.6 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2016-05-?? Keith Winstein <mosh-devel@mit.edu>
+2016-07-31 Keith Winstein <mosh-devel@mit.edu>
 
 	* Version 1.2.6 released.
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.61])
-AC_INIT([mosh], [1.2.5.95rc1], [mosh-devel@mit.edu])
+AC_INIT([mosh], [1.2.6], [mosh-devel@mit.edu])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_SRCDIR([src/frontend/mosh-client.cc])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mosh (1.2.6-1) unstable; urgency=low
+
+  * Version 1.2.6 released.
+
+ -- Keith Winstein <keithw@mit.edu>  Sun, 31 Jul 2016 00:00:00 -0400
+
 mosh (1.2.5.95rc1-1) unstable; urgency=low
 
   * Version 1.2.6 released.

--- a/src/tests/e2e-test
+++ b/src/tests/e2e-test
@@ -209,7 +209,7 @@ for run in $server_tests; do
     # XXX tmux 1.8 requires shell command as a single arg; once we move to 2.0, undo these quotes
     # XXX this ignores $TMPDIR, because it results in an overlong pathname on OS X
     tmux_socket="/tmp/.tmux-mosh-test-$$"
-    ${tmux_stdin} tmux -S "${tmux_socket}" -C new-session "${srcdir}/print-exitstatus ${client_wrapper} ${sut} \"${srcdir}/e2e-test-server\" \"${PWD}/${test_dir}/${run}\" \"${PWD}/${test_script} ${testarg}\"" > "${test_dir}/${run}.tmux.log"
+    ${tmux_stdin} tmux -f /dev/null -S "${tmux_socket}" -C new-session "${srcdir}/print-exitstatus ${client_wrapper} ${sut} \"${srcdir}/e2e-test-server\" \"${PWD}/${test_dir}/${run}\" \"${PWD}/${test_script} ${testarg}\"" > "${test_dir}/${run}.tmux.log"
     rv=$?
     rm -f "${tmux_socket}"
     if [ $rv -ne 0 ]; then


### PR DESCRIPTION
Final check with Travis.

This seems OK on OS X 10.11 and Ubuntu 16.04.  The `unicode-later-combining` test fails on FreeBSD 11.0-BETA2 with tmux 2.2, but that's because tmux is now handling the test differently and discarding the accent-circumflex, not because of any issue in Mosh.  Needs fixing but doesn't need to hold the release, I think.