### PR TITLE
Support OpenSSL's AES128_OCB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -336,6 +336,33 @@ case "${with_crypto_library}" in
     ;;
 esac
 
+if test "${with_crypto_library}" = "openssl"; then
+  # push LDFLAGS/CFLAGS
+  old_LIBS="$LIBS"
+  old_CFLAGS="$CFLAGS"
+  # modify
+  LIBS="$LIBS $CRYPTO_LIBS"
+  CFLAGS="$CFLAGS $CRYPTO_CFLAGS"
+
+  AC_CHECK_DECL([EVP_aes_128_ocb],
+    [AC_DEFINE([HAVE_OPENSSL_OCB], [1],
+       [Define if the OCB AE algorithm is available in OpenSSL.])],
+    , [[#include <openssl/evp.h>]])
+
+  dnl AC_MSG_CHECKING([whether OCB is available in OpenSSL])
+  dnl AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <openssl/evp.h>
+  dnl ]], [[(void) EVP_aes_128_ocb();]])],
+  dnl   [AC_DEFINE([HAVE_OPENSSL_OCB], [1],
+  dnl      [Define if the OCB AE algorithm is available in OpenSSL.])
+  dnl    AC_MSG_RESULT([yes])],
+  dnl   [AC_MSG_RESULT([no])])
+
+  # restore old LDFLAGS/CPPFLAGS
+  LIBS="$old_LIBS"
+  CFLAGS="$old_CFLAGS"
+fi
+
+
 AC_CHECK_DECL([forkpty],
   [AC_DEFINE([FORKPTY_IN_LIBUTIL], [1],
      [Define if libutil.h necessary for forkpty().])],

--- a/src/crypto/ocb.cc
+++ b/src/crypto/ocb.cc
@@ -90,6 +90,128 @@
 #include <sys/endian.h>
 #endif
 
+/*
+ * cheat for now and use USE_OPENSSL_AES as a proxy for the presence
+ * of OpenSSL
+ */
+#if defined(USE_OPENSSL_AES) && defined(HAVE_OPENSSL_OCB)
+/*
+ * This shims the Krovetz/Rogaway OCB API (which Mosh uses) on top of
+ * OpenSSL's API.  This shim does not implement all the possible uses
+ * of the Krovetz/Rogaway API; it only implements the simple cases
+ * that Mosh uses (a single call to ae_encrypt() with both plaintext
+ * and associated data, and ae_encrypt() calls on the resulting
+ * messages), and a few more.
+ *
+ * It fails some of the test cases in the test program at the bottom
+ * of this file (but passes all of Mosh's test cases).
+ */
+#include <openssl/evp.h>
+
+struct _ae_ctx {
+	unsigned char key[16];
+	EVP_CIPHER_CTX *ocb_ctx;
+};
+
+ae_ctx* ae_allocate(void *misc)
+{
+	return new(_ae_ctx);
+}
+void    ae_free      (ae_ctx *ctx)
+{
+	delete ctx;
+}
+int     ae_clear     (ae_ctx *ctx)
+{
+	EVP_CIPHER_CTX_free(ctx->ocb_ctx);
+	memset(ctx, '\0', sizeof *ctx);
+	return AE_SUCCESS;
+}
+int     ae_ctx_sizeof(void)
+{
+	return sizeof(_ae_ctx);
+}
+
+int ae_init(ae_ctx *ctx, const void *key_param, int key_len, int nonce_len, int tag_len)
+{
+	const unsigned char *key = (const unsigned char *)key_param;
+	ctx->ocb_ctx = EVP_CIPHER_CTX_new();
+	if (nonce_len != 12 || key_len != 16 || tag_len != 16)
+		return AE_NOT_SUPPORTED;
+	memcpy(ctx->key, key, key_len);
+	return AE_SUCCESS;
+}
+
+int ae_encrypt(ae_ctx     *  ctx,
+               const void *  nonce_param,
+               const void *pt_param,
+               int         pt_len,
+               const void *ad_param,
+               int         ad_len,
+               void       *ct_param,
+               void       *tag,
+               int         final)
+{
+	const unsigned char *nonce = (const unsigned char *)nonce_param;
+	const unsigned char *pt = (const unsigned char *)pt_param;
+	const unsigned char *ad = (const unsigned char *)ad_param;
+	unsigned char *ct = (unsigned char *)ct_param;
+	if (nonce) {
+		EVP_EncryptInit_ex(
+			ctx->ocb_ctx, EVP_aes_128_ocb(), NULL, ctx->key, nonce);
+	}
+	if (ad_len) {
+		int ad_ct_len;
+		EVP_EncryptUpdate(ctx->ocb_ctx, NULL, &ad_ct_len, ad, ad_len);
+	}
+	int ct_len = 0;
+	if (pt_len) {
+		EVP_EncryptUpdate(ctx->ocb_ctx, ct, &ct_len, pt, pt_len);
+	}
+	int ct_len_2 = 0;
+	if (final == AE_FINALIZE) {
+		EVP_EncryptFinal_ex(ctx->ocb_ctx, ct + ct_len, &ct_len_2);
+		EVP_CIPHER_CTX_ctrl(
+			ctx->ocb_ctx, EVP_CTRL_AEAD_GET_TAG, 16, ct + ct_len + ct_len_2);
+	}
+	return ct_len + ct_len_2 + 16;
+}
+
+int ae_decrypt(ae_ctx     *ctx,
+               const void *nonce_param,
+               const void *ct_param,
+               int         ct_len,
+               const void *ad_param,
+               int         ad_len,
+               void       *pt_param,
+               const void *tag,
+               int         final)
+{
+	const unsigned char *nonce = (const unsigned char *)nonce_param;
+	unsigned char *pt = (unsigned char *)pt_param;
+	unsigned char *ad = (unsigned char *)ad_param;
+	const unsigned char *ct = (const unsigned char *)ct_param;
+	if (nonce) {
+		EVP_DecryptInit_ex(ctx->ocb_ctx, EVP_aes_128_ocb(), NULL, ctx->key, nonce);
+		EVP_CIPHER_CTX_ctrl(
+			ctx->ocb_ctx, EVP_CTRL_AEAD_SET_TAG, 16, (void *)(ct + ct_len - 16));
+	}
+	if (ad_len) {
+		int ad_pt_len;
+		EVP_DecryptUpdate(ctx->ocb_ctx, NULL, &ad_pt_len, ad, ad_len);
+	}
+	int pt_len;
+	EVP_DecryptUpdate(ctx->ocb_ctx, pt, &pt_len, ct, ct_len - 16);
+	int pt_len_2 = 0;
+	int rv = 1;
+	if (final == AE_FINALIZE) {
+		rv = EVP_DecryptFinal_ex(ctx->ocb_ctx, pt + pt_len, &pt_len_2);
+	}
+	return rv ? pt_len + pt_len_2 : AE_INVALID;
+}
+
+#else
+
 /* Define standard sized integers                                          */
 #if defined(_MSC_VER) && (_MSC_VER < 1600)
 	typedef unsigned __int8  uint8_t;
@@ -1378,6 +1500,8 @@ int ae_decrypt(ae_ctx     *ctx,
     return ct_len;
  }
 
+#endif
+
 /* ----------------------------------------------------------------------- */
 /* Simple test program                                                     */
 /* ----------------------------------------------------------------------- */
@@ -1386,6 +1510,10 @@ int ae_decrypt(ae_ctx     *ctx,
 
 #include <stdio.h>
 #include <time.h>
+
+#ifndef BPI
+#define BPI 4
+#endif
 
 #if __GNUC__
 	#define ALIGN(n) __attribute__ ((aligned(n)))


### PR DESCRIPTION
This is an early implementation of support for the OCB implementation in OpenSSL 1.1.0.  Caveats:
- It depends on a pre-release version of OpenSSL.
- Only tested on FreeBSD.  (FreeBSD's multiple installs of OpenSSL can be quite annoying, but installing the "openssl-devel" package to get 1.1.0 was trivially simple.)
- Currently the code completely reinitializes OCB state for every message.

But it supports/passes test suites relevant for Mosh, and of course interoperates with the Rogaway/Krovetz implementation that Mosh normally uses.  Looking to the future, Mosh will probably gradually shift away from the Rogaway/Krovetz implementation, to external implementations, to get the benefits of ongoing maintenance, security analysis, etc.

This needs more work before it can go into Mosh; I want to at least see it support Linux and have better performance.  PRs gladly accepted :)  Also, there's no reason to pull it into master before there's some OpenSSL 1.1.0-release uptake by OS distributions.
