### PR TITLE
Travis-ci bot doesn't need to join #mosh to send notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,7 @@ script:
   - make distcheck VERBOSE=1
 
 notifications:
-  irc: "chat.freenode.net#mosh"
+  irc:
+    channels:
+      - "chat.freenode.net#mosh"
+    skip_join: true


### PR DESCRIPTION
If #mosh ever sets the +n channel mode, we'll need to remove the `skip_join: true` part