### PR TITLE
  AppVeyor CI configuration using Cygwin.

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+#
+# Cleanup for Appveyor peculiarities.
+#
+# This thing is dangerous.  See "rm -rf *".  It tries hard, but if it
+# gets it wrong you will not be happy.
+#
+# Only run this on an Appveyor instance, where the consequences are
+# nil.
+#
+
+# Echo, eval, and error on shell commands.
+eeval()
+{
+    echo "$0: $*" >&2
+    eval "$@"
+    rv=$?
+    if [ $rv -ne 0 ]; then
+	echo "$0: failed, exitcod $rv"
+	exit $rv
+    fi
+    return 0
+}
+
+# We inherit a broken Windows path with a Windows Git.
+PATH=/bin
+
+# This supposedly fixes some failures.
+exec 0</dev/null
+
+# Mosh-specific environment
+export LANG=en_US.UTF-8
+
+# Make sure we're on Appveyor
+if [ -z "$APPVEYOR_BUILD_FOLDER" ]; then
+    echo "$0: APPVEYOR_BUILD_FOLDER variable empty" >&2
+    exit 2
+fi
+
+# Make really, really sure we're in the build dir
+cd $APPVEYOR_BUILD_FOLDER || exit 2
+if [ "$(pwd)" = "$HOME" -o "$PWD" = "$HOME" ]; then
+    echo "$0: in home directory" >&2
+    exit 2
+fi
+
+set -e
+
+case $1 in
+    before_build)
+	# Check that we're in a Mosh repo with mosh-1.2.5, then clean it mercilessly
+	eeval git config --local core.symlinks true
+	eeval "git describe 3c3b356cb5e387887499beb2eedddce185f36944 && rm -rf * && git reset --hard"
+	;;
+    build_script)
+	eeval ./autogen.sh
+	eeval ./configure --enable-compile-warnings=error --enable-examples
+	eeval make distcheck VERBOSE=1 V=1
+	;;
+    wait)
+	touch wait.lck
+	while [ -f wait.lck ]; do
+	    sleep 10
+	done
+	;;
+    *)
+	echo "Fail: $0 $*"
+	exit 2
+	;;
+esac

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,54 @@
+#
+# Appveyor configuration file for CI build of Mosh on Windows (under Cygwin)
+#
+# For further details see http://www.appveyor.com
+#
+
+#
+# Custom environment variables
+#
+environment:
+    global:
+        CYG_ROOT: C:\cygwin64
+        CYG_MIRROR: http://cygwin.mirror.constant.com
+        CYG_CACHE: C:\cygwin64\var\cache\setup
+        CYG_BASH: C:\cygwin64\bin\bash
+
+cache:
+  - '%CYG_CACHE%'
+
+#
+# Do a shallow clone of the repo to speed up build
+#
+# clone_depth: 1
+
+# Initialisation prior to pulling the repository
+# Attempt to ensure we don't try to convert line endings to Win32 CRLF as this will cause build to fail
+init:
+    # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+    - git config --global core.autocrlf input
+#
+# Install needed build dependencies
+# 
+install:
+    - '%CYG_ROOT%\setup-x86_64.exe --quiet-mode --no-shortcuts --packages autoconf,autogen,automake,cygwin-devel,git,gcc-core,gcc-g++,libncurses-devel,libprotobuf-devel,make,openssh,openssl-devel,perl,pkg-config,tmux,zlib-devel'
+    - '%CYG_ROOT%\bin\cygcheck -dc cygwin'
+
+#
+# Mosh uses symlinks and other Unixisms in the work dir.  Fix by replacing it with a Cygwin checkout.
+#
+before_build:
+    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER && ./appveyor.sh before_build"'
+
+
+# Build and test, actually.
+build_script:
+    - 'echo Building...'
+    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER && ./appveyor.sh build_script"'
+#
+# Disable tests for now
+# 
+test: off
+
+# on_finish:
+#     - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER && ./appveyor.sh wait"'


### PR DESCRIPTION
I spent way too much time on this.
Anyway, I think Cygwin is a useful testing platform, because it is significantly different from any other Unixish platform out there.  Plus I've seen some Cygwin issues and this will help keep them honest.
There's no notification configuration yet.  AppVeyor doesn't have the neat GitHub integration that Travis does.  But it can do badges, and it can post comments on GitHub pull requests.  The possibilities are at https://www.appveyor.com/docs/notifications/
