### PR TITLE
Add links for Slackware mosh package

### DIFF
--- a/slackware/Slackware.README
+++ b/slackware/Slackware.README
@@ -1,0 +1,10 @@
+REQIURES:
+python-dateutil
+python-gflags
+protobuf
+perl-IO-Tty
+
+https://slackbuilds.org/repository/14.2/network/mosh/
+https://slackbuilds.org/slackbuilds/14.2/network/mosh/mosh.SlackBuild
+
+All of the requirements above have slackbuilds availble on https://slackbuilds.org


### PR DESCRIPTION
Slackware's package manager (pkgtool) does not track dependencies. Packages not bundled with the distribution have community maintained build scripts called $PKGNAME.slackbuild
These compile the package from source and create a Slackware package which pkgtool can install.

See https://slackbuilds.org/faq/#affiliation and http://www.linuxquestions.org/questions/slackware-14/slackware-14-2-is-coming-but-will-the-slackbuilds-will-also-be-updated-accordingly-4175575223/#post5517961