### PR TITLE
Spin fix

### DIFF
--- a/man/mosh-client.1
+++ b/man/mosh-client.1
@@ -20,6 +20,7 @@ mosh-client \- client-side helper for mosh
 .SH SYNOPSIS
 MOSH_KEY=KEY
 .B mosh-client 
+[\-v]
 IP PORT
 .br
 .B mosh-client 
@@ -48,6 +49,11 @@ directly.
 
 With the \-c option, \fBmosh-client\fP instead prints the number of colors
 of the terminal given by the TERM environment variable.
+
+The \-v option will print some debugging information on standard
+error.  More instances of this flag will result in more debugging
+information.  If standard error is not redirected from the terminal,
+the display will be corrupted and quickly become unusable.
 
 .SH ENVIRONMENT VARIABLES
 

--- a/man/mosh-server.1
+++ b/man/mosh-server.1
@@ -62,7 +62,8 @@ hosts)
 
 .TP
 .B \-v
-Print some debugging information even after detaching.
+Print some debugging information even after detaching.  More instances
+of this flag will result in more debugging information.
 
 .TP
 .B \-i \fIIP\fP

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -99,6 +99,7 @@ int mosh_main( int argc, char *argv[] )
 int main( int argc, char *argv[] )
 #endif
 {
+  unsigned int verbose = 0;
   /* For security, make sure we don't dump core */
   Crypto::disable_dumping_core();
 
@@ -107,7 +108,7 @@ int main( int argc, char *argv[] )
 
   /* Get arguments */
   int opt;
-  while ( (opt = getopt( argc, argv, "#:c" )) != -1 ) {
+  while ( (opt = getopt( argc, argv, "#:cv" )) != -1 ) {
     switch ( opt ) {
     case '#':
       // Ignore the original arguments to mosh wrapper
@@ -115,6 +116,9 @@ int main( int argc, char *argv[] )
     case 'c':
       print_colorcount();
       exit( 0 );
+      break;
+    case 'v':
+      verbose++;
       break;
     default:
       usage( argv[ 0 ] );
@@ -168,7 +172,7 @@ int main( int argc, char *argv[] )
 
   bool success = false;
   try {
-    STMClient client( ip, desired_port, key, predict_mode );
+    STMClient client( ip, desired_port, key, predict_mode, verbose );
     client.init();
 
     try {

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -102,7 +102,7 @@ static void serve( int host_fd,
 
 static int run_server( const char *desired_ip, const char *desired_port,
 		       const string &command_path, char *command_argv[],
-		       const int colors, bool verbose, bool with_motd );
+		       const int colors, unsigned int verbose, bool with_motd );
 
 using namespace std;
 
@@ -171,7 +171,7 @@ int main( int argc, char *argv[] )
   string command_path;
   char **command_argv = NULL;
   int colors = 0;
-  bool verbose = false; /* don't close stdin/stdout/stderr */
+  unsigned int verbose = 0; /* don't close stdin/stdout/stderr */
   /* Will cause mosh-server not to correctly detach on old versions of sshd. */
   list<string> locale_vars;
 
@@ -231,7 +231,7 @@ int main( int argc, char *argv[] )
 	}
 	break;
       case 'v':
-	verbose = true;
+	verbose++;
 	break;
       case 'l':
 	locale_vars.push_back( string( optarg ) );
@@ -355,7 +355,7 @@ int main( int argc, char *argv[] )
 
 static int run_server( const char *desired_ip, const char *desired_port,
 		       const string &command_path, char *command_argv[],
-		       const int colors, bool verbose, bool with_motd ) {
+		       const int colors, unsigned int verbose, bool with_motd ) {
   /* get network idle timeout */
   long network_timeout = 0;
   char *timeout_envar = getenv( "MOSH_SERVER_NETWORK_TMOUT" );
@@ -403,9 +403,8 @@ static int run_server( const char *desired_ip, const char *desired_port,
   Network::UserStream blank;
   ServerConnection *network = new ServerConnection( terminal, blank, desired_ip, desired_port );
 
-  if ( verbose ) {
-    network->set_verbose();
-  }
+  network->set_verbose( verbose );
+  Select::set_verbose( verbose );
 
   /*
    * If mosh-server is run on a pty, then typeahead may echo and break mosh.pl's
@@ -456,7 +455,7 @@ static int run_server( const char *desired_ip, const char *desired_port,
   int master;
 
   /* close file descriptors */
-  if ( !verbose ) {
+  if ( verbose == 0 ) {
     /* Necessary to properly detach on old versions of sshd (e.g. RHEL/CentOS 5.0). */
     int nullfd;
 

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -255,6 +255,10 @@ void STMClient::main_init( void )
 
   /* tell server the size of the terminal */
   network->get_current_state().push_back( Parser::Resize( window_size.ws_col, window_size.ws_row ) );
+
+  /* be noisy as necessary */
+  network->set_verbose( verbose );
+  Select::set_verbose( verbose );
 }
 
 void STMClient::output_new_frame( void )

--- a/src/frontend/stmclient.h
+++ b/src/frontend/stmclient.h
@@ -66,6 +66,7 @@ private:
   std::wstring connecting_notification;
   bool repaint_requested, lf_entered, quit_sequence_started;
   bool clean_shutdown;
+  unsigned int verbose;
 
   void main_init( void );
   void process_network_input( void );
@@ -83,7 +84,7 @@ private:
   void resume( void ); /* restore state after SIGCONT */
 
 public:
-  STMClient( const char *s_ip, const char *s_port, const char *s_key, const char *predict_mode )
+  STMClient( const char *s_ip, const char *s_port, const char *s_key, const char *predict_mode, unsigned int s_verbose )
     : ip( s_ip ? s_ip : "" ), port( s_port ? s_port : "" ),
     key( s_key ? s_key : "" ),
     escape_key( 0x1E ), escape_pass_key( '^' ), escape_pass_key2( '^' ),
@@ -99,7 +100,8 @@ public:
       repaint_requested( false ),
       lf_entered( false ),
       quit_sequence_started( false ),
-      clean_shutdown( false )
+      clean_shutdown( false ),
+      verbose( s_verbose )
   {
     if ( predict_mode ) {
       if ( !strcmp( predict_mode, "always" ) ) {

--- a/src/network/networktransport-impl.h
+++ b/src/network/networktransport-impl.h
@@ -49,7 +49,7 @@ Transport<MyState, RemoteState>::Transport( MyState &initial_state, RemoteState 
     receiver_quench_timer( 0 ),
     last_receiver_state( initial_remote ),
     fragments(),
-    verbose( false )
+    verbose( 0 )
 {
   /* server */
 }
@@ -63,7 +63,7 @@ Transport<MyState, RemoteState>::Transport( MyState &initial_state, RemoteState 
     receiver_quench_timer( 0 ),
     last_receiver_state( initial_remote ),
     fragments(),
-    verbose( false )
+    verbose( 0 )
 {
   /* client */
 }

--- a/src/network/networktransport.h
+++ b/src/network/networktransport.h
@@ -63,7 +63,7 @@ namespace Network {
     uint64_t receiver_quench_timer;
     RemoteState last_receiver_state; /* the state we were in when user last queried state */
     FragmentAssembly fragments;
-    bool verbose;
+    unsigned int verbose;
 
   public:
     Transport( MyState &initial_state, RemoteState &initial_remote,
@@ -106,7 +106,7 @@ namespace Network {
 
     const std::vector< int > fds( void ) const { return connection.fds(); }
 
-    void set_verbose( void ) { sender.set_verbose(); verbose = true; }
+    void set_verbose( unsigned int s_verbose ) { sender.set_verbose( s_verbose ); verbose = s_verbose; }
 
     void set_send_delay( int new_delay ) { sender.set_send_delay( new_delay ); }
 

--- a/src/network/transportsender-impl.h
+++ b/src/network/transportsender-impl.h
@@ -187,11 +187,16 @@ void TransportSender<MyState>::tick( void )
     }
   }
 
-  if ( diff.empty() && (now >= next_ack_time) ) {
-    send_empty_ack();
-    mindelay_clock = uint64_t( -1 );
-  } else if ( !diff.empty() && ( (now >= next_send_time)
-			  || (now >= next_ack_time) ) ) {
+  if ( diff.empty() ) {
+    if ( (now >= next_ack_time) ) {
+      send_empty_ack();
+      mindelay_clock = uint64_t( -1 );
+    }
+    if ( (now >= next_send_time) ) {
+      next_send_time = uint64_t( -1 );
+      mindelay_clock = uint64_t( -1 );
+    }
+  } else if ( (now >= next_send_time) || (now >= next_ack_time) ) {
     /* Send diffs or ack */
     send_to_receiver( diff );
     mindelay_clock = uint64_t( -1 );

--- a/src/network/transportsender-impl.h
+++ b/src/network/transportsender-impl.h
@@ -56,7 +56,7 @@ TransportSender<MyState>::TransportSender( Connection *s_connection, MyState &in
     fragmenter(),
     next_ack_time( timestamp() ),
     next_send_time( timestamp() ),
-    verbose( false ),
+    verbose( 0 ),
     shutdown_in_progress( false ),
     shutdown_tries( 0 ),
     shutdown_start( -1 ),

--- a/src/network/transportsender.h
+++ b/src/network/transportsender.h
@@ -91,7 +91,7 @@ namespace Network {
 
     void calculate_timers( void );
 
-    bool verbose;
+    unsigned int verbose;
     bool shutdown_in_progress;
     int shutdown_tries;
     uint64_t shutdown_start;
@@ -144,7 +144,7 @@ namespace Network {
       current_state = x;
       current_state.reset_input();
     }
-    void set_verbose( void ) { verbose = true; }
+    void set_verbose( unsigned int s_verbose ) { verbose = s_verbose; }
 
     bool get_shutdown_in_progress( void ) const { return shutdown_in_progress; }
     bool get_shutdown_acknowledged( void ) const { return sent_states.front().num == uint64_t(-1); }

--- a/src/statesync/completeterminal.cc
+++ b/src/statesync/completeterminal.cc
@@ -142,7 +142,7 @@ bool Complete::set_echo_ack( uint64_t now )
   for ( input_history_type::const_iterator i = input_history.begin();
         i != input_history.end();
         i++ ) {
-    if ( i->second < now - ECHO_TIMEOUT ) {
+    if ( i->second <= now - ECHO_TIMEOUT ) {
       newest_echo_ack = i->first;
     }
   }

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -22,6 +22,7 @@ displaytests = \
 	emulation-cursor-motion.test \
 	emulation-multiline-scroll.test \
 	emulation-wrap-across-frames.test \
+	network-no-diff.test \
 	prediction-unicode.test \
 	pty-deadlock.test \
 	server-network-timeout.test \

--- a/src/tests/e2e-test
+++ b/src/tests/e2e-test
@@ -229,9 +229,15 @@ for run in $server_tests; do
     if [ "$server_rv" -ne 0 ]; then
 	test_error "server harness exited with status %s\n" "$server_rv"
     fi
-    # Check for "round-trip" failures
-    if grep -q "round-trip Instruction verification failed" "${test_dir}/${run}.server.stderr"; then
-	test_error "Round-trip Instruction verification failed on server during %s\n" "$run"
+    if [ "${run}" != "direct" ]; then
+	# Check for "round-trip" failures
+	if grep -q "round-trip Instruction verification failed" "${test_dir}/${run}.server.stderr"; then
+	    test_error "Round-trip Instruction verification failed on server during %s\n" "$run"
+	fi
+	# Check for 0-timeout select() issue
+	if egrep -q "(polls, rate limiting|consecutive polls)" "${test_dir}/${run}.server.stderr"; then
+	    test_error "select() with zero timeout called too often on server during %s\n" "$run"
+	fi
     fi
     # XXX We'd also like to check for "target state Instruction
     # verification failed", a new check, but tmux's lack of BCE

--- a/src/tests/e2e-test
+++ b/src/tests/e2e-test
@@ -102,7 +102,7 @@ mosh_server()
 	test_error "mosh_server: variables missing\n"
     fi
     exec 2> "${MOSH_E2E_TEST}.server.stderr"
-    exec "$MOSH_SERVER" new -v $MOSH_SERVER_ARGS -@ "$@"
+    exec "$MOSH_SERVER" new -vv $MOSH_SERVER_ARGS -@ "$@"
 }
 
 # main

--- a/src/tests/e2e-test-server
+++ b/src/tests/e2e-test-server
@@ -24,6 +24,11 @@ fi
 # run harnessed command
 eval "$@"
 testret=$?
+# Capture mosh-server runtime if possible.
+runtime=$(ps -o time= $PPID)
+if [ $? -ne 0 ]; then # Cygwin...
+    runtime=-
+fi
 # Wait for tmux client screen to become up to date.
 sleep 1
 printf "@@@ server complete @@@" >&2
@@ -48,6 +53,8 @@ if ! tmux save-buffer $testname.capture; then
     printf "tmux save-buffer failed, erroring test\n" >&2
     exit 99
 fi
+# Dump runtime into tmux log.
+printf "@@@ runtime %s @@@\n" "$runtime"
 # return useful exitstatus from harnessed command
 if [ $testret -ne 0 ]; then
     exit 1

--- a/src/tests/e2e-test-server
+++ b/src/tests/e2e-test-server
@@ -25,7 +25,7 @@ fi
 eval "$@"
 testret=$?
 # Capture mosh-server runtime if possible.
-runtime=$(ps -o time= $PPID)
+runtime=$(ps -o time= $PPID 2>/dev/null)
 if [ $? -ne 0 ]; then # Cygwin...
     runtime=-
 fi

--- a/src/tests/network-no-diff.test
+++ b/src/tests/network-no-diff.test
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+#
+# This is a regression test to ensure that Mosh does not spin
+# on updates that do not actually change the framebuffer.
+#
+
+. $(dirname $0)/e2e-test-subrs
+PATH=$PATH:.:$srcdir
+# Top-level wrapper.
+if [ $# -eq 0 ]; then
+    e2e-test $0 baseline post
+    exit
+fi
+
+# OK, we have arguments, we're one of the test hooks.
+if [ $# -ne 1 ]; then
+    fail "bad arguments %s\n" "$@"
+fi
+
+baseline()
+{
+    # Generate updates that don't change the screen
+    local i
+    i=0
+    while [ $i -lt 10 ]; do
+	printf 'x\b'
+	i=$((i + 1))
+	sleep 1
+    done
+}
+
+post()
+{
+    # Extract server run time.
+    runtime=$(sed -E -n 's/.*@@@ runtime: (.*) @@@.*/\1/p' "$(basename $0).d/baseline.tmux.log")
+
+    # If this system can't actually report runtime, bail.
+    if [ "$runtime" -eq "-" ]; then
+	exit 0
+    fi
+
+    # If we ran for more than one second, fail.
+    seconds=${runtime##*:}
+    bigger=${runtime%:*}
+    onesec=$(echo "$seconds >= 1" | bc)
+    if [ "$onesec" -eq 1 -o "$bigger" -ne 0 ]; then
+	exit 1
+    fi
+    exit 0
+}
+
+case $1 in
+    baseline)
+	baseline;;
+    post)
+	post;;
+    *)
+	fail "unknown test argument %s\n" $1;;
+esac

--- a/src/tests/network-no-diff.test
+++ b/src/tests/network-no-diff.test
@@ -36,7 +36,7 @@ post()
     runtime=$(sed -E -n 's/.*@@@ runtime: (.*) @@@.*/\1/p' "$(basename $0).d/baseline.tmux.log")
 
     # If this system can't actually report runtime, bail.
-    if [ "$runtime" -eq "-" ]; then
+    if [ -z "$runtime" -o "$runtime" -eq "-" ]; then
 	exit 0
     fi
 

--- a/src/util/select.cc
+++ b/src/util/select.cc
@@ -36,6 +36,8 @@ fd_set Select::dummy_fd_set;
 
 sigset_t Select::dummy_sigset;
 
+unsigned int Select::verbose = 0;
+
 void Select::handle_signal( int signum )
 {
   fatal_assert( signum >= 0 );

--- a/src/util/select.h
+++ b/src/util/select.h
@@ -122,13 +122,16 @@ public:
     clear_got_signal();
 
     /* Rate-limit and warn about polls. */
+    if ( verbose > 1 && timeout == 0 ) {
+      fprintf( stderr, "%s: got poll (timeout 0)\n", __func__ );
+    }
     if ( timeout == 0 && ++consecutive_polls >= MAX_POLLS ) {
-      if ( consecutive_polls == MAX_POLLS ) {
+      if ( verbose > 1 && consecutive_polls == MAX_POLLS ) {
 	fprintf( stderr, "%s: got %d polls, rate limiting.\n", __func__, MAX_POLLS );
       }
       timeout = 1;
     } else if ( timeout != 0 && consecutive_polls ) {
-      if ( consecutive_polls >= MAX_POLLS ) {
+      if ( verbose > 1 && consecutive_polls >= MAX_POLLS ) {
 	fprintf( stderr, "%s: got %d consecutive polls\n", __func__, consecutive_polls );
       }
       consecutive_polls = 0;
@@ -212,6 +215,8 @@ public:
     return rv;
   }
 
+  static void set_verbose( unsigned int s_verbose ) { verbose = s_verbose; }
+
 private:
   static const int MAX_SIGNAL_NUMBER = 64;
   /* Number of 0-timeout selects after which we begin to think
@@ -233,6 +238,7 @@ private:
   static fd_set dummy_fd_set;
   static sigset_t dummy_sigset;
   int consecutive_polls;
+  static unsigned int verbose;
 };
 
 #endif

--- a/src/util/select.h
+++ b/src/util/select.h
@@ -63,6 +63,7 @@ private:
     , all_fds( dummy_fd_set )
     , read_fds( dummy_fd_set )
     , empty_sigset( dummy_sigset )
+    , consecutive_polls( 0 )
   {
     FD_ZERO( &all_fds );
     FD_ZERO( &read_fds );
@@ -119,6 +120,19 @@ public:
   {
     memcpy( &read_fds,  &all_fds, sizeof( read_fds  ) );
     clear_got_signal();
+
+    /* Rate-limit and warn about polls. */
+    if ( timeout == 0 && ++consecutive_polls >= MAX_POLLS ) {
+      if ( consecutive_polls == MAX_POLLS ) {
+	fprintf( stderr, "%s: got %d polls, rate limiting.\n", __func__, MAX_POLLS );
+      }
+      timeout = 1;
+    } else if ( timeout != 0 && consecutive_polls ) {
+      if ( consecutive_polls >= MAX_POLLS ) {
+	fprintf( stderr, "%s: got %d consecutive polls\n", __func__, consecutive_polls );
+      }
+      consecutive_polls = 0;
+    }
 
 #ifdef HAVE_PSELECT
     struct timespec ts;
@@ -200,6 +214,9 @@ public:
 
 private:
   static const int MAX_SIGNAL_NUMBER = 64;
+  /* Number of 0-timeout selects after which we begin to think
+   * something's wrong. */
+  static const int MAX_POLLS = 10;
 
   static void handle_signal( int signum );
 
@@ -215,6 +232,7 @@ private:
 
   static fd_set dummy_fd_set;
   static sigset_t dummy_sigset;
+  int consecutive_polls;
 };
 
 #endif


### PR DESCRIPTION
This fix was a long time in coming.

This fixes a problem I discovered where `mosh-server` would get into a state where it would call select() with a timeout of 0, and could spin for up to 3 seconds (until the next ack was sent to the client).  This happens when the client writes to the terminal in some way that leaves the display unchanged (such as `"x\b"`).  It took me...quite a while to discover that there was another very similar bug where input prediction's rapid acks could also cause a spin for 1 millisecond.

The fix for the second problem was simple, but the theoretically best fix for the first problem (making `Terminal::Complete::operator==()` do its comparison with the correct depth, and always agree with `Terminal::Complete::diff_from()`) turns out to be a large project, with implications for things like object lifetime and performance.  I might finish that half-done work, but it doesn't make sense for a near-term release.  So instead I have this fix that simply adjusts the timers involved to avoid the zero timeout.  (There's also a band-aid to convert zero timeouts to 1ms timeouts, which will reduce the impact of anything like this in the future.)

@keithw, I believe that fix will do something fairly reasonable, but would you have a look at 
https://github.com/mobile-shell/mosh/commit/34e69867750578b4cc6a1c137113913a30107d4b for me and see if you agree?

In this PR, the fixes are after the tests, to make it easy to run the tests on the buggy code.  When I merge this into mobile-shell/mosh, I'll reorder the commits so the fixes are before the tests, so as to not break future bisecting.
