### PR TITLE
Travis osx package build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ addons:
     - perl
 
 before_install:
-  # Get full repo and describe this
+  # Get full repo for `git describe`
   - git fetch --tags --unshallow
   # OS X dependencies.  The package_deps step takes 15 minutes or so
   # and is fairly quiet, so wrap it in travis_wait to keep it from
@@ -78,7 +78,7 @@ script:
       (
         set -e
         cd macosx
-        env MACOSX_DEPLOYMENT_TARGET=10.10 ./build.sh
+        env ZERO_AR_DATE=1 MACOSX_DEPLOYMENT_TARGET=10.10 ./build.sh
         ln ${TRAVIS_TAG}.pkg mosh.pkg
         shasum -a 256 mosh.pkg
       )

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,7 @@ script:
         set -e
         cd macosx
         env ZERO_AR_DATE=1 MACOSX_DEPLOYMENT_TARGET=10.10 ./build.sh
-        ln ${TRAVIS_TAG}.pkg mosh.pkg
-        shasum -a 256 mosh.pkg
+        shasum -a 256 "${TRAVIS_TAG}.pkg" "${TRAVIS_TAG}-build-report.tbz"
       )
     fi
 # Deploy the OS X package to a GitHub release.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-osx_image: xcode8
-
+# This does Travis CI builds on Linux and OS X, and on a tag build,
+# also produces an OS X package.
 os:
   - linux
   - osx
@@ -8,28 +8,96 @@ cache:
   - apt
 
 language: cpp
+
+# Use the Ubuntu 14.04 build environment for Linux.
 sudo: required
 dist: trusty
 
+# Currently we're using the Travis Xcode 7.1/OS X 10.10 image to
+# get i386/x86_64 fat binaries.
+osx_image: xcode7.1
+
+# Linux dependencies
 addons:
   apt:
     packages:
+    # For build.
     - protobuf-compiler
     - libprotobuf-dev
     - libutempter-dev
-    - tmux			# test suite
-    - perl			# test suite
+    # Test suite needs these.
+    - tmux
+    - perl
 
 before_install:
-  - if test "$TRAVIS_OS_NAME" = osx; then brew update; fi
-  - if test "$TRAVIS_OS_NAME" = osx; then brew install protobuf tmux; fi
-  - if test "$TRAVIS_OS_NAME" = osx; then brew outdated protobuf tmux || brew upgrade protobuf tmux; fi
+  # Get full repo and describe this
   - git fetch --tags --unshallow
+  # OS X dependencies.  The package_deps step takes 15 minutes or so
+  # and is fairly quiet, so wrap it in travis_wait to keep it from
+  # being killed.
+  - |
+    (
+      set -e
+      if test osx = "${TRAVIS_OS_NAME}"; then
+        macosx/brew-deps.sh install
+        if test -n "${TRAVIS_TAG}"; then
+          travis_wait 30 macosx/brew-deps.sh package_deps
+        else
+          macosx/brew-deps.sh deps
+        fi
+      fi
+    )
 
+# Use before_script to report the build configuration.
+before_script:
+  # Describe this system.
+  - id
+  - env
+  - git describe --long
+  - |
+    (
+      set -e
+      if test osx = "${TRAVIS_OS_NAME}" && test -n "${TRAVIS_TAG}"; then
+        rm -rf macosx/build-report "macosx/${TRAVIS_TAG}-build-report.tbz"
+        mkdir macosx/build-report
+        cd macosx/build-report
+        ../brew-deps.sh describe
+        ../osx-xcode.sh describe
+        tar -cjf "../${TRAVIS_TAG}-build-report.tbz" .
+      fi
+    )
+
+# 'make distcheck', and OS X package build on tag builds.
 script:
   - ./autogen.sh
   - ./configure --enable-compile-warnings=error --enable-examples
   - make distcheck VERBOSE=1 V=1
+  # Build OS X package for tags.
+  - |
+    if test osx = "${TRAVIS_OS_NAME}" && test -n "${TRAVIS_TAG}"; then
+      (
+        set -e
+        cd macosx
+        env MACOSX_DEPLOYMENT_TARGET=10.10 ./build.sh
+        ln ${TRAVIS_TAG}.pkg mosh.pkg
+        shasum -a 256 mosh.pkg
+      )
+    fi
+# Deploy the OS X package to a GitHub release.
+deploy:
+  provider: releases
+  api_key:
+    secure: O+EmNHUQpqvrWNb1LYv5CXF9o35Mybi+Y48jr+nV3oJ+dLlwgmP71tDzARY0rEY18xT4DL9RBbl5Y74A4nZxvSMSih+VBUf+lgBhkAFkU5W1sRTaJdQVtJw6NcaeuDR/TvVMpJAPxLtHOZnmqplkQVDn4fpkweGaW0Suk7eSlibF3fd0dhoZ8sfDgWQpUW61C08ENBC9/ru01BqDcNuWA9EoS2aLRVCHKR5C02D2EFONlHTxu32X9qm5IcVrk+Zi5mmqyHk74A4a7QRJCDixKyt53LGXYpQh9flePmzSqZDKO5q3PSmWohoUzGLkKBcZit/mSd5aUeIzd7gk/YHNxGfZpGvLzjVDWpjdTXxALTcpVA64VFqLbb3P7N+zYQ7S9ZucwAz8XQ+wArqszQrLtU3vtz+AsO6dLRxAg0lLjNe084Gv0hFAn8u8HGNqBBZ177sTKoEmL3w0wdwSuxhk1aGIFnlKrzjFY57HvJlxSNupAeXqtU9/DNwLyzsnFc1qN4UKJ/hXdb5mtwug+DZy7E0RpJ/jJemfy7RjIAAZCowCLRFBxfRkY3HRaHeaF31mAogkc8FLXFjx2sR95t7GvK1AvJvHdmXs4OxjvgEVl9OI+mWQ9xMqcmjKwx5KuuAcBt8sLK7MJE6iRBwYBQ7eUQrJcYxRMN+w0vhznvLZwv8=
+  # Save build artifacts.
+  skip_cleanup: true
+  # Using a shell variable in deploy.file is undocumented but seems to work.
+  file:
+    - macosx/${TRAVIS_TAG}.pkg
+    - macosx/${TRAVIS_TAG}-build-report.tbz
+  on:
+    repo: cgull/mosh
+    tags: true
+    condition: ${TRAVIS_OS_NAME} = osx
 
 notifications:
   irc:

--- a/macosx/brew-deps.sh
+++ b/macosx/brew-deps.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+#
+# Install Homebrew dependencies
+#
+# This script handles build dependencies other than those provided by
+# MacOS and Xcode, for a Mosh build using macosx/build.sh or the
+# native autoconf/automake build for CI.  It is intended to be used by
+# a build system, and should be agnostic to any particular system.
+#
+# Similar scripts could be developed for MacPorts, direct dependency
+# builds, etc.
+#
+
+#
+# Install and/or configure the system used to provide dependencies.
+#
+install()
+{
+    # Straight from https://brew.sh
+    if ! brew --version > /dev/null 2>&1; then
+	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    fi
+}
+
+#
+# Install up-to-date build dependencies required for a development or
+# CI build.  These dependencies only need to provide runtime
+# dependencies for the build system, support for things like previous
+# OS versions and fat binaries is not needed.
+#
+deps()
+{
+    brew update
+    brew update
+    brew reinstall tmux
+    brew reinstall protobuf
+}
+
+#
+# Install build dependencies required for the MacOS package build.
+# Runtime dependencies are required to support the targeted OS X
+# version, static libraries, and fat binaries for the package build.
+#
+# This reinstalls protobuf with --universal --bottle to get a fat
+# library that will run on any machine.  (This takes about 15 minutes
+# on current Travis infrastructure.)
+#
+package_deps()
+{
+    deps
+    brew rm protobuf
+    brew install protobuf --universal --bottle
+}
+
+#
+# Describe the dependencies installed and used as best as possible.
+#
+describe()
+{
+    brew --version > brew-version.txt
+    brew info --json=v1 --installed > brew-info.json
+}
+
+#
+# Do something.
+#
+set -e
+"$@"

--- a/macosx/osx-xcode.sh
+++ b/macosx/osx-xcode.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+#
+# OS X and Xcode support script.
+#
+
+#
+# Describe the OS X and Xcode installation, patches, etc as best as possible.
+#
+# Beware: System Profiler dumps significant private and security information.
+#
+describe()
+{
+    # Most of the XML in this report is plist files, which can be read more easily with plutil -p
+    pkgutil --pkgs-plist > packages-plist.xml
+    mkdir package-info-plist/
+    for i in $(pkgutil --pkgs); do pkgutil --pkg-info-plist=$i > package-info-plist/$i.xml; done
+    xcodebuild -version > xcodebuild-version.txt
+    # CLT info can be found in package-info-plist/com.apple.pkg.CLTools_Executables.xml
+    xcode-select --print-path > xcode-path.txt
+    # System Profiler's XML can be read more easily with plutil -p, or
+    # opened with the System Profiler GUI.
+    system_profiler -xml -detailLevel full > system-profile.spx 2>/dev/null
+}
+
+#
+# Do something.
+#
+set -e
+"$@"


### PR DESCRIPTION
This is for issue #812, following discussion on the mosh-devel mailing list.
This gets us an automated build with hopefully-good reporting of the components that go into it (OS X, Xcode, Homebrew, Mosh Git).  It creates a package, and a separate tarball reporting the build environment and configuration.

I've given up on deterministic/reproducible builds for the moment.  Apparently Apple's toolchain (in particular the linker) is incapable of doing deterministic builds.  It appears the bitcoin crowd has managed to get deterministic builds, but only by cobbling together a Linux VM environment, cross-compile tools (some of which are fairly broken), and Apple SDK components.  Not quite ready to go there yet.

I've mostly cleanly separated the Travis build from the package manager install from the package build itself.  From this point it may not be too hard to compose a more independently trustable build VM with either manual builds, or using Gitlab as a conduit to automatically start builds.

See https://github.com/cgull/mosh/releases/tag/mosh-1.2.6.98.8 and https://travis-ci.org/cgull/mosh/jobs/173651031 for the latest package build using this setup.  Pay no attention to the release number here, it hasn't got any relation to actual Mosh releases and shouldn't be viewed as an early release candidate.  The Travis package build is activated by pushing a tag, and I needed to name the tag *something*.