### PR TITLE
Make all commands properly support --help and --version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.61])
 AC_INIT([mosh], [1.2.6], [mosh-devel@mit.edu])
-AM_INIT_AUTOMAKE([foreign -Wall -Werror])
+AM_INIT_AUTOMAKE([foreign std-options -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_SRCDIR([src/frontend/mosh-client.cc])
 AC_CONFIG_MACRO_DIR([m4])

--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -160,8 +160,14 @@ GetOptions( 'client=s' => \$client,
 	    'bind-server=s' => \$bind_ip,
 	    'experimental-remote-ip=s' => \$use_remote_ip) or die $usage;
 
-die $usage if ( defined $help );
-die $version_message if ( defined $version );
+if ( defined $help ) {
+    print $usage;
+    exit;
+}
+if ( defined $version ) {
+    print $version_message;
+    exit;
+}
 
 if ( defined $predict ) {
   predict_check( $predict, 0 );

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -70,12 +70,18 @@
 #  error "SysV or X/Open-compatible Curses header file required"
 #endif
 
-static void usage( const char *argv0 ) {
-  fprintf( stderr, "mosh-client (%s) [build %s]\n", PACKAGE_STRING, BUILD_VERSION );
-  fprintf( stderr, "Copyright 2012 Keith Winstein <mosh-devel@mit.edu>\n" );
-  fprintf( stderr, "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n\n" );
+static void print_version( FILE *file )
+{
+  fprintf( file, "mosh-client (%s) [build %s]\n", PACKAGE_STRING, BUILD_VERSION );
+  fprintf( file, "Copyright 2012 Keith Winstein <mosh-devel@mit.edu>\n" );
+  fprintf( file, "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n" );
+}
 
-  fprintf( stderr, "Usage: %s [-# 'ARGS'] IP PORT\n       %s -c\n", argv0, argv0 );
+static void print_usage( FILE *file, const char *argv0 )
+{
+  print_version( file );
+  fprintf( file, "\n" );
+  fprintf( file, "Usage: %s [-# 'ARGS'] IP PORT\n       %s -c\n", argv0, argv0 );
 }
 
 static void print_colorcount( void )
@@ -107,6 +113,17 @@ int main( int argc, char *argv[] )
   fatal_assert( argc > 0 );
 
   /* Get arguments */
+  for ( int i = 1; i < argc; i++ ) {
+    if ( 0 == strcmp( argv[ i ], "--help" ) ) {
+      print_usage( stdout, argv[ 0 ] );
+      exit( 0 );
+    }
+    if ( 0 == strcmp( argv[ i ], "--version" ) ) {
+      print_version( stdout );
+      exit( 0 );
+    }
+  }
+
   int opt;
   while ( (opt = getopt( argc, argv, "#:cv" )) != -1 ) {
     switch ( opt ) {
@@ -121,7 +138,7 @@ int main( int argc, char *argv[] )
       verbose++;
       break;
     default:
-      usage( argv[ 0 ] );
+      print_usage( stderr, argv[ 0 ] );
       exit( 1 );
       break;
     }
@@ -130,7 +147,7 @@ int main( int argc, char *argv[] )
   char *ip, *desired_port;
 
   if ( argc - optind != 2 ) {
-    usage( argv[ 0 ] );
+    print_usage( stderr, argv[ 0 ] );
     exit( 1 );
   }
 
@@ -141,7 +158,7 @@ int main( int argc, char *argv[] )
   if ( desired_port
        && ( strspn( desired_port, "0123456789" ) != strlen( desired_port ) ) ) {
     fprintf( stderr, "%s: Bad UDP port (%s)\n\n", argv[ 0 ], desired_port );
-    usage( argv[ 0 ] );
+    print_usage( stderr, argv[ 0 ] );
     exit( 1 );
   }
 

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -106,6 +106,13 @@ static int run_server( const char *desired_ip, const char *desired_port,
 
 using namespace std;
 
+static void print_version( FILE *file )
+{
+  fprintf( file, "mosh-server (%s) [build %s]\n", PACKAGE_STRING, BUILD_VERSION );
+  fprintf( file, "Copyright 2012 Keith Winstein <mosh-devel@mit.edu>\n" );
+  fprintf( file, "License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n" );
+}
+
 static void print_usage( FILE *stream, const char *argv0 )
 {
   fprintf( stream, "Usage: %s new [-s] [-v] [-i LOCALADDR] [-p PORT[:PORT2]] [-c COLORS] [-l NAME=VALUE] [-- COMMAND...]\n", argv0 );
@@ -176,9 +183,13 @@ int main( int argc, char *argv[] )
   list<string> locale_vars;
 
   /* strip off command */
-  for ( int i = 0; i < argc; i++ ) {
+  for ( int i = 1; i < argc; i++ ) {
     if ( 0 == strcmp( argv[ i ], "--help" ) || 0 == strcmp( argv[ i ], "-h" ) ) {
       print_usage( stdout, argv[ 0 ] );
+      exit( 0 );
+    }
+    if ( 0 == strcmp( argv[ i ], "--version" ) ) {
+      print_version( stdout );
       exit( 0 );
     }
     if ( 0 == strcmp( argv[ i ], "--" ) ) { /* -- is mandatory */


### PR DESCRIPTION
These should output to stdout and exit with status 0.  Passing `std-options` to `AM_INIT_AUTOMAKE` causes `make installcheck` (hence also `make distcheck`) to verify this.