### PR TITLE
Support OCLint static checker; do some source cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,14 @@ AM_DISTCHECK_CONFIGURE_FLAGS = --enable-compile-warnings=distcheck --enable-exam
 # non-Automake defines
 CPPCHECK_FLAGS = --enable=all --template=gcc --force # -j8 disables unused function checking.
 CLANG_SCAN_BUILD = scan-build
+BEAR = bear
+OCLINT_JCD = oclint-json-compilation-database
+OCLINT_OPTIONS = -enable-global-analysis -max-priority-2=1000 -max-priority-3=1000 \
+	-rc LONG_LINE=160 \
+	-rc LONG_VARIABLE_NAME=40 \
+	-rc SHORT_VARIABLE_NAME=1 \
+	-rc MINIMUM_CASES_IN_SWITCH=2
+
 .PHONY:	VERSION
 
 VERSION:
@@ -29,7 +37,7 @@ version.h:	VERSION
 	@rm -f version.h.new
 
 clean-local:
-	@rm -rf version.h VERSION cov-int mosh-coverity.txz
+	@rm -rf version.h VERSION cov-int mosh-coverity.txz compile_commands.json
 
 # Linters and static checkers, for development only.  Not included in
 # build dependencies, and outside of Automake processing.
@@ -46,6 +54,15 @@ cov-build:
 	rm -rf cov-int
 	cov-build --dir cov-int $(MAKE) check TESTS=
 	tar -caf mosh-coverity.txz cov-int
+
+# These two rules are for Bear + OCLint.
+# Don't *run* the tests, prediction-unicode.test generates arguments
+# with illegal UTF-8 that make Bear unhappy.
+compile_commands.json:
+	$(MAKE) clean
+	bear $(MAKE) check TESTS=
+oclint: compile_commands.json
+	$(OCLINT_JCD) -e src/protobufs -- $(OCLINT_OPTIONS)
 
 # Clang's scan-build static checker.
 scan-build:

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,9 +2,11 @@ ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = scripts src man conf
 EXTRA_DIST = autogen.sh ocb-license.html README.md COPYING.iOS
 BUILT_SOURCES = version.h
-CLANG_SCAN_BUILD = scan-build
 AM_DISTCHECK_CONFIGURE_FLAGS = --enable-compile-warnings=distcheck --enable-examples
 
+# non-Automake defines
+CPPCHECK_FLAGS = --enable=all --template=gcc --force # -j8 disables unused function checking.
+CLANG_SCAN_BUILD = scan-build
 .PHONY:	VERSION
 
 VERSION:
@@ -29,17 +31,23 @@ version.h:	VERSION
 clean-local:
 	@rm -rf version.h VERSION cov-int mosh-coverity.txz
 
-cppcheck: $(BUILT_SOURCES) config.h
-	cppcheck --enable=all --template=gcc -include config.h -I . \
+# Linters and static checkers, for development only.  Not included in
+# build dependencies, and outside of Automake processing.
+cppcheck:
+	cppcheck $(CPPCHECK_FLAGS) -include config.h -I . \
 		-I src/crypto -I src/frontend -I src/network -I src/protobufs \
 		-I src/statesync -I src/terminal -I src/util \
 		-I /usr/include -I /usr/include/google/protobuf -I/usr/include/openssl \
 		.
 
-cov-build: $(BUILT_SOURCES) config.h
-	$(MAKE) clean && rm -rf cov-int && \
-		cov-build --dir cov-int $(MAKE) check && \
-		tar -caf mosh-coverity.txz cov-int
+# Coverity.
+cov-build:
+	$(MAKE) clean
+	rm -rf cov-int
+	cov-build --dir cov-int $(MAKE) check TESTS=
+	tar -caf mosh-coverity.txz cov-int
 
-scan-build: $(BUILT_SOURCES) config.h
-	$(MAKE) clean && $(CLANG_SCAN_BUILD) $(MAKE) check
+# Clang's scan-build static checker.
+scan-build:
+	$(MAKE) clean
+	$(CLANG_SCAN_BUILD) $(MAKE) check TESTS=

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -250,8 +250,9 @@ int main( int argc, char *argv[] )
 	locale_vars.push_back( string( optarg ) );
 	break;
       default:
-	print_usage( stderr, argv[ 0 ] );
 	/* don't die on unknown options */
+	print_usage( stderr, argv[ 0 ] );
+	break;
       }
     }
   } else if ( argc == 1 ) {
@@ -658,7 +659,7 @@ static void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &
 
   bool child_released = false;
 
-  while ( 1 ) {
+  while ( true ) {
     try {
       static const uint64_t timeout_if_no_client = 60000;
       int timeout = INT_MAX;

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -826,12 +826,11 @@ static void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &
 	fprintf( stderr, "Network idle for %llu seconds.\n", 
 		 static_cast<unsigned long long>( time_since_remote_state / 1000 ) );
       }
-      if ( sel.signal( SIGUSR1 ) ) {
-	if ( !network_signaled_timeout_ms || network_signaled_timeout_ms <= time_since_remote_state ) {
-	  idle_shutdown = true;
-	  fprintf( stderr, "Network idle for %llu seconds when SIGUSR1 received\n",
-		   static_cast<unsigned long long>( time_since_remote_state / 1000 ) );
-	}
+      if ( sel.signal( SIGUSR1 )
+	   && ( !network_signaled_timeout_ms || network_signaled_timeout_ms <= time_since_remote_state ) ) {
+	idle_shutdown = true;
+	fprintf( stderr, "Network idle for %llu seconds when SIGUSR1 received\n",
+		 static_cast<unsigned long long>( time_since_remote_state / 1000 ) );
       }
 
       if ( sel.any_signal() || idle_shutdown ) {
@@ -860,24 +859,21 @@ static void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &
 
       #ifdef HAVE_UTEMPTER
       /* update utmp if has been more than 30 seconds since heard from client */
-      if ( connected_utmp ) {
-	if ( time_since_remote_state > 30000 ) {
-	  utempter_remove_record( host_fd );
+      if ( connected_utmp 
+	   && time_since_remote_state > 30000 ) {
+	utempter_remove_record( host_fd );
 
-	  char tmp[ 64 ];
-	  snprintf( tmp, 64, "mosh [%d]", getpid() );
-	  utempter_add_record( host_fd, tmp );
+	char tmp[ 64 ];
+	snprintf( tmp, 64, "mosh [%d]", getpid() );
+	utempter_add_record( host_fd, tmp );
 
-	  connected_utmp = false;
-	}
+	connected_utmp = false;
       }
       #endif
 
-      if ( terminal.set_echo_ack( now ) ) {
+      if ( terminal.set_echo_ack( now ) && !network.shutdown_in_progress() ) {
 	/* update client with new echo ack */
-	if ( !network.shutdown_in_progress() ) {
-	  network.set_current_state( terminal );
-	}
+	network.set_current_state( terminal );
       }
 
       if ( !network.get_remote_state_num()

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -948,7 +948,7 @@ static bool motd_hushed( void )
 {
   /* must be in home directory already */
   struct stat buf;
-  return (0 == lstat( ".hushlogin", &buf ));
+  return 0 == lstat( ".hushlogin", &buf );
 }
 
 #ifdef HAVE_UTMPX_H
@@ -956,7 +956,7 @@ static bool device_exists( const char *ut_line )
 {
   string device_name = string( "/dev/" ) + string( ut_line );
   struct stat buf;
-  return (0 == lstat( device_name.c_str(), &buf ));
+  return 0 == lstat( device_name.c_str(), &buf );
 }
 #endif
 

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -314,82 +314,82 @@ bool STMClient::process_user_input( int fd )
 
   NetworkType &net = *network;
 
-  if ( !net.shutdown_in_progress() ) {
-    overlays.get_prediction_engine().set_local_frame_sent( net.get_sent_state_last() );
+  if ( net.shutdown_in_progress() ) {
+    return true;
+  }
+  overlays.get_prediction_engine().set_local_frame_sent( net.get_sent_state_last() );
 
-    /* Don't predict for bulk data. */
-    bool paste = bytes_read > 100;
-    if ( paste ) {
-      overlays.get_prediction_engine().reset();
+  /* Don't predict for bulk data. */
+  bool paste = bytes_read > 100;
+  if ( paste ) {
+    overlays.get_prediction_engine().reset();
+  }
+
+  for ( int i = 0; i < bytes_read; i++ ) {
+    char the_byte = buf[ i ];
+
+    if ( !paste ) {
+      overlays.get_prediction_engine().new_user_byte( the_byte, local_framebuffer );
     }
 
-    for ( int i = 0; i < bytes_read; i++ ) {
-      char the_byte = buf[ i ];
+    if ( quit_sequence_started ) {
+      if ( the_byte == '.' ) { /* Quit sequence is Ctrl-^ . */
+	if ( net.has_remote_addr() && (!net.shutdown_in_progress()) ) {
+	  overlays.get_notification_engine().set_notification_string( wstring( L"Exiting on user request..." ), true );
+	  net.start_shutdown();
+	  return true;
+	}
+	return false;
+      } else if ( the_byte == 0x1a ) { /* Suspend sequence is escape_key Ctrl-Z */
+	/* Restore terminal and terminal-driver state */
+	swrite( STDOUT_FILENO, display.close().c_str() );
 
-      if ( !paste ) {
-	overlays.get_prediction_engine().new_user_byte( the_byte, local_framebuffer );
-      }
-
-      if ( quit_sequence_started ) {
-	if ( the_byte == '.' ) { /* Quit sequence is Ctrl-^ . */
-	  if ( net.has_remote_addr() && (!net.shutdown_in_progress()) ) {
-	    overlays.get_notification_engine().set_notification_string( wstring( L"Exiting on user request..." ), true );
-	    net.start_shutdown();
-	    return true;
-	  } else {
-	    return false;
-	  }
-	} else if ( the_byte == 0x1a ) { /* Suspend sequence is escape_key Ctrl-Z */
-	  /* Restore terminal and terminal-driver state */
-	  swrite( STDOUT_FILENO, display.close().c_str() );
-
-	  if ( tcsetattr( STDIN_FILENO, TCSANOW, &saved_termios ) < 0 ) {
-	    perror( "tcsetattr" );
-	    exit( 1 );
-	  }
-
-	  fputs( "\n\033[37;44m[mosh is suspended.]\033[m\n", stdout );
-
-	  fflush( NULL );
-
-	  /* actually suspend */
-	  kill( 0, SIGSTOP );
-
-	  resume();
-	} else if ( (the_byte == escape_pass_key) || (the_byte == escape_pass_key2) ) {
-	  /* Emulation sequence to type escape_key is escape_key +
-	     escape_pass_key (that is escape key without Ctrl) */
-	  net.get_current_state().push_back( Parser::UserByte( escape_key ) );
-	} else {
-	  /* Escape key followed by anything other than . and ^ gets sent literally */
-	  net.get_current_state().push_back( Parser::UserByte( escape_key ) );
-	  net.get_current_state().push_back( Parser::UserByte( the_byte ) );
+	if ( tcsetattr( STDIN_FILENO, TCSANOW, &saved_termios ) < 0 ) {
+	  perror( "tcsetattr" );
+	  exit( 1 );
 	}
 
-	quit_sequence_started = false;
+	fputs( "\n\033[37;44m[mosh is suspended.]\033[m\n", stdout );
 
-	if ( overlays.get_notification_engine().get_notification_string() == escape_key_help ) {
-	  overlays.get_notification_engine().set_notification_string( L"" );
-	}
+	fflush( NULL );
 
-	continue;
+	/* actually suspend */
+	kill( 0, SIGSTOP );
+
+	resume();
+      } else if ( (the_byte == escape_pass_key) || (the_byte == escape_pass_key2) ) {
+	/* Emulation sequence to type escape_key is escape_key +
+	   escape_pass_key (that is escape key without Ctrl) */
+	net.get_current_state().push_back( Parser::UserByte( escape_key ) );
+      } else {
+	/* Escape key followed by anything other than . and ^ gets sent literally */
+	net.get_current_state().push_back( Parser::UserByte( escape_key ) );
+	net.get_current_state().push_back( Parser::UserByte( the_byte ) );	  
       }
 
-      quit_sequence_started = (escape_key > 0) && (the_byte == escape_key) && (lf_entered || (! escape_requires_lf));
-      if ( quit_sequence_started ) {
-	lf_entered = false;
-	overlays.get_notification_engine().set_notification_string( escape_key_help, true, false );
-	continue;
+      quit_sequence_started = false;
+
+      if ( overlays.get_notification_engine().get_notification_string() == escape_key_help ) {
+	overlays.get_notification_engine().set_notification_string( L"" );
       }
 
-      lf_entered = ( (the_byte == 0x0A) || (the_byte == 0x0D) ); /* LineFeed, Ctrl-J, '\n' or CarriageReturn, Ctrl-M, '\r' */
-
-      if ( the_byte == 0x0C ) { /* Ctrl-L */
-	repaint_requested = true;
-      }
-
-      net.get_current_state().push_back( Parser::UserByte( the_byte ) );
+      continue;
     }
+
+    quit_sequence_started = (escape_key > 0) && (the_byte == escape_key) && (lf_entered || (! escape_requires_lf));
+    if ( quit_sequence_started ) {
+      lf_entered = false;
+      overlays.get_notification_engine().set_notification_string( escape_key_help, true, false );
+      continue;
+    }
+
+    lf_entered = ( (the_byte == 0x0A) || (the_byte == 0x0D) ); /* LineFeed, Ctrl-J, '\n' or CarriageReturn, Ctrl-M, '\r' */
+
+    if ( the_byte == 0x0C ) { /* Ctrl-L */
+      repaint_requested = true;
+    }
+
+    net.get_current_state().push_back( Parser::UserByte( the_byte ) );		
   }
 
   return true;

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -85,7 +85,7 @@ void STMClient::init( void )
     string native_charset( locale_charset() );
 
     fprintf( stderr, "mosh-client needs a UTF-8 native locale to run.\n\n"
-    "Unfortunately, the client's environment (%s) specifies\n"
+	     "Unfortunately, the client's environment (%s) specifies\n"
 	     "the character set \"%s\".\n\n",
 	     native_ctype.str().c_str(), native_charset.c_str() );
     int unused __attribute((unused)) = system( "locale" );
@@ -213,10 +213,10 @@ void STMClient::shutdown( void )
   }
 
   if ( still_connecting() ) {
-    fprintf( stderr, "\nmosh did not make a successful connection to %s:%s.\n", ip.c_str(), port.c_str() );
-    fprintf( stderr, "Please verify that UDP port %s is not firewalled and can reach the server.\n\n", port.c_str() );
-    fputs( "(By default, mosh uses a UDP port between 60000 and 61000. The -p option\n"
-	   "selects a specific UDP port number.)\n", stderr );
+    fprintf( stderr, "\nmosh did not make a successful connection to %s:%s.\n"
+	     "Please verify that UDP port %s is not firewalled and can reach the server.\n\n"
+	     "(By default, mosh uses a UDP port between 60000 and 61000. The -p option\n"
+	     "selects a specific UDP port number.)\n", ip.c_str(), port.c_str(), port.c_str() );
   } else if ( network ) {
     if ( !clean_shutdown ) {
       fputs( "\n\nmosh did not shut down cleanly. Please note that the\n"

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -552,11 +552,10 @@ void PredictionEngine::cull( const Framebuffer &fb )
 	}
 
 	/* When predictions come in quickly, slowly take away the glitch trigger. */
-	if ( (now - j->prediction_time) < GLITCH_THRESHOLD ) {
-	  if ( (glitch_trigger > 0) && (now - GLITCH_REPAIR_MININTERVAL >= last_quick_confirmation) ) {
-	    glitch_trigger--;
-	    last_quick_confirmation = now;
-	  }
+	if ( now - j->prediction_time < GLITCH_THRESHOLD 
+	     && ( glitch_trigger > 0 && now - GLITCH_REPAIR_MININTERVAL >= last_quick_confirmation ) ) {
+	  glitch_trigger--;
+	  last_quick_confirmation = now;
 	}
 
 	/* match rest of row to the actual renditions */
@@ -594,24 +593,23 @@ void PredictionEngine::cull( const Framebuffer &fb )
   }
 
   /* go through cursor predictions */
-  if ( !cursors.empty() ) {
-    if ( cursor().get_validity( fb,
+  if ( !cursors.empty() 
+       && cursor().get_validity( fb,
 				local_frame_acked, local_frame_late_acked ) == IncorrectOrExpired ) {
-      /*
+    /*
       fprintf( stderr, "Sadly, we're predicting (%d,%d) vs. (%d,%d) [tau: %ld, expiration_time=%ld, now=%ld]\n",
-	       cursor().row, cursor().col,
-	       fb.ds.get_cursor_row(),
-	       fb.ds.get_cursor_col(),
-	       cursor().tentative_until_epoch,
-	       cursor().expiration_time,
-	       now );
-      */
-      if ( display_preference == Experimental ) {
-	cursors.clear();
-      } else {
-	reset();
-	return;
-      }
+      cursor().row, cursor().col,
+      fb.ds.get_cursor_row(),
+      fb.ds.get_cursor_col(),
+      cursor().tentative_until_epoch,
+      cursor().expiration_time,
+      now );
+    */
+    if ( display_preference == Experimental ) {
+      cursors.clear();
+    } else {
+      reset();
+      return;
     }
   }
 
@@ -635,17 +633,16 @@ ConditionalOverlayRow & PredictionEngine::get_or_make_row( int row_num, int num_
 
   if ( it != overlays.end() ) {
     return *it;
-  } else {
-    /* make row */
-    ConditionalOverlayRow r( row_num );
-    r.overlay_cells.reserve( num_cols );
-    for ( int i = 0; i < num_cols; i++ ) {
-      r.overlay_cells.push_back( ConditionalOverlayCell( 0, i, prediction_epoch ) );
-      assert( r.overlay_cells[ i ].col == i );
-    }
-    overlays.push_back( r );
-    return overlays.back();
   }
+  /* make row */
+  ConditionalOverlayRow r( row_num );
+  r.overlay_cells.reserve( num_cols );
+  for ( int i = 0; i < num_cols; i++ ) {
+    r.overlay_cells.push_back( ConditionalOverlayCell( 0, i, prediction_epoch ) );
+    assert( r.overlay_cells[ i ].col == i );
+  }
+  overlays.push_back( r );
+  return overlays.back();
 }
 
 void PredictionEngine::new_user_byte( char the_byte, const Framebuffer &fb )

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -90,32 +90,30 @@ Validity ConditionalOverlayCell::get_validity( const Framebuffer &fb, int row,
   const Cell &current = *( fb.get_cell( row, col ) );
 
   /* see if it hasn't been updated yet */
-  if ( late_ack >= expiration_frame ) {
-    if ( unknown ) {
-      return CorrectNoCredit;
-    }
-
-    if ( replacement.is_blank() ) { /* too easy for this to trigger falsely */
-      return CorrectNoCredit;
-    }
-
-    if ( current.contents_match( replacement ) ) {
-      vector<Cell>::const_iterator it = original_contents.begin();
-      for ( ; it != original_contents.end(); it++ ) {
-        if ( it->contents_match( replacement ) )
-          break;
-      }
-      if ( it == original_contents.end() ) {
-	return Correct;
-      } else {
-	return CorrectNoCredit;
-      }
-    } else {
-      return IncorrectOrExpired;
-    }
+  if ( late_ack < expiration_frame ) {
+    return Pending;
   }
 
-  return Pending;
+  if ( unknown ) {
+    return CorrectNoCredit;
+  }
+
+  if ( replacement.is_blank() ) { /* too easy for this to trigger falsely */
+    return CorrectNoCredit;
+  }
+
+  if ( current.contents_match( replacement ) ) {
+    vector<Cell>::const_iterator it = original_contents.begin();
+    for ( ; it != original_contents.end(); it++ ) {
+      if ( it->contents_match( replacement ) )
+	break;
+    }
+    if ( it == original_contents.end() ) {
+      return Correct;
+    }
+    return CorrectNoCredit;
+  }
+  return IncorrectOrExpired;
 }
 
 Validity ConditionalCursorMove::get_validity( const Framebuffer &fb,

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -137,9 +137,8 @@ Validity ConditionalCursorMove::get_validity( const Framebuffer &fb,
     if ( (fb.ds.get_cursor_col() == col)
 	 && (fb.ds.get_cursor_row() == row) ) {
       return Correct;
-    } else {
-      return IncorrectOrExpired;
     }
+    return IncorrectOrExpired;
   }
 
   return Pending;

--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -173,11 +173,9 @@ Connection::Socket::Socket( int family )
   /* request explicit congestion notification on received datagrams */
 #ifdef HAVE_IP_RECVTOS
   int tosflag = true;
-  if ( setsockopt( _fd, IPPROTO_IP, IP_RECVTOS, &tosflag, sizeof tosflag ) < 0 ) {
-    /* FreeBSD disallows this option on IPv6 sockets. */
-    if ( family == IPPROTO_IP ) {
-      perror( "setsockopt( IP_RECVTOS )" );
-    }
+  if ( setsockopt( _fd, IPPROTO_IP, IP_RECVTOS, &tosflag, sizeof tosflag ) < 0
+       && family == IPPROTO_IP ) { /* FreeBSD disallows this option on IPv6 sockets. */
+    perror( "setsockopt( IP_RECVTOS )" );
   }
 #endif
 }

--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -504,12 +504,12 @@ string Connection::recv_one( int sock_to_recv, bool nonblocking )
 
   struct cmsghdr *ecn_hdr = CMSG_FIRSTHDR( &header );
   if ( ecn_hdr
-       && (ecn_hdr->cmsg_level == IPPROTO_IP)
-       && ((ecn_hdr->cmsg_type == IP_TOS)
+       && ecn_hdr->cmsg_level == IPPROTO_IP
+       && ( ecn_hdr->cmsg_type == IP_TOS
 #ifdef IP_RECVTOS
-	   || (ecn_hdr->cmsg_type == IP_RECVTOS)
+	    || ecn_hdr->cmsg_type == IP_RECVTOS
 #endif
-	   )) {
+	    ) ) {
     /* got one */
     uint8_t *ecn_octet_p = (uint8_t *)CMSG_DATA( ecn_hdr );
     assert( ecn_octet_p );

--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -514,9 +514,7 @@ string Connection::recv_one( int sock_to_recv, bool nonblocking )
     uint8_t *ecn_octet_p = (uint8_t *)CMSG_DATA( ecn_hdr );
     assert( ecn_octet_p );
 
-    if ( (*ecn_octet_p & 0x03) == 0x03 ) {
-      congestion_experienced = true;
-    }
+    congestion_experienced = (*ecn_octet_p & 0x03) == 0x03;
   }
 
   Packet p( session.decrypt( msg_payload, received_len ) );

--- a/src/network/transportfragment.cc
+++ b/src/network/transportfragment.cc
@@ -124,7 +124,7 @@ bool FragmentAssembly::add_fragment( Fragment &frag )
   }
 
   /* see if we're done */
-  return ( fragments_arrived == fragments_total );
+  return fragments_arrived == fragments_total;
 }
 
 Instruction FragmentAssembly::get_assembly( void )

--- a/src/statesync/completeterminal.cc
+++ b/src/statesync/completeterminal.cc
@@ -173,9 +173,8 @@ int Complete::wait_time( uint64_t now ) const
   uint64_t next_echo_ack_time = it->second + ECHO_TIMEOUT;
   if ( next_echo_ack_time <= now ) {
     return 0;
-  } else {
-    return next_echo_ack_time - now;
   }
+  return next_echo_ack_time - now;
 }
 
 bool Complete::compare( const Complete &other ) const

--- a/src/terminal/parserstate.cc
+++ b/src/terminal/parserstate.cc
@@ -79,15 +79,15 @@ Transition State::input( wchar_t ch ) const
 
 static bool C0_prime( wchar_t ch )
 {
-  return ( (ch <= 0x17)
-	   || (ch == 0x19)
-	   || ( (0x1C <= ch) && (ch <= 0x1F) ) );
+  return (ch <= 0x17)
+    || (ch == 0x19)
+    || ( (0x1C <= ch) && (ch <= 0x1F) );
 }
 
 static bool GLGR ( wchar_t ch )
 {
-  return ( ( (0x20 <= ch) && (ch <= 0x7F) ) /* GL area */
-	   || ( (0xA0 <= ch) && (ch <= 0xFF) ) ); /* GR area */
+  return ( (0x20 <= ch) && (ch <= 0x7F) ) /* GL area */
+    || ( (0xA0 <= ch) && (ch <= 0xFF) ); /* GR area */
 }
 
 Transition Ground::input_state_rule( wchar_t ch ) const

--- a/src/terminal/terminal.cc
+++ b/src/terminal/terminal.cc
@@ -179,5 +179,5 @@ void Emulator::resize( size_t s_width, size_t s_height )
 bool Emulator::operator==( Emulator const &x ) const
 {
   /* dispatcher and user are irrelevant for us */
-  return ( fb == x.fb );
+  return fb == x.fb;
 }

--- a/src/terminal/terminal.cc
+++ b/src/terminal/terminal.cc
@@ -109,10 +109,9 @@ void Emulator::print( const Parser::Print *act )
     this_cell->set_wide( chwidth == 2 ); /* chwidth had better be 1 or 2 here */
     fb.apply_renditions_to_cell( this_cell );
 
-    if ( chwidth == 2 ) { /* erase overlapped cell */
-      if ( fb.ds.get_cursor_col() + 1 < fb.ds.get_width() ) {
-	fb.reset_cell( fb.get_mutable_cell( fb.ds.get_cursor_row(), fb.ds.get_cursor_col() + 1 ) );
-      }
+    if ( chwidth == 2
+      && fb.ds.get_cursor_col() + 1 < fb.ds.get_width() ) { /* erase overlapped cell */
+      fb.reset_cell( fb.get_mutable_cell( fb.ds.get_cursor_row(), fb.ds.get_cursor_col() + 1 ) );
     }
 
     fb.ds.move_col( chwidth, true, true );

--- a/src/terminal/terminaldispatcher.cc
+++ b/src/terminal/terminaldispatcher.cc
@@ -226,12 +226,11 @@ void Dispatcher::dispatch( Function_Type type, const Parser::Action *act, Frameb
     /* unknown function */
     fb->ds.next_print_will_wrap = false;
     return;
-  } else {
-    if ( i->second.clears_wrap_state ) {
-      fb->ds.next_print_will_wrap = false;
-    }
-    return i->second.function( fb, this );
   }
+  if ( i->second.clears_wrap_state ) {
+    fb->ds.next_print_will_wrap = false;
+  }
+  i->second.function( fb, this );
 }
 
 void Dispatcher::OSC_put( const Parser::OSC_Put *act )

--- a/src/terminal/terminaldispatcher.cc
+++ b/src/terminal/terminaldispatcher.cc
@@ -248,6 +248,10 @@ void Dispatcher::OSC_start( const Parser::OSC_Start *act __attribute((unused)) )
 
 bool Dispatcher::operator==( const Dispatcher &x ) const
 {
-  return ( params == x.params ) && ( parsed_params == x.parsed_params ) && ( parsed == x.parsed )
-    && ( dispatch_chars == x.dispatch_chars ) && ( OSC_string == x.OSC_string ) && ( terminal_to_host == x.terminal_to_host );
+  return ( params == x.params )
+    && ( parsed_params == x.parsed_params )
+    && ( parsed == x.parsed )
+    && ( dispatch_chars == x.dispatch_chars )
+    && ( OSC_string == x.OSC_string )
+    && ( terminal_to_host == x.terminal_to_host );
 }

--- a/src/terminal/terminaldisplay.cc
+++ b/src/terminal/terminaldisplay.cc
@@ -181,29 +181,30 @@ std::string Display::new_frame( bool initialized, const Framebuffer &last, const
     for ( int row = 0; row < f.ds.get_height(); row++ ) {
       const Row *new_row = f.get_row( 0 );
       const Row *old_row = &*rows.at( row );
-      if ( new_row == old_row || *new_row == *old_row ) {
-	/* if row 0, we're looking at ourselves and probably didn't scroll */
-	if ( row == 0 ) {
-	  break;
-	}
-	/* found a scroll */
-	lines_scrolled = row;
-	scroll_height = 1;
-
-	/* how big is the region that was scrolled? */
-	for ( int region_height = 1;
-	      lines_scrolled + region_height < f.ds.get_height();
-	      region_height++ ) {
-	  if ( *f.get_row( region_height )
-	       == *rows.at( lines_scrolled + region_height ) ) {
-	    scroll_height = region_height + 1;
-	  } else {
-	    break;
-	  }
-	}
-
+      if ( ! ( new_row == old_row || *new_row == *old_row ) ) {
+	continue;
+      }
+      /* if row 0, we're looking at ourselves and probably didn't scroll */
+      if ( row == 0 ) {
 	break;
       }
+      /* found a scroll */
+      lines_scrolled = row;
+      scroll_height = 1;
+
+      /* how big is the region that was scrolled? */
+      for ( int region_height = 1;
+	    lines_scrolled + region_height < f.ds.get_height();
+	    region_height++ ) {
+	if ( *f.get_row( region_height )
+	     == *rows.at( lines_scrolled + region_height ) ) {
+	  scroll_height = region_height + 1;
+	} else {
+	  break;
+	}
+      }
+
+      break;
     }
 
     if ( scroll_height ) {
@@ -458,23 +459,23 @@ bool Display::put_row( bool initialized, FrameState &frame, const Framebuffer &f
     }
   }
 
-  if ( wrote_last_cell
-       && (frame_y < f.ds.get_height() - 1) ) {
-    /* To hint that a word-select should group the end of one line
-       with the beginning of the next, we let the real cursor
-       actually wrap around in cases where it wrapped around for us. */
-    if ( wrap_this ) {
-      /* Update our cursor, and ask for wrap on the next row. */
-      frame.cursor_x = 0;
-      frame.cursor_y++;
-      return true;
-    } else {
-      /* Resort to CR/LF and update our cursor. */
-      frame.append( "\r\n" );
-      frame.cursor_x = 0;
-      frame.cursor_y++;
-    }
+  if ( ! ( wrote_last_cell
+	   && (frame_y < f.ds.get_height() - 1) ) ) {
+    return false;
   }
+  /* To hint that a word-select should group the end of one line
+     with the beginning of the next, we let the real cursor
+     actually wrap around in cases where it wrapped around for us. */
+  if ( wrap_this ) {
+    /* Update our cursor, and ask for wrap on the next row. */
+    frame.cursor_x = 0;
+    frame.cursor_y++;
+    return true;
+  }
+  /* Resort to CR/LF and update our cursor. */
+  frame.append( "\r\n" );
+  frame.cursor_x = 0;
+  frame.cursor_y++;
   return false;
 }
 

--- a/src/terminal/terminaldisplay.cc
+++ b/src/terminal/terminaldisplay.cc
@@ -227,7 +227,8 @@ std::string Display::new_frame( bool initialized, const Framebuffer &last, const
 	/* Common case:  if we're already on the bottom line and we're scrolling the whole
 	 * screen, just do a CR and LFs.
 	 */
-	if ( (scroll_height + lines_scrolled == f.ds.get_height() ) && frame.cursor_y + 1 == f.ds.get_height() ) {
+	if ( scroll_height + lines_scrolled == f.ds.get_height()
+	     && frame.cursor_y + 1 == f.ds.get_height() ) {
 	  frame.append( '\r' );
 	  frame.append( lines_scrolled, '\n' );
 	  frame.cursor_x = 0;

--- a/src/terminal/terminaldisplay.h
+++ b/src/terminal/terminaldisplay.h
@@ -63,10 +63,6 @@ namespace Terminal {
 
   class Display {
   private:
-    static bool ti_flag( const char *capname );
-    static int ti_num( const char *capname );
-    static const char *ti_str( const char *capname );
-
     bool has_ech; /* erase character is part of vt200 but not supported by tmux
 		     (or by "screen" terminfo entry, which is what tmux advertises) */
 

--- a/src/terminal/terminaldisplayinit.cc
+++ b/src/terminal/terminaldisplayinit.cc
@@ -62,7 +62,7 @@
 
 using namespace Terminal;
 
-bool Display::ti_flag( const char *capname )
+static bool ti_flag( const char *capname )
 {
   int val = tigetflag( const_cast<char *>( capname ) );
   if ( val == -1 ) {
@@ -71,16 +71,7 @@ bool Display::ti_flag( const char *capname )
   return val;
 }
 
-int Display::ti_num( const char *capname )
-{
-  int val = tigetnum( const_cast<char *>( capname ) );
-  if ( val == -2 ) {
-    throw std::invalid_argument( std::string( "Invalid terminfo numeric capability " ) + capname );
-  }
-  return val;
-}
-
-const char *Display::ti_str( const char *capname )
+static const char *ti_str( const char *capname )
 {
   const char *val = tigetstr( const_cast<char *>( capname ) );
   if ( val == (const char *)-1 ) {

--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -512,6 +512,7 @@ void Renditions::set_rendition( color_type num )
   case 5: case 25: set_attribute(blink, value); break;
   case 7: case 27: set_attribute(inverse, value); break;
   case 8: case 28: set_attribute(invisible, value); break;
+  default: assert(false);
   }
 }
 

--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -313,21 +313,21 @@ void Framebuffer::insert_line( int before_row, int count )
     return;
   }
 
-  int max_scroll = ds.get_scrolling_region_bottom_row() + 1 - before_row;
-  if ( count > max_scroll ) {
-    count = max_scroll;
+  int scroll = ds.get_scrolling_region_bottom_row() + 1 - before_row;
+  if ( count < scroll ) {
+    scroll = count;
   }
 
-  if ( count == 0 ) {
+  if ( scroll == 0 ) {
     return;
   }
 
   // delete old rows
-  rows_type::iterator start = rows.begin() + ds.get_scrolling_region_bottom_row() + 1 - count;
-  rows.erase( start, start + count );
+  rows_type::iterator start = rows.begin() + ds.get_scrolling_region_bottom_row() + 1 - scroll;
+  rows.erase( start, start + scroll );
   // insert new rows
   start = rows.begin() + before_row;
-  rows.insert( start, count, newrow());
+  rows.insert( start, scroll, newrow());
 }
 
 void Framebuffer::delete_line( int row, int count )
@@ -337,21 +337,21 @@ void Framebuffer::delete_line( int row, int count )
     return;
   }
 
-  int max_scroll = ds.get_scrolling_region_bottom_row() + 1 - row;
-  if ( count > max_scroll ) {
-    count = max_scroll;
+  int scroll = ds.get_scrolling_region_bottom_row() + 1 - row;
+  if ( count < scroll ) {
+    scroll = count;
   }
 
-  if ( count == 0 ) {
+  if ( scroll == 0 ) {
     return;
   }
 
   // delete old rows
   rows_type::iterator start = rows.begin() + row;
-  rows.erase( start, start + count );
+  rows.erase( start, start + scroll );
   // insert a block of dummy rows
-  start = rows.begin() + ds.get_scrolling_region_bottom_row() + 1 - count;
-  rows.insert( start, count, newrow());
+  start = rows.begin() + ds.get_scrolling_region_bottom_row() + 1 - scroll;
+  rows.insert( start, scroll, newrow());
 }
 
 Row::Row( const size_t s_width, const color_type background_color )

--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -229,14 +229,13 @@ int DrawState::get_next_tab( int count ) const
       }
     }
     return -1;
-  } else {
-    for ( int i = cursor_col - 1; i > 0; i-- ) {
-      if ( tabs[ i ] && ++count == 0 ) {
-	return i;
-      }
-    }
-    return 0;
   }
+  for ( int i = cursor_col - 1; i > 0; i-- ) {
+    if ( tabs[ i ] && ++count == 0 ) {
+      return i;
+    }
+  }
+  return 0;
 }
 
 void DrawState::set_scrolling_region( int top, int bottom )
@@ -597,23 +596,22 @@ std::string Cell::debug_contents( void ) const
 {
   if ( contents.empty() ) {
     return "'_' ()";
-  } else {
-    std::string chars( 1, '\'' );
-    print_grapheme( chars );
-    chars.append( "' [" );
-    const char *lazycomma = "";
-    char buf[64];
-    for ( content_type::const_iterator i = contents.begin();
-	  i < contents.end();
-	  i++ ) {
-
-      snprintf( buf, sizeof buf, "%s0x%02x", lazycomma, static_cast<uint8_t>(*i) );
-      chars.append( buf );
-      lazycomma = ", ";
-    }
-    chars.append( "]" );
-    return chars;
   }
+  std::string chars( 1, '\'' );
+  print_grapheme( chars );
+  chars.append( "' [" );
+  const char *lazycomma = "";
+  char buf[64];
+  for ( content_type::const_iterator i = contents.begin();
+	i < contents.end();
+	i++ ) {
+
+    snprintf( buf, sizeof buf, "%s0x%02x", lazycomma, static_cast<uint8_t>(*i) );
+    chars.append( buf );
+    lazycomma = ", ";
+  }
+  chars.append( "]" );
+  return chars;
 }
 
 bool Cell::compare( const Cell &other ) const

--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -584,8 +584,8 @@ void Dispatcher::OSC_dispatch( const Parser::OSC_End *act __attribute((unused)),
       cmd_num = OSC_string[ 0 ] - L'0';
       offset = 2;
     }
-    bool set_icon = (cmd_num == 0 || cmd_num == 1);
-    bool set_title = (cmd_num == 0 || cmd_num == 2);
+    bool set_icon = cmd_num == 0 || cmd_num == 1;
+    bool set_title = cmd_num == 0 || cmd_num == 2;
     if ( set_icon || set_title ) {
       fb->set_title_initialized();
       int title_length = min(OSC_string.size(), (size_t)256);

--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -64,6 +64,8 @@ static void CSI_EL( Framebuffer *fb, Dispatcher *dispatch )
   case 2: /* all of line */
     fb->reset_row( fb->get_mutable_row( -1 ) );
     break;
+  default:
+    break;
   }
 }
 
@@ -88,6 +90,8 @@ static void CSI_ED( Framebuffer *fb, Dispatcher *dispatch ) {
     for ( int y = 0; y < fb->ds.get_height(); y++ ) {
       fb->reset_row( fb->get_mutable_row( y ) );
     }
+    break;
+  default:
     break;
   }
 }
@@ -114,10 +118,11 @@ static void CSI_cursormove( Framebuffer *fb, Dispatcher *dispatch )
     break;
   case 'H':
   case 'f':
-    int x = dispatch->getparam( 0, 1 );
-    int y = dispatch->getparam( 1, 1 );
-    fb->ds.move_row( x - 1 );
-    fb->ds.move_col( y - 1 );
+    fb->ds.move_row( dispatch->getparam( 0, 1 ) - 1 );
+    fb->ds.move_col( dispatch->getparam( 1, 1 ) - 1 );
+    break;
+  default:
+    break;
   }
 }
 
@@ -261,6 +266,8 @@ static void CSI_TBC( Framebuffer *fb, Dispatcher *dispatch )
       fb->ds.clear_tab( x );
     }
     break;
+  default:
+    break;
   }
 }
 
@@ -295,6 +302,8 @@ static bool *get_DEC_mode( int param, Framebuffer *fb ) {
     return &(fb->ds.mouse_alternate_scroll);
   case 2004: /* bracketed paste */
     return &(fb->ds.bracketed_paste);
+  default:
+    break;
   }
   return NULL;
 }
@@ -340,8 +349,7 @@ static Function func_CSI_DECSM( CSI, "?h", CSI_DECSM, false );
 static Function func_CSI_DECRM( CSI, "?l", CSI_DECRM, false );
 
 static bool *get_ANSI_mode( int param, Framebuffer *fb ) {
-  switch ( param ) {
-  case 4: /* insert/replace mode */
+  if ( param == 4 ) { /* insert/replace mode */
     return &(fb->ds.insert_mode);
   }
   return NULL;
@@ -451,6 +459,8 @@ static void CSI_DSR( Framebuffer *fb, Dispatcher *dispatch )
 	      fb->ds.get_cursor_row() + 1,
 	      fb->ds.get_cursor_col() + 1 );
     dispatch->terminal_to_host.append( cpr );
+    break;
+  default:
     break;
   }
 }

--- a/src/terminal/terminaluserinput.cc
+++ b/src/terminal/terminaluserinput.cc
@@ -52,17 +52,14 @@ string UserInput::input( const Parser::UserByte *act,
       state = ESC;
     }
     return string( &act->c, 1 );
-    break;
 
   case ESC:
     if ( act->c == 'O' ) { /* ESC O = 7-bit SS3 */
       state = SS3;
       return string();
-    } else {
-      state = Ground;
-      return string( &act->c, 1 );
     }
-    break;
+    state = Ground;
+    return string( &act->c, 1 );
 
   case SS3:
     state = Ground;
@@ -75,12 +72,11 @@ string UserInput::input( const Parser::UserByte *act,
       char original_cursor[ 2 ] = { 'O', act->c };
       return string( original_cursor, 2 );
     }
-    break;
+
+  default:
+    /* This doesn't handle the 8-bit SS3 C1 control, which would be
+       two octets in UTF-8. Fortunately nobody seems to send this. */
+    assert( false );
+    return string();
   }
-
-  /* This doesn't handle the 8-bit SS3 C1 control, which would be
-     two octets in UTF-8. Fortunately nobody seems to send this. */
-
-  assert( false );
-  return string();
 }

--- a/src/util/locale_utils.cc
+++ b/src/util/locale_utils.cc
@@ -51,9 +51,8 @@ const string LocaleVar::str( void ) const
 {
   if ( name.empty() ) {
     return string( "[no charset variables]" );
-  } else {
-    return name + "=" + value;
   }
+  return name + "=" + value;
 }
 
 const LocaleVar get_ctype( void )
@@ -65,9 +64,8 @@ const LocaleVar get_ctype( void )
     return LocaleVar( "LC_CTYPE", ctype );
   } else if ( const char *lang = getenv( "LANG" ) ) {
     return LocaleVar( "LANG", lang );
-  } else {
-    return LocaleVar( "", "" );
   }
+  return LocaleVar( "", "" );
 }
 
 const char *locale_charset( void )

--- a/src/util/swrite.cc
+++ b/src/util/swrite.cc
@@ -46,9 +46,8 @@ int swrite( int fd, const char *str, ssize_t len )
     if ( bytes_written <= 0 ) {
       perror( "write" );
       return -1;
-    } else {
-      total_bytes_written += bytes_written;
     }
+    total_bytes_written += bytes_written;
   }
 
   return 0;


### PR DESCRIPTION
OCLint is a Clang/LLVM based static analyzer.  It is usefully different from other static analyzers and has found worthwhile things.
* The biggest issue it shows is the excess length and complexity of many methods.  It discovered 600,000,000 different execution paths through `Terminal::Framebuffer::new_frame()`, and rightly carps regularly about function length, cyclomatic complexity, and number of paths.  Nothing done to fix this...
* It also identified many smaller simplifications that could be done to the code base, some of which are quite worthwhile.  I think the best thing it identified was large conditionals in contexts that could be escaped, such as
```c++
if (foo) {
  // large block
}
return;
```
into
```c++
if (!foo) {
  return;
}
// large block
```
and there's some other good simplifications.

This has received a week of heavy use on a trip and seems to be in good shape.