### PR TITLE
Copy/paste fix

### DIFF
--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -280,7 +280,7 @@ void NotificationEngine::apply( Framebuffer &fb ) const
       this_cell->get_renditions().background_color = 44;
       
       this_cell->append( ch );
-      this_cell->set_width( chwidth );
+      this_cell->set_wide( chwidth == 2 );
       combining_cell = this_cell;
 
       overlay_col += chwidth;
@@ -291,7 +291,7 @@ void NotificationEngine::apply( Framebuffer &fb ) const
       }
 
       if ( combining_cell->empty() ) {
-	assert( combining_cell->get_width() == 1 );
+	assert( !combining_cell->get_wide() );
 	combining_cell->set_fallback( true );
 	overlay_col++;
       }

--- a/src/terminal/terminal.cc
+++ b/src/terminal/terminal.cc
@@ -106,7 +106,7 @@ void Emulator::print( const Parser::Print *act )
 
     fb.reset_cell( this_cell );
     this_cell->append( ch );
-    this_cell->set_width( chwidth );
+    this_cell->set_wide( chwidth == 2 ); /* chwidth had better be 1 or 2 here */
     fb.apply_renditions_to_cell( this_cell );
 
     if ( chwidth == 2 ) { /* erase overlapped cell */
@@ -131,7 +131,7 @@ void Emulator::print( const Parser::Print *act )
 	   base character [e.g. start of line], if the
 	   combining character has been cleared with
 	   a sequence like ED ("J") or EL ("K") */
-	assert( combining_cell->get_width() == 1 );
+	assert( !combining_cell->get_wide() );
 	combining_cell->set_fallback( true );
 	fb.ds.move_col( 1, true, true );
       }

--- a/src/terminal/terminaldisplay.cc
+++ b/src/terminal/terminaldisplay.cc
@@ -348,12 +348,14 @@ bool Display::put_row( bool initialized, FrameState &frame, const Framebuffer &f
     return false;
   }
 
+  const bool wrap_this = row.get_wrap();
+  const int row_width = f.ds.get_width();
   int clear_count = 0;
   bool wrote_last_cell = false;
   Renditions blank_renditions = initial_rendition();
 
   /* iterate for every cell */
-  while ( frame_x < f.ds.get_width() ) {
+  while ( frame_x < row_width ) {
 
     const Cell &cell = cells.at( frame_x );
 
@@ -405,12 +407,23 @@ bool Display::put_row( bool initialized, FrameState &frame, const Framebuffer &f
 
     /* Now draw a character cell. */
     /* Move to the right position. */
+    const int cell_width = cell.get_width();
+    /* If we are about to print the last character in a wrapping row,
+       trash the cursor position to force explicit positioning.  We do
+       this because our input terminal state may have the cursor on
+       the autowrap column ("column 81"), but our output terminal
+       states always snap the cursor to the true last column ("column
+       80"), and we want to be able to apply the diff to either, for
+       verification. */
+    if ( wrap_this && frame_x + cell_width >= row_width ) {
+      frame.cursor_x = frame.cursor_y = -1;
+    }
     frame.append_silent_move( frame_y, frame_x );
     frame.update_rendition( cell.get_renditions() );
     frame.append_cell( cell );
-    frame_x += cell.get_width();
-    frame.cursor_x += cell.get_width();
-    if ( frame_x >= f.ds.get_width() ) {
+    frame_x += cell_width;
+    frame.cursor_x += cell_width;
+    if ( frame_x >= row_width ) {
       wrote_last_cell = true;
     }
   }
@@ -423,7 +436,7 @@ bool Display::put_row( bool initialized, FrameState &frame, const Framebuffer &f
     frame.append_silent_move( frame_y, frame_x - clear_count );
     frame.update_rendition( blank_renditions );
 
-    bool can_use_erase = !row.get_wrap() && ( has_bce || ( frame.current_rendition == initial_rendition() ) );
+    bool can_use_erase = !wrap_this && ( has_bce || ( frame.current_rendition == initial_rendition() ) );
     if ( can_use_erase ) {
       frame.append( "\033[K" );
     } else {
@@ -438,7 +451,7 @@ bool Display::put_row( bool initialized, FrameState &frame, const Framebuffer &f
     /* To hint that a word-select should group the end of one line
        with the beginning of the next, we let the real cursor
        actually wrap around in cases where it wrapped around for us. */
-    if ( row.get_wrap() ) {
+    if ( wrap_this ) {
       /* Update our cursor, and ask for wrap on the next row. */
       frame.cursor_x = 0;
       frame.cursor_y++;

--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -41,14 +41,14 @@ using namespace Terminal;
 Cell::Cell( color_type background_color )
   : contents(),
     renditions( background_color ),
-    width( 1 ),
+    wide( false ),
     fallback( false ),
     wrap( false )
 {}
 Cell::Cell() /* default constructor required by C++11 STL */
   : contents(),
     renditions( 0 ),
-    width( 1 ),
+    wide( false ),
     fallback( false ),
     wrap( false )
 {
@@ -59,7 +59,7 @@ void Cell::reset( color_type background_color )
 {
   contents.clear();
   renditions = Renditions( background_color );
-  width = 1;
+  wide = false;
   fallback = false;
   wrap = false;
 }
@@ -642,10 +642,10 @@ bool Cell::compare( const Cell &other ) const
 	     fallback, other.fallback );
   }
 
-  if ( width != other.width ) {
+  if ( wide != other.wide ) {
     ret = true;
     fprintf( stderr, "width: %d vs. %d\n",
-	     width, other.width );
+	     wide, other.wide );
   }
 
   if ( !(renditions == other.renditions) ) {

--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -42,13 +42,15 @@ Cell::Cell( color_type background_color )
   : contents(),
     renditions( background_color ),
     width( 1 ),
-    fallback( false )
+    fallback( false ),
+    wrap( false )
 {}
 Cell::Cell() /* default constructor required by C++11 STL */
   : contents(),
     renditions( 0 ),
     width( 1 ),
-    fallback( false )
+    fallback( false ),
+    wrap( false )
 {
   assert( false );
 }
@@ -59,6 +61,7 @@ void Cell::reset( color_type background_color )
   renditions = Renditions( background_color );
   width = 1;
   fallback = false;
+  wrap = false;
 }
 
 void DrawState::reinitialize_tabs( unsigned int start )
@@ -350,11 +353,11 @@ void Framebuffer::delete_line( int row, int count )
 }
 
 Row::Row( const size_t s_width, const color_type background_color )
-  : cells( s_width, Cell( background_color ) ), wrap( false ), gen( get_gen() )
+  : cells( s_width, Cell( background_color ) ), gen( get_gen() )
 {}
 
 Row::Row() /* default constructor required by C++11 STL */
-  : cells( 1, Cell() ), wrap( false ), gen( get_gen() )
+  : cells( 1, Cell() ), gen( get_gen() )
 {
   assert( false );
 }
@@ -648,6 +651,12 @@ bool Cell::compare( const Cell &other ) const
   if ( !(renditions == other.renditions) ) {
     ret = true;
     fprintf( stderr, "renditions differ\n" );
+  }
+
+  if ( wrap != other.wrap ) {
+    ret = true;
+    fprintf( stderr, "wrap: %d vs. %d\n",
+	     wrap, other.wrap );
   }
 
   return ret;

--- a/src/terminal/terminalframebuffer.h
+++ b/src/terminal/terminalframebuffer.h
@@ -89,9 +89,9 @@ namespace Terminal {
     typedef std::string content_type; /* can be std::string, std::vector<uint8_t>, or __gnu_cxx::__vstring */
     content_type contents;
     Renditions renditions;
-    uint8_t width;
-    bool fallback; /* first character is combining character */
-    bool wrap;
+    unsigned int width : 2;
+    unsigned int fallback : 1; /* first character is combining character */
+    unsigned int wrap : 1;
 
   public:
     Cell( color_type background_color );

--- a/src/terminal/terminalframebuffer.h
+++ b/src/terminal/terminalframebuffer.h
@@ -91,6 +91,7 @@ namespace Terminal {
     Renditions renditions;
     uint8_t width;
     bool fallback; /* first character is combining character */
+    bool wrap;
 
   public:
     Cell( color_type background_color );
@@ -103,7 +104,8 @@ namespace Terminal {
       return ( (contents == x.contents)
 	       && (fallback == x.fallback)
 	       && (width == x.width)
-	       && (renditions == x.renditions) );
+	       && (renditions == x.renditions)
+	       && (wrap == x.wrap) );
     }
 
     bool operator!=( const Cell &x ) const { return !operator==( x ); }
@@ -192,13 +194,14 @@ namespace Terminal {
     void set_width( unsigned int w ) { width = w; }
     bool get_fallback( void ) const { return fallback; }
     void set_fallback( bool f ) { fallback = f; }
+    bool get_wrap( void ) const { return wrap; }
+    void set_wrap( bool f ) { wrap = f; }
   };
 
   class Row {
   public:
     typedef std::vector<Cell> cells_type;
     cells_type cells;
-    bool wrap; /* if last cell, wrap to next line */
     // gen is a generation counter.  It can be used to quickly rule
     // out the possibility of two rows being identical; this is useful
     // in scrolling.
@@ -214,11 +217,11 @@ namespace Terminal {
 
     bool operator==( const Row &x ) const
     {
-      return ( gen == x.gen && cells == x.cells && wrap == x.wrap );
+      return ( gen == x.gen && cells == x.cells );
     }
 
-    bool get_wrap( void ) const { return wrap; }
-    void set_wrap( bool w ) { wrap = w; }
+    bool get_wrap( void ) const { return cells.back().get_wrap(); }
+    void set_wrap( bool w ) { cells.back().set_wrap( w ); }
 
     uint64_t get_gen() const;
   };

--- a/src/terminal/terminalframebuffer.h
+++ b/src/terminal/terminalframebuffer.h
@@ -89,7 +89,7 @@ namespace Terminal {
     typedef std::string content_type; /* can be std::string, std::vector<uint8_t>, or __gnu_cxx::__vstring */
     content_type contents;
     Renditions renditions;
-    unsigned int width : 2;
+    unsigned int wide : 1; /* 0 = narrow, 1 = wide */
     unsigned int fallback : 1; /* first character is combining character */
     unsigned int wrap : 1;
 
@@ -103,7 +103,7 @@ namespace Terminal {
     {
       return ( (contents == x.contents)
 	       && (fallback == x.fallback)
-	       && (width == x.width)
+	       && (wide == x.wide)
 	       && (renditions == x.renditions)
 	       && (wrap == x.wrap) );
     }
@@ -190,8 +190,9 @@ namespace Terminal {
     const Renditions& get_renditions( void ) const { return renditions; }
     Renditions& get_renditions( void ) { return renditions; }
     void set_renditions( const Renditions& r ) { renditions = r; }
-    unsigned int get_width( void ) const { return width; }
-    void set_width( unsigned int w ) { width = w; }
+    bool get_wide( void ) const { return wide; }
+    void set_wide( bool w ) { wide = w; }
+    unsigned int get_width( void ) const { return wide + 1; }
     bool get_fallback( void ) const { return fallback; }
     void set_fallback( bool f ) { fallback = f; }
     bool get_wrap( void ) const { return wrap; }


### PR DESCRIPTION
Well, that took a while.

My earlier performance commits changed how the wrapped-line bit is stored, and that change caused Mosh to not clear the wrap bit when a long line was replaced by a short one on screen.  So I essentially reverted that change.  But that broke one of the regression tests in a subtle way.  Fixing that took even longer.

I believe this to be well and truly fixed, though I have not had a lot of interactive usage yet.  If you have this problem, please try this code.