### PR TITLE
Start ssh with -f instead of -n to avoid ssh hangs.

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -346,7 +346,7 @@ die "$0: fork: $!\n" unless ( defined $pid );
 if ( $pid == 0 ) { # child
   open(STDERR, ">&STDOUT") or die;
 
-  my @sshopts = ( '-n' );
+  my @sshopts = ( '-f' );
   if ($ssh_pty) {
       push @sshopts, '-tt';
   }


### PR DESCRIPTION
This seems to resolve #833.