### PR TITLE
Exponential backoff to prevent aggressive resends

### DIFF
--- a/src/network/transportsender-impl.h
+++ b/src/network/transportsender-impl.h
@@ -274,9 +274,8 @@ void TransportSender<MyState>::update_assumed_receiver_state( void )
 
   /* start from what is known and give benefit of the doubt to unacknowledged states
      transmitted recently enough ago */
-  assumed_receiver_state = sent_states.begin();
-
   typename list< TimestampedState<MyState> >::iterator i = sent_states.begin();
+  assumed_receiver_state = i;
   i++;
 
   while ( i != sent_states.end() ) {

--- a/src/network/transportsender-impl.h
+++ b/src/network/transportsender-impl.h
@@ -35,6 +35,7 @@
 
 #include <algorithm>
 #include <list>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -83,6 +84,30 @@ unsigned int TransportSender<MyState>::send_interval( void ) const
   return SEND_INTERVAL;
 }
 
+/* If we're not seeing acks for sent states, exponentially
+ * increase send interval since last unacked state.
+ */
+template <class MyState>
+uint64_t TransportSender<MyState>::backoff_send( uint64_t now ) const
+{
+  typename sent_states_type::const_iterator unreceived_state = sent_states.begin();
+  if ( ++unreceived_state != sent_states.end() &&
+       ++unreceived_state != sent_states.end() &&
+       now - unreceived_state->timestamp > 2 * connection->timeout() ) {
+    uint64_t rtt = connection->timeout();
+    uint64_t target = sent_states.back().timestamp * 2 - unreceived_state->timestamp;
+    if ( verbose > 1 ) {
+      fprintf( stderr, "%s: now %" PRIu64 ", next_send_time %" PRIu64
+	       ", rtt %" PRIu64 ", uts %" PRIu64 ", lts %" PRIu64
+	       ", target %" PRIu64 ", step %" PRIu64 "\n",
+	       __func__, now, next_send_time,
+	       rtt, unreceived_state->timestamp, sent_states.back().timestamp,
+	       target, target - now );
+    }
+    return target;
+  }
+  return 0;
+}
 /* Housekeeping routine to calculate next send and ack times */
 template <class MyState>
 void TransportSender<MyState>::calculate_timers( void )
@@ -100,24 +125,31 @@ void TransportSender<MyState>::calculate_timers( void )
   }
 
   if ( !(current_state == sent_states.back().state) ) {
+    /* New, unsent state */
     if ( mindelay_clock == uint64_t( -1 ) ) {
       mindelay_clock = now;
     }
 
     next_send_time = max( mindelay_clock + SEND_MINDELAY,
 			  sent_states.back().timestamp + send_interval() );
+    next_send_time = max( next_send_time, backoff_send( now ) );
   } else if ( !(current_state == assumed_receiver_state->state)
 	      && (last_heard + ACTIVE_RETRY_TIMEOUT > now) ) {
+    /* The receiver isn't up to date with our state */
     next_send_time = sent_states.back().timestamp + send_interval();
     if ( mindelay_clock != uint64_t( -1 ) ) {
       next_send_time = max( next_send_time, mindelay_clock + SEND_MINDELAY );
     }
+    next_send_time = max( next_send_time, backoff_send( now ) );
   } else if ( !(current_state == sent_states.front().state )
 	      && (last_heard + ACTIVE_RETRY_TIMEOUT > now) ) {
+    /* Receiver does not have our current state */
     next_send_time = sent_states.back().timestamp + connection->timeout() + ACK_DELAY;
   } else {
+    /* Nothing to send */
     next_send_time = uint64_t(-1);
   }
+
 
   /* speed up shutdown sequence */
   if ( shutdown_in_progress || (ack_num == uint64_t(-1)) ) {

--- a/src/network/transportsender.h
+++ b/src/network/transportsender.h
@@ -158,6 +158,7 @@ namespace Network {
     void set_send_delay( int new_delay ) { SEND_MINDELAY = new_delay; }
 
     unsigned int send_interval( void ) const;
+    uint64_t backoff_send( uint64_t now ) const;
 
     /* nonexistent methods to satisfy -Weffc++ */
     TransportSender( const TransportSender &x );

--- a/src/statesync/completeterminal.cc
+++ b/src/statesync/completeterminal.cc
@@ -136,7 +136,6 @@ static bool old_ack(uint64_t newest_echo_ack, const pair<uint64_t, uint64_t> p)
 
 bool Complete::set_echo_ack( uint64_t now )
 {
-  bool ret = false;
   uint64_t newest_echo_ack = 0;
 
   for ( input_history_type::const_iterator i = input_history.begin();
@@ -149,13 +148,13 @@ bool Complete::set_echo_ack( uint64_t now )
 
   input_history.remove_if( bind1st( ptr_fun( old_ack ), newest_echo_ack ) );
 
-  if ( echo_ack != newest_echo_ack ) {
-    ret = true;
+  if ( echo_ack == newest_echo_ack ) {
+    return false;
   }
 
   echo_ack = newest_echo_ack;
 
-  return ret;
+  return true;
 }
 
 void Complete::register_input_frame( uint64_t n, uint64_t now )

--- a/src/statesync/user.h
+++ b/src/statesync/user.h
@@ -89,7 +89,7 @@ namespace Network {
     /* interface for Network::Transport */
     void subtract( const UserStream *prefix );
     string diff_from( const UserStream &existing ) const;
-    string init_diff( void ) const { assert( false ); return string(); };
+    string init_diff( void ) const { return diff_from( UserStream() ); };
     void apply_string( const string &diff );
     bool operator==( const UserStream &x ) const { return actions == x.actions; }
 


### PR DESCRIPTION
If a client has one-way connectivity to a server such that it keeps requesting the same state from the server, the server may spam the client with updates on its interactivity-timeout interval of 40ms until 10s have gone by, at which point it reverts to a 3s interval.  With large terminal windows, this can cause excessive bandwidth usage.  If the link has limited bandwidth causing it to drop some packets from a large message, the flood of these packets can also prevent the client from receiving a new state successfully.  See #747 and #832.  I also think this issue might be responsible for some of the "VPN" issues that we have lumped under #299.

This implements a rather crude exponential backoff for resends, simply delaying the next send by the amount of time since the first unsuccessfully sent state.  The actual delays calculated are rather noisy and sometimes larger than they need to be.  The backoff is initiated after at least two messages have been sent to the remote and not acked; we need to work from the timestamp of the first unsuccessful send, not the timestamp of the last successful send (which may have been unusefully long ago), and one of the messages sent in this time may have been an ack-only message, which doesn't count.  This inherently adds a bit of conservatism to the backoff.  The backoff is limited by the existing calculations for `next_send_timer` and `next_ack_timer` which currently impose a ceiling of 3 seconds.

I was concerned about the impact of exponential backoff-- I thought that its much less frequent sends on lossy networks would result in laggier interactive behavior.  But in testing with Network Simulator on OS X with 50% packet loss and 1s+ latency, I don't see any change in behavior-- Mosh seems fine.

Comments and testing greatly appreciated.