### PR TITLE
Release 1.3.0 candidate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,17 +36,14 @@ before_install:
   # and is fairly quiet, so wrap it in travis_wait to keep it from
   # being killed.
   - |
-    (
-      set -e
-      if test osx = "${TRAVIS_OS_NAME}"; then
-        macosx/brew-deps.sh install
+    if test osx = "${TRAVIS_OS_NAME}"; then
+      macosx/brew-deps.sh install &&
         if test -n "${TRAVIS_TAG}"; then
           travis_wait 30 macosx/brew-deps.sh package_deps
         else
           macosx/brew-deps.sh deps
         fi
-      fi
-    )
+    fi
 
 # Use before_script to report the build configuration.
 before_script:
@@ -55,17 +52,15 @@ before_script:
   - env
   - git describe --long
   - |
-    (
-      set -e
-      if test osx = "${TRAVIS_OS_NAME}" && test -n "${TRAVIS_TAG}"; then
-        rm -rf macosx/build-report "macosx/${TRAVIS_TAG}-build-report.tbz"
-        mkdir macosx/build-report
-        cd macosx/build-report
-        ../brew-deps.sh describe
-        ../osx-xcode.sh describe
-        tar -cjf "../${TRAVIS_TAG}-build-report.tbz" .
-      fi
-    )
+    if test osx = "${TRAVIS_OS_NAME}" && test -n "${TRAVIS_TAG}"; then
+      rm -rf macosx/build-report "macosx/${TRAVIS_TAG}-build-report.tbz" &&
+        mkdir macosx/build-report &&
+        cd macosx/build-report &&
+        ../brew-deps.sh describe &&
+        ../osx-xcode.sh describe &&
+        tar -cjf "../${TRAVIS_TAG}-build-report.tbz" . &&
+        cd -
+    fi
 
 # 'make distcheck', and OS X package build on tag builds.
 script:
@@ -75,12 +70,10 @@ script:
   # Build OS X package for tags.
   - |
     if test osx = "${TRAVIS_OS_NAME}" && test -n "${TRAVIS_TAG}"; then
-      (
-        set -e
-        cd macosx
-        env ZERO_AR_DATE=1 MACOSX_DEPLOYMENT_TARGET=10.10 ./build.sh
-        shasum -a 256 "${TRAVIS_TAG}.pkg" "${TRAVIS_TAG}-build-report.tbz"
-      )
+      cd macosx &&
+        env ZERO_AR_DATE=1 MACOSX_DEPLOYMENT_TARGET=10.10 ./build.sh &&
+        shasum -a 256 "${TRAVIS_TAG}.pkg" "${TRAVIS_TAG}-build-report.tbz" &&
+        cd -
     fi
 # Deploy the OS X package and distribution tarball to a GitHub release.
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ language: cpp
 sudo: required
 dist: trusty
 
-# Currently we're using the Travis Xcode 7.1/OS X 10.10 image to
+# Currently we're using the Travis Xcode 6.4/OS X 10.10 image to
 # get i386/x86_64 fat binaries.
-osx_image: xcode7.1
+osx_image: xcode6.4
 
 # Linux dependencies
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script:
         shasum -a 256 "${TRAVIS_TAG}.pkg" "${TRAVIS_TAG}-build-report.tbz"
       )
     fi
-# Deploy the OS X package to a GitHub release.
+# Deploy the OS X package and distribution tarball to a GitHub release.
 deploy:
   provider: releases
   api_key:
@@ -91,6 +91,7 @@ deploy:
   skip_cleanup: true
   # Using a shell variable in deploy.file is undocumented but seems to work.
   file:
+    - ${TRAVIS_TAG}.tar.gz
     - macosx/${TRAVIS_TAG}.pkg
     - macosx/${TRAVIS_TAG}-build-report.tbz
   on:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,54 @@
+2016-11-28 Keith Winstein <mosh-devel@mit.edu>
+
+	* Version 1.3.0 released.
+
+	* New features:
+		* Change website URLs from http://mosh.mit.edu to
+		  https://mosh.org.  (Keith Winstein)
+		* Add --no-ssh-pty option for Dropbear compatibility and
+		  other issues.
+		* Switch to semantic versioning, making this version 1.3.0
+		  instead of 1.2.7.
+
+	* Platform support:
+		* Added nonce-incrementing test.  (Keith Winstein)
+		* Add build-source-package.sh for Debian.  (Keith Winstein)
+		* Fix CPPFLAGS handling possibly causing curses detection
+	failure.  (John Hood)
+		* Add an Appveyor/Cygwin CI build.
+		* Improve warning-flags detection for 'make distcheck'.  (John Hood)
+		* Improve robustness of regression tests.  (John Hood)
+		* Support OpenBSD pledge() sandboxing.  (John Hood)
+		* Use backward-compatible name for AES in
+		  AppleCommonCrypto, fixing builds with older OS X SDKs.  (John Hood)
+		* Detect clock_gettime() and CLOCK_MONOTONIC carefully,
+		  fixing OS X 10.12 + Xcode 7.3 builds.  (John Hood)
+		* Support older versions of Perl, back to 5.10, fixing
+		  RHEL 5 builds. (Anders Kaseorg)
+		* Add a Travis OS X CI and release build.  (John Hood)
+		* Add --help and --version, enabling Automake's
+		 'std-options' checks.  (Anders Kaseorg)
+		* Add a simple smoke test not requiring tmux, to help
+		  validate builds on older platforms including RHEL 5. (Anders Kaseorg)
+		* Other minor platform compatibility fixes for Mosh
+		  sources and tests.  (John Hood)
+
+	* Bug fixes:
+		* Work around a pty buffering issue causing failed
+		  connections on FreeBSD 11, or with Dropbear.  (John Hood)
+		* Restore '-p 0' option for OS-selected UDP port bindings.  (John Hood)
+		* Shell hygiene fixes, including better quoting of
+		  pathnames.  (Anders Kaseorg)
+		* Fix typos in project docs.  (Jakub Wilk)
+		* Fix excess newlines on mosh client startup/shutdown.  (John Hood)
+		* Exit gracefully, closing session, on pty write or ioctl failure.  (John Hood)
+		* Fix two bugs that caused mosh-server to consume
+		  excessive CPU in certain circumstances.  (John Hood)
+		* Fix bug that caused text copied from mosh-client to
+		  paste as long lines joined by spaces.  (John Hood)
+		* Documentation improvements. (chenxiaoqino, Ashish Gupta)
+		* Use getuid(), not geteuid(), for correct getpw* lookups.  (John Hood)
+
 2016-08-10 Keith Winstein <mosh-devel@mit.edu>
 
 	* Version 1.2.6 released.

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.61])
-AC_INIT([mosh], [1.2.6], [mosh-devel@mit.edu])
+AC_INIT([mosh], [1.3.0-rc0], [mosh-devel@mit.edu])
 AM_INIT_AUTOMAKE([foreign std-options -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_SRCDIR([src/frontend/mosh-client.cc])


### PR DESCRIPTION
This is my current plan for 1.3.0 release.

This will add some significant changes to Mosh's release process:

* Semantic versioning
* The Travis OS X build generates a distribution tarball and OS X package, and uploads them to Github.  It also generates copious logging-- it's not a fully reproducible build (both Travis and OS X make this quite challenging) but it is intended to make the build more repeatable and traceable.

Note, this is not 100% complete, `travis.yml` needs to be switched from `cgull/mosh` to `mobile-shell/mosh`, and the `mobile-shell/mosh` project and its Travis config need to add a key to allow Travis to upload the artifacts.

@keithw, are you OK with these changes?  We'd be switching from generating these artifacts manually and uploading directly to mosh.org, to taking Travis artifacts from Github and copying them to mosh.org.  One upside is that this would resolve #654.  One downside is that if Travis is having problems then we can't generate a release this way (and Travis has been having lots of problems lately).