### PR TITLE
fix: stop overwriting command from `--server`

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -382,6 +382,11 @@ if ( $pid == 0 ) { # child
   if ( scalar @command > 0 ) {
     push @server, '--', @command;
   }
+  
+  if ( $server cmp 'mosh-server' ) {
+    undef @server;
+    my @server = ( '' );
+  }
 
   if ( defined( $localhost )) {
     delete $ENV{ 'SSH_CONNECTION' };


### PR DESCRIPTION
Currently the options specified with `--server=COMMAND` got overwritten by some built-in parameters in the script, which could cause problems when I intend to do
```
mosh example.com --server='mosh-server new -i :: -l LANG=en_US.UTF-8'
```
while getting something like
```
mosh-server new -i :: -l LANG=en_US.UTF-8 new -c 256 -s -l LANG=en_US.UTF-8
```
on the server side. The latter will bind to a wrong IP in some of my multi-homed servers.