### PR TITLE
Renew socket when closed

### DIFF
--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -442,7 +442,12 @@ string Connection::recv( void )
 	   || (e.the_errno == EWOULDBLOCK) ) {
 	assert( !islast );
 	continue;
-      } else {
+      } else if (e.the_errno == ENOTCONN) {
+	hop_port();
+	socks.erase(it--);
+	continue;
+      }
+      else {
 	throw;
       }
     }


### PR DESCRIPTION
The Socket might be renewed during the lifetime of the Mosh session, but
if it was closed for some reason, the client hangs.
We have added support to check the state of the socket, and in case it
has been closed externally (systems with low resources), to reopen it and continue.