### PR TITLE
Fixes for GCC 7

### DIFF
--- a/src/crypto/ocb.cc
+++ b/src/crypto/ocb.cc
@@ -163,6 +163,16 @@
 	#endif
 #endif
 
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(gnu::fallthrough)
+#define FALLTHROUGH [[gnu::fallthrough]]
+#endif
+#endif
+
+#ifndef FALLTHROUGH
+#define FALLTHROUGH
+#endif
+
 /* ----------------------------------------------------------------------- */
 /* Define blocks and operations -- Patch if incorrect on your compiler.    */
 /* ----------------------------------------------------------------------- */
@@ -964,13 +974,20 @@ static void process_ad(ae_ctx *ctx, const void *ad, int ad_len, int final)
 			switch (k) {
 				#if (BPI == 8)
 				case 8: ad_checksum = xor_block(ad_checksum, ta[7]);
+					FALLTHROUGH;
 				case 7: ad_checksum = xor_block(ad_checksum, ta[6]);
+					FALLTHROUGH;
 				case 6: ad_checksum = xor_block(ad_checksum, ta[5]);
+					FALLTHROUGH;
 				case 5: ad_checksum = xor_block(ad_checksum, ta[4]);
+					FALLTHROUGH;
 				#endif
 				case 4: ad_checksum = xor_block(ad_checksum, ta[3]);
+					FALLTHROUGH;
 				case 3: ad_checksum = xor_block(ad_checksum, ta[2]);
+					FALLTHROUGH;
 				case 2: ad_checksum = xor_block(ad_checksum, ta[1]);
+					FALLTHROUGH;
 				case 1: ad_checksum = xor_block(ad_checksum, ta[0]);
 			}
 			ctx->ad_checksum = ad_checksum;
@@ -1132,12 +1149,18 @@ int ae_encrypt(ae_ctx     *  ctx,
 		switch (k) {
 			#if (BPI == 8)
 			case 7: ctp[6] = xor_block(ta[6], oa[6]);
+				FALLTHROUGH;
 			case 6: ctp[5] = xor_block(ta[5], oa[5]);
+				FALLTHROUGH;
 			case 5: ctp[4] = xor_block(ta[4], oa[4]);
+				FALLTHROUGH;
 			case 4: ctp[3] = xor_block(ta[3], oa[3]);
+				FALLTHROUGH;
 			#endif
 			case 3: ctp[2] = xor_block(ta[2], oa[2]);
+				FALLTHROUGH;
 			case 2: ctp[1] = xor_block(ta[1], oa[1]);
+				FALLTHROUGH;
 			case 1: ctp[0] = xor_block(ta[0], oa[0]);
 		}
 
@@ -1336,17 +1359,23 @@ int ae_decrypt(ae_ctx     *ctx,
 			#if (BPI == 8)
 			case 7: ptp[6] = xor_block(ta[6], oa[6]);
 				    checksum = xor_block(checksum, ptp[6]);
+				    FALLTHROUGH;
 			case 6: ptp[5] = xor_block(ta[5], oa[5]);
 				    checksum = xor_block(checksum, ptp[5]);
+				    FALLTHROUGH;
 			case 5: ptp[4] = xor_block(ta[4], oa[4]);
 				    checksum = xor_block(checksum, ptp[4]);
+				    FALLTHROUGH;
 			case 4: ptp[3] = xor_block(ta[3], oa[3]);
 				    checksum = xor_block(checksum, ptp[3]);
+				    FALLTHROUGH;
 			#endif
 			case 3: ptp[2] = xor_block(ta[2], oa[2]);
 				    checksum = xor_block(checksum, ptp[2]);
+				    FALLTHROUGH;
 			case 2: ptp[1] = xor_block(ta[1], oa[1]);
 				    checksum = xor_block(checksum, ptp[1]);
+				    FALLTHROUGH;
 			case 1: ptp[0] = xor_block(ta[0], oa[0]);
 				    checksum = xor_block(checksum, ptp[0]);
 		}

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -38,6 +38,16 @@
 
 #include "terminaloverlay.h"
 
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(gnu::fallthrough)
+#define FALLTHROUGH [[gnu::fallthrough]]
+#endif
+#endif
+
+#ifndef FALLTHROUGH
+#define FALLTHROUGH
+#endif
+
 using namespace Overlay;
 using std::max;
 using std::mem_fun_ref;
@@ -568,7 +578,7 @@ void PredictionEngine::cull( const Framebuffer &fb )
 	  }
 	}
 
-	/* no break */
+	FALLTHROUGH;
       case CorrectNoCredit:
 	j->reset();
 

--- a/src/terminal/parseraction.cc
+++ b/src/terminal/parseraction.cc
@@ -40,12 +40,12 @@ using namespace Parser;
 
 std::string Action::str( void )
 {
-  char thechar[ 10 ] = { 0 };
+  char thechar[ 11 ] = { 0 };
   if ( char_present ) {
     if ( iswprint( ch ) )
-      snprintf( thechar, 10, "(%lc)", static_cast<wint_t>(ch) );
+      snprintf( thechar, 11, "(%lc)", static_cast<wint_t>(ch) );
     else
-      snprintf( thechar, 10, "(0x%x)", static_cast<unsigned int>(ch) );
+      snprintf( thechar, 11, "(0x%x)", static_cast<unsigned int>(ch) );
   }
 
   return name() + std::string( thechar );


### PR DESCRIPTION
We’ll need something like this to build with GCC 7 and `--enable-compile-warnings=error`. (A [Debian bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=853558) about this was reported by the Debian GCC maintainers.)