### PR TITLE
Handle GCC 7's new -Wimplicit-fallthrough.

### DIFF
--- a/src/crypto/ocb.cc
+++ b/src/crypto/ocb.cc
@@ -964,13 +964,20 @@ static void process_ad(ae_ctx *ctx, const void *ad, int ad_len, int final)
 			switch (k) {
 				#if (BPI == 8)
 				case 8: ad_checksum = xor_block(ad_checksum, ta[7]);
+					/* fallthrough */
 				case 7: ad_checksum = xor_block(ad_checksum, ta[6]);
+					/* fallthrough */
 				case 6: ad_checksum = xor_block(ad_checksum, ta[5]);
+					/* fallthrough */
 				case 5: ad_checksum = xor_block(ad_checksum, ta[4]);
+					/* fallthrough */
 				#endif
 				case 4: ad_checksum = xor_block(ad_checksum, ta[3]);
+					/* fallthrough */
 				case 3: ad_checksum = xor_block(ad_checksum, ta[2]);
+					/* fallthrough */
 				case 2: ad_checksum = xor_block(ad_checksum, ta[1]);
+					/* fallthrough */
 				case 1: ad_checksum = xor_block(ad_checksum, ta[0]);
 			}
 			ctx->ad_checksum = ad_checksum;
@@ -1132,12 +1139,18 @@ int ae_encrypt(ae_ctx     *  ctx,
 		switch (k) {
 			#if (BPI == 8)
 			case 7: ctp[6] = xor_block(ta[6], oa[6]);
+				/* fallthrough */
 			case 6: ctp[5] = xor_block(ta[5], oa[5]);
+				/* fallthrough */
 			case 5: ctp[4] = xor_block(ta[4], oa[4]);
+				/* fallthrough */
 			case 4: ctp[3] = xor_block(ta[3], oa[3]);
+				/* fallthrough */
 			#endif
 			case 3: ctp[2] = xor_block(ta[2], oa[2]);
+				/* fallthrough */
 			case 2: ctp[1] = xor_block(ta[1], oa[1]);
+				/* fallthrough */
 			case 1: ctp[0] = xor_block(ta[0], oa[0]);
 		}
 
@@ -1336,17 +1349,23 @@ int ae_decrypt(ae_ctx     *ctx,
 			#if (BPI == 8)
 			case 7: ptp[6] = xor_block(ta[6], oa[6]);
 				    checksum = xor_block(checksum, ptp[6]);
+				    /* fallthrough */
 			case 6: ptp[5] = xor_block(ta[5], oa[5]);
 				    checksum = xor_block(checksum, ptp[5]);
+				    /* fallthrough */
 			case 5: ptp[4] = xor_block(ta[4], oa[4]);
 				    checksum = xor_block(checksum, ptp[4]);
+				    /* fallthrough */
 			case 4: ptp[3] = xor_block(ta[3], oa[3]);
 				    checksum = xor_block(checksum, ptp[3]);
+				    /* fallthrough */
 			#endif
 			case 3: ptp[2] = xor_block(ta[2], oa[2]);
 				    checksum = xor_block(checksum, ptp[2]);
+				    /* fallthrough */
 			case 2: ptp[1] = xor_block(ta[1], oa[1]);
 				    checksum = xor_block(checksum, ptp[1]);
+				    /* fallthrough */
 			case 1: ptp[0] = xor_block(ta[0], oa[0]);
 				    checksum = xor_block(checksum, ptp[0]);
 		}

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -568,7 +568,7 @@ void PredictionEngine::cull( const Framebuffer &fb )
 	  }
 	}
 
-	/* no break */
+	/* fallthrough */
       case CorrectNoCredit:
 	j->reset();
 

--- a/src/terminal/parseraction.cc
+++ b/src/terminal/parseraction.cc
@@ -38,19 +38,6 @@
 
 using namespace Parser;
 
-std::string Action::str( void )
-{
-  char thechar[ 10 ] = { 0 };
-  if ( char_present ) {
-    if ( iswprint( ch ) )
-      snprintf( thechar, 10, "(%lc)", static_cast<wint_t>(ch) );
-    else
-      snprintf( thechar, 10, "(0x%x)", static_cast<unsigned int>(ch) );
-  }
-
-  return name() + std::string( thechar );
-}
-
 void Print::act_on_terminal( Terminal::Emulator *emu ) const
 {
   emu->print( this );

--- a/src/terminal/parseraction.h
+++ b/src/terminal/parseraction.h
@@ -47,8 +47,6 @@ namespace Parser {
     wchar_t ch;
     bool char_present;
 
-    std::string str( void );
-
     virtual std::string name( void ) = 0;
 
     virtual void act_on_terminal( Terminal::Emulator * ) const {};


### PR DESCRIPTION
This is an alternate fix to the one on #851.  Syntax checked on an online C++ playground with GCC 7, but not actually tested on Mosh + GCC 7.  @andersk, do you have any strong preference?

Curiously, clang++ 4.0 on FreeBSD seems to have the option but doesn't seem to actually warn.