### PR TITLE
 Add the packaging metadata to build the mosh snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,8 +28,9 @@ parts:
       - pkg-config
       - perl
       - protobuf-compiler
-      - libprotobuf-dev
+    stage-packages:
       - libncurses5-dev
-      - zlib1g-dev
-      - libutempter-dev
+      - libprotobuf-dev
       - libssl-dev
+      - libutempter-dev
+      - zlib1g-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,29 @@
+name: mosh
+version: master
+summary: the mobile shell
+description: |
+  Mosh is a remote terminal application that supports intermittent
+  connectivity, allows roaming, and provides speculative local echo and line
+  editing of user keystrokes.
+
+grade: devel
+confinement: devmode
+
+apps:
+  mosh:
+    command: mosh
+
+parts:
+  mosh:
+    source: .
+    plugin: autotools
+    build-packages:
+      - g++
+      - pkg-config
+      - perl
+      - protobuf-compiler
+      - libprotobuf-dev
+      - libncurses5-dev
+      - zlib1g-dev
+      - libutempter-dev
+      - libssl-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,11 +7,17 @@ description: |
   editing of user keystrokes.
 
 grade: devel
-confinement: devmode
+confinement: classic
 
 apps:
   mosh:
     command: mosh
+  mosh-client:
+    command: mosh-client
+    aliases: [mosh-client]
+  mosh-server:
+    command: mosh-server
+    aliases: [mosh-server]
 
 parts:
   mosh:


### PR DESCRIPTION
This is a package for the installation of apps that works in most Linux distributions.
Landing it upstream will enable frequent builds that then can be distributed to many users through the Ubuntu store.