### PR TITLE
Ensure a UTF-8 locale is available for tests

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: mosh
 Section: net
 Priority: optional
 Maintainer: Keith Winstein <keithw@mit.edu>
-Build-Depends: debhelper (>= 9), autotools-dev, protobuf-compiler, libprotobuf-dev, dh-autoreconf, pkg-config, libutempter-dev, zlib1g-dev, libncurses5-dev, libssl-dev, bash-completion
+Build-Depends: debhelper (>= 9), autotools-dev, protobuf-compiler, libprotobuf-dev, dh-autoreconf, pkg-config, libutempter-dev, zlib1g-dev, libncurses5-dev, libssl-dev, bash-completion, locales, tmux, less
 Standards-Version: 3.9.8
 Homepage: https://mosh.org
 Vcs-Git: https://github.com/mobile-shell/mosh.git

--- a/src/tests/e2e-test
+++ b/src/tests/e2e-test
@@ -109,7 +109,7 @@ mosh_server()
 
 # Set up environment
 if [ -z "$srcdir" ]; then
-    srcdir=$PWD
+    export srcdir=$PWD
 else
     srcdir="$(cd "$srcdir" && pwd)"
     if [ $? -ne 0 ]; then

--- a/src/tests/e2e-test
+++ b/src/tests/e2e-test
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. "$(dirname "$0")/e2e-test-subrs"
+
 #
 # Validate that mosh produces expected output, using screen captures
 # in tmux.
@@ -106,6 +108,9 @@ mosh_server()
 }
 
 # main
+if ! set_locale; then
+    test_error "e2e-test: no usable locale\n"
+fi
 
 # Set up environment
 if [ -z "$srcdir" ]; then

--- a/src/tests/e2e-test-subrs
+++ b/src/tests/e2e-test-subrs
@@ -54,3 +54,24 @@ chr()
 {
     printf '%b' "\\0$(printf %03o "$1")"
 }
+
+# If the locale is not set to a UTF-8 locale, set it to en_US.UTF-8
+# or C.UTF-8.
+set_locale()
+{
+    # Test for a usable locale.
+    map=$(locale charmap 2>/dev/null)
+    if [ "$map" = "utf-8" ] || [ "$map" = "UTF-8" ]; then
+	return 0
+    fi
+    # Attempt to find/set a usable locale.
+    for i in en_US.UTF-8 en_US.utf8 C.UTF-8; do
+	map="$(env LANG=$i locale charmap 2>/dev/null)"
+	if [ "$map" = "utf-8" ] || [ "$map" = "UTF-8" ]; then
+	    export LANG=$i LC_ALL=''
+	    return 0
+	fi
+    done
+    # Fail.
+    return 1
+}

--- a/src/tests/emulation-attributes.test
+++ b/src/tests/emulation-attributes.test
@@ -51,20 +51,20 @@ baseline()
 	    ;;
 	# First 8 256-color attributes.  Comparing mosh and tmux fails.
 	256color8)
-	for attr in $(seq 0 7); do
-	    printf '\033[38;5;%dmE\033[m ' "$attr"
-	    printf '\033[48;5;%dmM\033[m ' "$attr"
-	done
-	printf '\n'
-	;;
+	    for attr in $(seq 0 7); do
+		printf '\033[38;5;%dmE\033[m ' "$attr"
+		printf '\033[48;5;%dmM\033[m ' "$attr"
+	    done
+	    printf '\n'
+	    ;;
 	# Last 248 256-color attributes.
 	256color248)
-	for attr in $(seq 8 255); do
-	    printf '\033[38;5;%dmE\033[m ' "$attr"
-	    printf '\033[48;5;%dmM\033[m ' "$attr"
-	done
-	printf '\n'
-	;;
+	    for attr in $(seq 8 255); do
+		printf '\033[38;5;%dmE\033[m ' "$attr"
+		printf '\033[48;5;%dmM\033[m ' "$attr"
+	    done
+	    printf '\n'
+	    ;;
 	*)
 	    fail "unknown test name %s\n" "$1"
 	    ;;

--- a/src/tests/emulation-attributes.test
+++ b/src/tests/emulation-attributes.test
@@ -40,14 +40,12 @@ baseline()
 	    for attr in 0 1 4 5 7; do
 		printf '\033[%dmE\033[m ' $attr
 	    done
-	    printf '\n'
 	    ;;
 	# 16-color attributes.
 	16color)
 	    for attr in $(seq 30 37) $(seq 39 47) 49; do
 		printf '\033[%dmE\033[m ' "$attr"
 	    done
-	    printf '\n'
 	    ;;
 	# First 8 256-color attributes.  Comparing mosh and tmux fails.
 	256color8)
@@ -55,7 +53,6 @@ baseline()
 		printf '\033[38;5;%dmE\033[m ' "$attr"
 		printf '\033[48;5;%dmM\033[m ' "$attr"
 	    done
-	    printf '\n'
 	    ;;
 	# Last 248 256-color attributes.
 	256color248)
@@ -63,12 +60,13 @@ baseline()
 		printf '\033[38;5;%dmE\033[m ' "$attr"
 		printf '\033[48;5;%dmM\033[m ' "$attr"
 	    done
-	    printf '\n'
 	    ;;
 	*)
 	    fail "unknown test name %s\n" "$1"
 	    ;;
     esac
+
+    printf '\033[mend\n'
 } 
 
 case $1 in

--- a/src/tests/local.test
+++ b/src/tests/local.test
@@ -1,4 +1,11 @@
 #!/bin/sh
+
+. "$(dirname "$0")/e2e-test-subrs"
+if ! set_locale; then
+    echo "$0: no usable locale" >&2
+    exit 99
+fi
+
 set -eu
 out=$(
     TERM=xterm \

--- a/src/tests/window-resize.test
+++ b/src/tests/window-resize.test
@@ -42,7 +42,7 @@ tmux_commands()
     # An interactive shell is waiting for us in the mosh session.
     # Start a full screen application that will redraw on window
     # resize.
-    printf "send-keys 'less /etc/services' 0x0d\n"
+    printf "send-keys 'less \"%s\"' 0x0d\n" "${srcdir}/e2e-test"
     sleep 1
     # we control the horizontal...
     tmux_resize_commands v D U


### PR DESCRIPTION
I think this will fix the Debian build failures we're experiencing, but cannot fully test this, not being the Debian package maintainer :)

I think it'll work on other platforms too, though I have a perhaps-confused memory of some platform that does not use `en_US.UTF-8` but instead some different naming convention.  (On some platforms, `locale -a` will output `en_US.utf8` even though the other form is required.)
