### PR TITLE
Fix pledge() usage and make test cases work properly on OpenBSD

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -577,7 +577,7 @@ static int run_server( const char *desired_ip, const char *desired_port,
     /* Drop unnecessary privileges */
 #ifdef HAVE_PLEDGE
     /* OpenBSD pledge() syscall */
-    if ( pledge( "stdio inet ioctl tty", NULL )) {
+    if ( pledge( "stdio inet tty", NULL )) {
       perror( "pledge() failed" );
       exit( 1 );
     }

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -415,7 +415,7 @@ bool STMClient::main( void )
   /* Drop unnecessary privileges */
 #ifdef HAVE_PLEDGE
   /* OpenBSD pledge() syscall */
-  if ( pledge( "stdio inet ioctl tty", NULL )) {
+  if ( pledge( "stdio inet tty", NULL )) {
     perror( "pledge() failed" );
     exit( 1 );
   }

--- a/src/tests/e2e-test
+++ b/src/tests/e2e-test
@@ -60,6 +60,14 @@ test_exitstatus()
 # Tmux check.
 tmux_check()
 {
+    # OpenBSD tmux does not have '-V'.
+    if [ "$(uname -s)" = "OpenBSD" ]; then
+	openbsd_major="$(uname -r)"
+	openbsd_major="${openbsd_major%%.*}"
+	if [ "${openbsd_major}" -ge 6 ]; then
+	    return 0
+	fi
+    fi
     version=$(tmux -V)
     if [ $? != 0 ]; then
 	error "tmux unavailable\n"

--- a/src/tests/e2e-test-subrs
+++ b/src/tests/e2e-test-subrs
@@ -61,6 +61,11 @@ set_locale()
 {
     # Test for a usable locale.
     map=$(locale charmap 2>/dev/null)
+    # 'locale charmap' is not POSIX.  If it's not available,
+    # pretend everything is OK.
+    if [ $? != 0 ]; then
+	return 0
+    fi
     if [ "$map" = "utf-8" ] || [ "$map" = "UTF-8" ]; then
 	return 0
     fi


### PR DESCRIPTION
Tested on OpenBSD 6.0.

This might or might not make it into mosh 1.3.0, but if not will be committed immediately after release.  I'm somewhat inclined to do this after release.  Jeremie, would it be possible for you to do this in the OpenBSD port for this release?  @keithw, do you have any opinion one way or another?
