### PR TITLE
Reduce excess newlines inside and outside Mosh session

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -423,6 +423,8 @@ if ( $pid == 0 ) { # child
       } else {
 	die "Bad MOSH CONNECT string: $_\n";
       }
+    } elsif ( m{^\s*$} ) {
+      # do nothing
     } else {
       if ( defined $port_request and $port_request =~ m{:} and m{Bad UDP port} ) {
 	$bad_udp_port_warning = 1;

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -422,11 +422,11 @@ static int run_server( const char *desired_ip, const char *desired_port,
    * If mosh-server is run on a pty, then typeahead may echo and break mosh.pl's
    * detection of the MOSH CONNECT message.  Print it on a new line to bodge
    * around that.
+   *
+   * Do it all in one printf to get a single write on the pty.
    */
-  if ( isatty( STDIN_FILENO ) ) {
-    puts( "\r\n" );
-  }
-  printf( "MOSH CONNECT %s %s\n", network->port().c_str(), network->get_key().c_str() );
+  printf( "%sMOSH CONNECT %s %s\n", isatty( STDIN_FILENO ) ? "\n" : "",
+	  network->port().c_str(), network->get_key().c_str() );
 
   /* don't let signals kill us */
   struct sigaction sa;


### PR DESCRIPTION
Mosh is adding an extra newline at the start of its full-screen session, and two newlines outside the full-screen session, which show up after exiting mosh.

We can eliminate the former newline (at the cost of some extra complexity), but the latter two newlines present a Hobson's choice:
* If we start ssh without a pty, we can eliminate all the newlines.  But that breaks backward compatibility with mosh <= 1.2.3.
* If we don't print any newlines before `MOSH CONNECT`, we run a risk of Mosh breaking for people who type ahead before mosh-client is started.
* We could run mosh-server with the programmatic equivalent of `stty -echo`.  But that also breaks backward compatibilty because older `mosh-server`s get the termios state from the ssh session.
* We can eat newlines in the `mosh` script, which eats newlines in any non-Mosh output it receives.

The compromise I chose here is to eat newlines in `mosh`.  Please contribute your opinions.

This is one of the things that argues for an incompatible break to `mosh2`, in my mind-- here, we'd use ssh without a pty, and with stdin redirected away from the client tty, so it doesn't eat typeahead.
