### PR TITLE
Do not move cursor for SCROLL UP and SCROLL DOWN

### DIFF
--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -119,11 +119,8 @@ void Framebuffer::scroll( int N )
 {
   if ( N >= 0 ) {
     delete_line( ds.get_scrolling_region_top_row(), N );
-    ds.move_row( -N, true );
   } else {
-    N = -N;
-    insert_line( ds.get_scrolling_region_top_row(), N );
-    ds.move_row( N, true );
+    insert_line( ds.get_scrolling_region_top_row(), -N );
   }
 }
 
@@ -187,9 +184,13 @@ void Framebuffer::move_rows_autoscroll( int rows )
   }
 
   if ( ds.get_cursor_row() + rows > ds.get_scrolling_region_bottom_row() ) {
-    scroll( ds.get_cursor_row() + rows - ds.get_scrolling_region_bottom_row() );
+    int N = ds.get_cursor_row() + rows - ds.get_scrolling_region_bottom_row();
+    scroll( N );
+    ds.move_row( -N, true );
   } else if ( ds.get_cursor_row() + rows < ds.get_scrolling_region_top_row() ) {
-    scroll( ds.get_cursor_row() + rows - ds.get_scrolling_region_top_row() );
+    int N = ds.get_cursor_row() + rows - ds.get_scrolling_region_top_row();
+    scroll( N );
+    ds.move_row( -N, true );
   }
 
   ds.move_row( rows, true );

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -22,6 +22,7 @@ displaytests = \
 	emulation-back-tab.test \
 	emulation-cursor-motion.test \
 	emulation-multiline-scroll.test \
+	emulation-scroll.test \
 	emulation-wrap-across-frames.test \
 	network-no-diff.test \
 	prediction-unicode.test \

--- a/src/tests/emulation-scroll.test
+++ b/src/tests/emulation-scroll.test
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+#
+# This is a regression test for a bug in Mosh: it would move the
+# cursor for the SCROLL UP and SCROLL DOWN commands, though it should
+# not.
+#
+
+# shellcheck source=e2e-test-subrs
+. "$(dirname "$0")/e2e-test-subrs"
+PATH=$PATH:.:$srcdir
+# Top-level wrapper.
+if [ $# -eq 0 ]; then
+    e2e-test "$0" baseline post
+    exit
+fi
+
+# OK, we have arguments, we're one of the test hooks.
+if [ $# -ne 1 ]; then
+    fail "bad arguments %s\n" "$@"
+fi
+
+baseline()
+{
+    # Clear
+    printf '\033[H\033[J'
+    # Fill with sample text
+    for i in $(seq 1 24); do
+	printf '\ntext %s' "$i"
+    done
+    # Scroll up 4 lines
+    printf '\033[4S'
+    # Then down 2
+    printf '\033[2T'
+
+    # The cursor should not have moved and this should print on the
+    # last line, and not overprint 'line 24'
+    printf '\rBad line'
+    # Overprint on line 24
+    printf '\033[24;1HLast line'
+    # and line 1
+    printf '\033[HFirst line\n'
+
+}
+
+post()
+{
+    local capture
+    capture="$(basename "$0").d/baseline.capture"
+    # 'Bad line' should have been overwritten
+    if grep -q '^Bad line$' "$capture"; then
+	exit 1
+    fi
+    # The first four lines should have scrolled off
+    if grep -q '^text [1-4]$' "$capture"; then
+	exit 1
+    fi
+    # The last line should not have scrolled off or been overwritten
+    if ! grep -q '^text 24$' "$capture"; then
+	exit 1
+    fi
+    # 20 lines of the original text should remain
+    if [ "$(grep -c '^text' "$capture")" -ne 20 ]; then
+	exit 1
+    fi
+    exit 0
+}
+
+case $1 in
+    baseline)
+	baseline;;
+    post)
+	post;;
+    *)
+	fail "unknown test argument %s\n" "$1";;
+esac


### PR DESCRIPTION
tmux 2.4 uncovered a bug in Mosh where it was leaving the cursor incorrectly positioned after the SCROLL UP and SCROLL DOWN commands (it moves the cursor along with the scrolled region, when it shouldn't move the cursor at all).  When displaying a man page with tables (or presumably any UTF-8 text with line-drawing characters), tmux will often draw the boxes first, then go back and fill the boxes with text.  Sometimes it uses the SCROLL UP command to position the screen correctly for the next box to draw.  tmux 2.3 was generally doing the same thing, but it was always doing an absolute reposition of the cursor after using those commands-- tmux 2.4 no longer does so.

This bug appears to have existed since the very early days of Mosh, I'm a little surprised the bug hasn't shown up before.