### PR TITLE
Re-enable unicode-later-combining.test, except for tmux 2.4

### DIFF
--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -32,6 +32,7 @@ displaytests = \
 	server-signal-timeout.test \
 	window-resize.test \
 	unicode-combine-fallback-assert.test \
+	unicode-later-combining.test \
 	window-resize.test
 
 check_PROGRAMS = ocb-aes encrypt-decrypt base64 nonce-incr inpty is-utf8-locale

--- a/src/tests/e2e-test-subrs
+++ b/src/tests/e2e-test-subrs
@@ -10,6 +10,12 @@ fail()
     exit 99
 }
 
+skip()
+{
+    printf "$@" 2>&1
+    exit 77
+}
+
 sleepf()
 {
     (sleep .1 || sleep 1) > /dev/null 2>&1

--- a/src/tests/unicode-later-combining.test
+++ b/src/tests/unicode-later-combining.test
@@ -37,6 +37,9 @@ variant()
 post()
 {
     export LANG=C
+    if [ "$(tmux -V)" = "tmux 2.4" ]; then
+	skip "tmux 2.4 unicode combining bug breaks this test\n"
+    fi
     if grep -q "$(printf '^\302\240\314\202$')" "$(basename "$0").d/baseline.capture"; then
 	exit 0
     fi


### PR DESCRIPTION
@keithw has done a PR to fix the tmux issue, and it's in tmux master now, so only tmux 2.4 suffers this bug.  So we can safely re-enable this test for all other versions of tmux.  See also:
https://github.com/tmux/tmux/pull/899
https://github.com/tmux/tmux/commit/a2dd7daf4e583ebb9ddc9d7cf09105c43df51399