### PR TITLE
Accept both IPv4 and IPv6 connections when listening on any address

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -453,6 +453,11 @@ AC_CHECK_DECL([IP_RECVTOS],
      [Define if IP_RECVTOS is a valid sockopt.])],
   , [[#include <netinet/in.h>]])
 
+AC_CHECK_DECL([IPV6_V6ONLY],
+  [AC_DEFINE([HAVE_IPV6_V6ONLY], [1],
+     [Define if IPV6_V6ONLY is a valid IPv6 socket option.])],
+  , [[#include <netinet/in.h>]])
+
 AC_CHECK_DECL([__STDC_ISO_10646__],
   [],
   [AC_MSG_WARN([C library doesn't advertise wchar_t is Unicode (OS X works anyway with workaround).])],

--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -327,6 +327,7 @@ bool Connection::try_bind( const char *addr, int port_low, int port_high )
       throw NetworkException( "Unknown address family", 0 );
     }
 
+#ifdef HAVE_IPV6_V6ONLY
     if ( local_addr.sa.sa_family == AF_INET6
       && memcmp(&local_addr.sin6.sin6_addr, &in6addr_any, sizeof(in6addr_any)) == 0 ) {
       const int off = 0;
@@ -334,6 +335,7 @@ bool Connection::try_bind( const char *addr, int port_low, int port_high )
         perror( "setsockopt( IPV6_V6ONLY, off )" );
       }
     }
+#endif
 
     if ( bind( sock(), &local_addr.sa, local_addr_len ) == 0 ) {
       set_MTU( local_addr.sa.sa_family );


### PR DESCRIPTION
On some Linux systems this is the default. On most other operating
systems accepting IPv4 connections on a IPv6 socket only happens when
explicitly requested. Even on Linux it depends on the sysctl config.

This change makes it independent from the system's defaults whether IPv4
connections will be accepted too through the same socket.