### PR TITLE
mosh 1.3.1 proposed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@
 	* Version 1.3.1 released.
 
 	* Platform support:
+		* Explicitly enable binding to both IPv4 and IPv6 addresses.
+		  (Giel van Schijndel)
 		* Restore perl 5.8.8 support for RHEL5.  (Alexander Chernyakhovsky)
 		* Make tests detect UTF-8 locale with a helper executable.  (John Hood)
 		* Don't print /etc/motd on IllumOS.  (John Hood)
@@ -12,6 +14,8 @@
 		  This fixes build failures.  (John Hood)
 
 	* Bug fixes:
+		* In tests, explicitly set 80x24 tmux window, for newer versions
+		  of tmux.  (John Hood)
 		* Work around JuiceSSH rendering bug.  (John Hood)
 		* Do not move cursor for SCROLL UP and SCROLL DOWN--
 		  fixes an issue with tmux 2.4.  (John Hood)

--- a/THANKS
+++ b/THANKS
@@ -92,3 +92,7 @@
 * HIGUCHI Yuta
 
 * Baruch Siach
+
+* Adrien Destugues
+
+* Giel van Schijndel

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.61])
-AC_INIT([mosh], [1.3.1-rc2], [mosh-devel@mit.edu])
+AC_INIT([mosh], [1.3.1], [mosh-devel@mit.edu])
 AM_INIT_AUTOMAKE([foreign std-options -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_SRCDIR([src/frontend/mosh-client.cc])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+mosh (1.3.1-1) unstable; urgency=medium
+
+  * Version 1.3.1 released to unstable.
+
+  * Platform support:
+    * Explicitly enable binding to both IPv4 and IPv6 addresses.
+      (Giel van Schijndel)
+
+  * Bug fixes:
+    * In tests, explicitly set 80x24 tmux window, for newer versions
+      of tmux.  (John Hood)
+
+ -- Keith Winstein <keithw@cs.stanford.edu>  Sun, 16 Jul 2017 22:56:07 -0400
+
 mosh (1.3.1~rc2-1) experimental; urgency=medium
 
   * Build fix.


### PR DESCRIPTION
Run CI on what will? should? be mosh-1.3.1.  Also let others (@keithw in particular) comment on the wisdom of including some code changes in the final release.