### PR TITLE
Adds Dockerfile-s for building a static mosh-server on Alpine Linux

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:latest
+MAINTAINER Brett Randall <javabrett@gmail.com>
+
+# NOTE: openssh is only required for testing connection to built docker using the built mosh-server
+RUN apk update \
+	&& apk add alpine-sdk autoconf automake protobuf-dev ncurses ncurses-dev ncurses-static openssl-dev openssh
+
+RUN git clone https://github.com/mobile-shell/mosh.git \
+	&& cd mosh \
+	&& ./autogen.sh \
+	&& LDFLAGS="-static" ./configure --prefix=/usr \
+	&& make \
+	&& make install \
+	&& ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa \
+	&& ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa \
+	&& adduser -D mosh \
+	&& echo 'mosh:m0sh-st@t1c' | chpasswd
+
+EXPOSE 22
+
+ENTRYPOINT /usr/sbin/sshd \
+	&& sh

--- a/dockerfiles/Dockerfile.gentoo
+++ b/dockerfiles/Dockerfile.gentoo
@@ -1,0 +1,13 @@
+FROM gentoo/stage3-amd64:latest
+MAINTAINER Brett Randall <javabrett@gmail.com>
+
+RUN ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa \
+	&& ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa \
+	&& ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -N '' -t ed25519 \
+	&& useradd mosh \
+	&& echo 'mosh:m0sh-st@t1c' | chpasswd
+
+EXPOSE 22
+
+ENTRYPOINT /usr/sbin/sshd \
+	&& sh

--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -1,0 +1,13 @@
+FROM ubuntu:latest
+MAINTAINER Brett Randall <javabrett@gmail.com>
+
+RUN apt-get update
+
+RUN apt-get install -y openssh-server openssh-client \
+	&& useradd -m mosh \
+	&& echo 'mosh:m0sh-st@t1c' | chpasswd
+
+EXPOSE 22
+
+ENTRYPOINT service ssh start \
+	&& sh


### PR DESCRIPTION
Prototype dockerfiles to build/test a statically-linked (musl glibc) mosh-server.  Part of research on #188.
- Dockerfile - Alpine linux base, installed build toolchain, checks-out mosh master, builds/installs, starts sshd and creates a mosh test-user.
- Dockerfile.ubuntu - Ubuntu base running sshd with mosh test-user.