### PR TITLE
Automatic memory

### DIFF
--- a/src/crypto/ocb.cc
+++ b/src/crypto/ocb.cc
@@ -1449,12 +1449,10 @@ static void validate()
     ALIGN(16) uint8_t key[32] = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
     ALIGN(16) uint8_t valid[] = {0xB2,0xB4,0x1C,0xBF,0x9B,0x05,0x03,0x7D,
                                  0xA7,0xF1,0x6C,0x24,0xA3,0x5C,0x1C,0x94};
+    ALIGN(16) uint8_t val_buf[22400];
     ae_ctx ctx;
-    uint8_t *val_buf, *next;
+    uint8_t *next = val_buf;
     int i, len;
-
-    val_buf = (uint8_t *)malloc(22400 + 16);
-    next = val_buf = (uint8_t *)(((size_t)val_buf + 16) & ~((size_t)15));
 
     if (0) {
 		ae_init(&ctx, key, 16, 12, 16);

--- a/src/examples/ntester.cc
+++ b/src/examples/ntester.cc
@@ -38,6 +38,7 @@
 #include "pty_compat.h"
 #include "networktransport-impl.h"
 #include "select.h"
+#include "shared.h"
 
 using namespace Network;
 
@@ -49,9 +50,8 @@ int main( int argc, char *argv[] )
   char *port;
 
   UserStream me, remote;
-
-  Transport<UserStream, UserStream> *n;
-
+  typedef shared::shared_ptr<Transport<UserStream, UserStream> > NetworkPointer;
+  Transport<UserStream, UserStream> *raw_n;
   try {
     if ( argc > 1 ) {
       server = false;
@@ -61,15 +61,16 @@ int main( int argc, char *argv[] )
       ip = argv[ 2 ];
       port = argv[ 3 ];
       
-      n = new Transport<UserStream, UserStream>( me, remote, key, ip, port );
+      raw_n = new Transport<UserStream, UserStream>( me, remote, key, ip, port );
     } else {
-      n = new Transport<UserStream, UserStream>( me, remote, NULL, NULL );
+      raw_n = new Transport<UserStream, UserStream>( me, remote, NULL, NULL );
     }
-    fprintf( stderr, "Port bound is %s, key is %s\n", n->port().c_str(), n->get_key().c_str() );
   } catch ( const std::exception &e ) {
     fprintf( stderr, "Fatal startup error: %s\n", e.what() );
     exit( 1 );
   }
+  NetworkPointer n( raw_n );
+  fprintf( stderr, "Port bound is %s, key is %s\n", n->port().c_str(), n->get_key().c_str() );
 
   if ( server ) {
     Select &sel = Select::get_instance();
@@ -168,6 +169,4 @@ int main( int argc, char *argv[] )
       exit( 1 );
     }    
   }
-
-  delete n;
 }

--- a/src/examples/parse.cc
+++ b/src/examples/parse.cc
@@ -199,20 +199,18 @@ static int vt_parser( int fd, Parser::UTF8Parser *parser )
 	  j != actions.end();
 	  j++ ) {
 
-      Parser::Action *act = *j;
-      assert( act );
+      assert( *j );
+      Parser::Action &act = **j;
 
-      if ( act->char_present ) {
-	if ( iswprint( act->ch ) ) {
-	  printf( "%s(0x%02x=%lc) ", act->name().c_str(), (unsigned int)act->ch, (wint_t)act->ch );
+      if ( act.char_present ) {
+	if ( iswprint( act.ch ) ) {
+	  printf( "%s(0x%02x=%lc) ", act.name().c_str(), (unsigned int)act.ch, (wint_t)act.ch );
 	} else {
-	  printf( "%s(0x%02x) ", act->name().c_str(), (unsigned int)act->ch );
+	  printf( "%s(0x%02x) ", act.name().c_str(), (unsigned int)act.ch );
 	}
       } else {
-	printf( "[%s] ", act->name().c_str() );
+	printf( "[%s] ", act.name().c_str() );
       }
-
-      delete act;
 
       fflush( stdout );
     }

--- a/src/examples/termemu.cc
+++ b/src/examples/termemu.cc
@@ -270,8 +270,7 @@ static void emulate_terminal( int fd )
       std::string terminal_to_host;
       
       for ( int i = 0; i < bytes_read; i++ ) {
-	Parser::UserByte ub( buf[ i ] );
-	terminal_to_host += complete.act( &ub );
+	terminal_to_host += complete.act( Parser::UserByte( buf[ i ] ) );
       }
       
       if ( swrite( fd, terminal_to_host.c_str(), terminal_to_host.length() ) < 0 ) {
@@ -302,8 +301,7 @@ static void emulate_terminal( int fd )
       }
 
       /* tell emulator */
-      Parser::Resize r( window_size.ws_col, window_size.ws_row );
-      complete.act( &r );
+      complete.act( Parser::Resize( window_size.ws_col, window_size.ws_row ) );
 
       /* tell child process */
       if ( ioctl( fd, TIOCSWINSZ, &window_size ) < 0 ) {

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -179,11 +179,7 @@ int main( int argc, char *argv[] )
   char *predict_overwrite = getenv( "MOSH_PREDICTION_OVERWRITE" );
   /* can be NULL */
 
-  char *key = strdup( env_key );
-  if ( key == NULL ) {
-    perror( "strdup" );
-    exit( 1 );
-  }
+  string key( env_key );
 
   if ( unsetenv( "MOSH_KEY" ) < 0 ) {
     perror( "unsetenv" );
@@ -195,7 +191,7 @@ int main( int argc, char *argv[] )
 
   bool success = false;
   try {
-    STMClient client( ip, desired_port, key, predict_mode, verbose, predict_overwrite );
+    STMClient client( ip, desired_port, key.c_str(), predict_mode, verbose, predict_overwrite );
     client.init();
 
     try {
@@ -220,8 +216,6 @@ int main( int argc, char *argv[] )
   }
 
   printf( "[mosh is exiting.]\n" );
-
-  free( key );
 
   return !success;
 }

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -953,12 +953,14 @@ static bool motd_hushed( void )
   return (0 == lstat( ".hushlogin", &buf ));
 }
 
+#ifdef HAVE_UTMPX_H
 static bool device_exists( const char *ut_line )
 {
   string device_name = string( "/dev/" ) + string( ut_line );
   struct stat buf;
   return (0 == lstat( device_name.c_str(), &buf ));
 }
+#endif
 
 static void warn_unattached( const string & ignore_entry )
 {

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -417,7 +417,8 @@ static int run_server( const char *desired_ip, const char *desired_port,
 
   /* open network */
   Network::UserStream blank;
-  ServerConnection *network = new ServerConnection( terminal, blank, desired_ip, desired_port );
+  typedef shared::shared_ptr<ServerConnection> NetworkPointer;
+  NetworkPointer network( new ServerConnection( terminal, blank, desired_ip, desired_port ) );
 
   network->set_verbose( verbose );
   Select::set_verbose( verbose );
@@ -521,7 +522,7 @@ static int run_server( const char *desired_ip, const char *desired_port,
     fatal_assert( 0 == sigaction( SIGPIPE, &sa, NULL ) );
 
     /* close server-related file descriptors */
-    delete network;
+    network.reset();
 
     /* set IUTF8 if available */
 #ifdef HAVE_IUTF8
@@ -628,8 +629,6 @@ static int run_server( const char *desired_ip, const char *desired_port,
       perror( "close" );
       exit( 1 );
     }
-
-    delete network;
   }
 
   fputs( "\n[mosh-server is exiting.]\n", stdout );

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -252,8 +252,7 @@ void STMClient::main_init( void )
   /* open network */
   Network::UserStream blank;
   Terminal::Complete local_terminal( window_size.ws_col, window_size.ws_row );
-  network = new Network::Transport< Network::UserStream, Terminal::Complete >( blank, local_terminal,
-									       key.c_str(), ip.c_str(), port.c_str() );
+  network = NetworkPointer( new NetworkType( blank, local_terminal, key.c_str(), ip.c_str(), port.c_str() ) );
 
   network->set_send_delay( 1 ); /* minimal delay on outgoing keystrokes */
 

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -314,8 +314,10 @@ bool STMClient::process_user_input( int fd )
     return false;
   }
 
-  if ( !network->shutdown_in_progress() ) {
-    overlays.get_prediction_engine().set_local_frame_sent( network->get_sent_state_last() );
+  NetworkType &net = *network;
+
+  if ( !net.shutdown_in_progress() ) {
+    overlays.get_prediction_engine().set_local_frame_sent( net.get_sent_state_last() );
 
     /* Don't predict for bulk data. */
     bool paste = bytes_read > 100;
@@ -332,9 +334,9 @@ bool STMClient::process_user_input( int fd )
 
       if ( quit_sequence_started ) {
 	if ( the_byte == '.' ) { /* Quit sequence is Ctrl-^ . */
-	  if ( network->has_remote_addr() && (!network->shutdown_in_progress()) ) {
+	  if ( net.has_remote_addr() && (!net.shutdown_in_progress()) ) {
 	    overlays.get_notification_engine().set_notification_string( wstring( L"Exiting on user request..." ), true );
-	    network->start_shutdown();
+	    net.start_shutdown();
 	    return true;
 	  } else {
 	    return false;
@@ -359,11 +361,11 @@ bool STMClient::process_user_input( int fd )
 	} else if ( (the_byte == escape_pass_key) || (the_byte == escape_pass_key2) ) {
 	  /* Emulation sequence to type escape_key is escape_key +
 	     escape_pass_key (that is escape key without Ctrl) */
-	  network->get_current_state().push_back( Parser::UserByte( escape_key ) );
+	  net.get_current_state().push_back( Parser::UserByte( escape_key ) );
 	} else {
 	  /* Escape key followed by anything other than . and ^ gets sent literally */
-	  network->get_current_state().push_back( Parser::UserByte( escape_key ) );
-	  network->get_current_state().push_back( Parser::UserByte( the_byte ) );	  
+	  net.get_current_state().push_back( Parser::UserByte( escape_key ) );
+	  net.get_current_state().push_back( Parser::UserByte( the_byte ) );
 	}
 
 	quit_sequence_started = false;
@@ -388,7 +390,7 @@ bool STMClient::process_user_input( int fd )
 	repaint_requested = true;
       }
 
-      network->get_current_state().push_back( Parser::UserByte( the_byte ) );		
+      net.get_current_state().push_back( Parser::UserByte( the_byte ) );
     }
   }
 

--- a/src/frontend/stmclient.h
+++ b/src/frontend/stmclient.h
@@ -40,6 +40,7 @@
 #include "completeterminal.h"
 #include "networktransport.h"
 #include "user.h"
+#include "shared.h"
 #include "terminaloverlay.h"
 
 class STMClient {
@@ -60,7 +61,9 @@ private:
 
   Terminal::Framebuffer local_framebuffer, new_state;
   Overlay::OverlayManager overlays;
-  Network::Transport< Network::UserStream, Terminal::Complete > *network;
+  typedef Network::Transport< Network::UserStream, Terminal::Complete > NetworkType;
+  typedef shared::shared_ptr< NetworkType > NetworkPointer;
+  NetworkPointer network;
   Terminal::Display display;
 
   std::wstring connecting_notification;
@@ -94,7 +97,7 @@ public:
       local_framebuffer( 1, 1 ),
       new_state( 1, 1 ),
       overlays(),
-      network( NULL ),
+      network(),
       display( true ), /* use TERM environment var to initialize display */
       connecting_notification(),
       repaint_requested( false ),
@@ -125,13 +128,6 @@ public:
   void init( void );
   void shutdown( void );
   bool main( void );
-
-  ~STMClient()
-  {
-    if ( network != NULL ) {
-      delete network;
-    }
-  }
 
   /* unused */
   STMClient( const STMClient & );

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -672,22 +672,22 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer &fb )
   for ( Parser::Actions::iterator it = actions.begin();
         it != actions.end();
         it++ ) {
-    Parser::Action *act = *it;
+    Parser::Action& act = **it;
 
     /*
     fprintf( stderr, "Action: %s (%lc)\n",
 	     act->name().c_str(), act->char_present ? act->ch : L'_' );
     */
 
-    const std::type_info& type_act = typeid( *act );
+    const std::type_info& type_act = typeid( act );
     if ( type_act == typeid( Parser::Print ) ) {
       /* make new prediction */
 
       init_cursor( fb );
 
-      assert( act->char_present );
+      assert( act.char_present );
 
-      wchar_t ch = act->ch;
+      wchar_t ch = act.ch;
       /* XXX handle wide characters */
 
       if ( ch == 0x7f ) { /* backspace */
@@ -826,24 +826,24 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer &fb )
 	}
       }
     } else if ( type_act == typeid( Parser::Execute ) ) {
-      if ( act->char_present && (act->ch == 0x0d) /* CR */ ) {
+      if ( act.char_present && (act.ch == 0x0d) /* CR */ ) {
 	become_tentative();
 	newline_carriage_return( fb );
       } else {
-	//	fprintf( stderr, "Execute 0x%x\n", act->ch );
+	//	fprintf( stderr, "Execute 0x%x\n", act.ch );
 	become_tentative();	
       }
     } else if ( type_act == typeid( Parser::Esc_Dispatch ) ) {
       //      fprintf( stderr, "Escape sequence\n" );
       become_tentative();
     } else if ( type_act == typeid( Parser::CSI_Dispatch ) ) {
-      if ( act->char_present && (act->ch == L'C') ) { /* right arrow */
+      if ( act.char_present && (act.ch == L'C') ) { /* right arrow */
 	init_cursor( fb );
 	if ( cursor().col < fb.ds.get_width() - 1 ) {
 	  cursor().col++;
 	  cursor().expire( local_frame_sent + 1, now );
 	}
-      } else if ( act->char_present && (act->ch == L'D') ) { /* left arrow */
+      } else if ( act.char_present && (act.ch == L'D') ) { /* left arrow */
 	init_cursor( fb );
 	
 	if ( cursor().col > 0 ) {
@@ -851,12 +851,10 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer &fb )
 	  cursor().expire( local_frame_sent + 1, now );
 	}
       } else {
-	//	fprintf( stderr, "CSI sequence %lc\n", act->ch );
+	//	fprintf( stderr, "CSI sequence %lc\n", act.ch );
 	become_tentative();
       }
     }
-
-    delete act;
   }
 }
 

--- a/src/network/compressor.h
+++ b/src/network/compressor.h
@@ -40,11 +40,11 @@ namespace Network {
   private:
     static const int BUFFER_SIZE = 2048 * 2048; /* effective limit on terminal size */
 
-    unsigned char *buffer;
+    unsigned char buffer[BUFFER_SIZE];
 
   public:
-    Compressor() : buffer( NULL ) { buffer = new unsigned char[ BUFFER_SIZE ]; }
-    ~Compressor() { if ( buffer ) { delete[] buffer; } }
+    Compressor() {}
+    ~Compressor() {}
 
     std::string compress_str( const std::string &input );
     std::string uncompress_str( const std::string &input );

--- a/src/statesync/completeterminal.cc
+++ b/src/statesync/completeterminal.cc
@@ -52,9 +52,8 @@ string Complete::act( const string &str )
     for ( Actions::iterator it = actions.begin();
 	  it != actions.end();
 	  it++ ) {
-      Action *act = *it;
-      act->act_on_terminal( &terminal );
-      delete act;
+      Action &act = **it;
+      act.act_on_terminal( &terminal );
     }
     actions.clear();
   }
@@ -62,10 +61,10 @@ string Complete::act( const string &str )
   return terminal.read_octets_to_host();
 }
 
-string Complete::act( const Action *act )
+string Complete::act( const Action &act )
 {
   /* apply action to terminal */
-  act->act_on_terminal( &terminal );
+  act.act_on_terminal( &terminal );
   return terminal.read_octets_to_host();
 }
 
@@ -112,9 +111,8 @@ void Complete::apply_string( const string & diff )
       string terminal_to_host = act( input.instruction( i ).GetExtension( hostbytes ).hoststring() );
       assert( terminal_to_host.empty() ); /* server never interrogates client terminal */
     } else if ( input.instruction( i ).HasExtension( resize ) ) {
-      Resize new_size( input.instruction( i ).GetExtension( resize ).width(),
-		       input.instruction( i ).GetExtension( resize ).height() );
-      act( &new_size );
+      act( Resize( input.instruction( i ).GetExtension( resize ).width(),
+				      input.instruction( i ).GetExtension( resize ).height() ) );
     } else if ( input.instruction( i ).HasExtension( echoack ) ) {
       uint64_t inst_echo_ack_num = input.instruction( i ).GetExtension( echoack ).echo_ack_num();
       assert( inst_echo_ack_num >= echo_ack );

--- a/src/statesync/completeterminal.h
+++ b/src/statesync/completeterminal.h
@@ -64,7 +64,7 @@ namespace Terminal {
 					      actions(), input_history(), echo_ack( 0 ) {}
     
     std::string act( const std::string &str );
-    std::string act( const Parser::Action *act );
+    std::string act( const Parser::Action &act );
 
     const Framebuffer & get_fb( void ) const { return terminal.get_fb(); }
     void reset_input( void ) { parser.reset_input(); }

--- a/src/statesync/user.cc
+++ b/src/statesync/user.cc
@@ -123,15 +123,16 @@ void UserStream::apply_string( const string &diff )
   }
 }
 
-const Parser::Action *UserStream::get_action( unsigned int i ) const
+const Parser::Action &UserStream::get_action( unsigned int i ) const
 {
   switch( actions[ i ].type ) {
   case UserByteType:
-    return &( actions[ i ].userbyte );
+    return actions[ i ].userbyte;
   case ResizeType:
-    return &( actions[ i ].resize );
+    return actions[ i ].resize;
   default:
     assert( false );
-    return NULL;
+    static const Parser::Ignore nothing = Parser::Ignore();
+    return nothing;
   }
 }

--- a/src/statesync/user.h
+++ b/src/statesync/user.h
@@ -84,7 +84,7 @@ namespace Network {
     
     bool empty( void ) const { return actions.empty(); }
     size_t size( void ) const { return actions.size(); }
-    const Parser::Action *get_action( unsigned int i ) const;
+    const Parser::Action &get_action( unsigned int i ) const;
     
     /* interface for Network::Transport */
     void subtract( const UserStream *prefix );

--- a/src/terminal/parser.cc
+++ b/src/terminal/parser.cc
@@ -40,15 +40,13 @@
 
 const Parser::StateFamily Parser::family;
 
-static void append_or_delete( Parser::Action *act,
+static void append_or_delete( Parser::ActionPointer act,
 			      Parser::Actions &vec )
 {
   assert( act );
 
   if ( !act->ignore() ) {
     vec.push_back( act );
-  } else {
-    delete act;
   }
 }
 
@@ -61,7 +59,6 @@ void Parser::Parser::input( wchar_t ch, Actions &ret )
   }
 
   append_or_delete( tx.action, ret );
-  tx.action = NULL;
 
   if ( tx.next_state != NULL ) {
     append_or_delete( tx.next_state->enter(), ret );

--- a/src/terminal/parseraction.h
+++ b/src/terminal/parseraction.h
@@ -36,6 +36,8 @@
 #include <string>
 #include <vector>
 
+#include "shared.h"
+
 namespace Terminal {
   class Emulator;
 }
@@ -59,7 +61,8 @@ namespace Parser {
     virtual bool operator==( const Action &other ) const;
   };
 
-  typedef std::vector<Action *> Actions;
+  typedef shared::shared_ptr<Action> ActionPointer;
+  typedef std::vector<ActionPointer> Actions;
 
   class Ignore : public Action {
   public:

--- a/src/terminal/parserstate.cc
+++ b/src/terminal/parserstate.cc
@@ -32,6 +32,7 @@
 
 #include "parserstate.h"
 #include "parserstatefamily.h"
+#include "shared.h"
 
 using namespace Parser;
 
@@ -41,7 +42,7 @@ Transition State::anywhere_rule( wchar_t ch ) const
        || ((0x80 <= ch) && (ch <= 0x8F))
        || ((0x91 <= ch) && (ch <= 0x97))
        || (ch == 0x99) || (ch == 0x9A) ) {
-    return Transition( new Execute, &family->s_Ground );
+    return Transition( shared::make_shared<Execute>(), &family->s_Ground );
   } else if ( ch == 0x9C ) {
     return Transition( &family->s_Ground );
   } else if ( ch == 0x1B ) {
@@ -56,7 +57,7 @@ Transition State::anywhere_rule( wchar_t ch ) const
     return Transition( &family->s_CSI_Entry );
   }
 
-  return Transition(( State * )NULL, NULL ); /* don't allocate an Ignore action */
+  return Transition(( State * )NULL, ActionPointer() ); /* don't allocate an Ignore action */
 }
 
 Transition State::input( wchar_t ch ) const
@@ -92,29 +93,29 @@ static bool GLGR ( wchar_t ch )
 Transition Ground::input_state_rule( wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
-    return Transition( new Execute );
+    return Transition( shared::make_shared< Execute >() );
   }
 
   if ( GLGR( ch ) ) {
-    return Transition( new Print );
+    return Transition( shared::make_shared< Print >() );
   }
 
   return Transition();
 }
 
-Action *Escape::enter( void ) const
+ActionPointer Escape::enter( void ) const
 {
-  return new Clear;
+  return shared::make_shared< Clear >();
 }
 
 Transition Escape::input_state_rule( wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
-    return Transition( new Execute );
+    return Transition( shared::make_shared< Execute >() );
   }
 
   if ( (0x20 <= ch) && (ch <= 0x2F) ) {
-    return Transition( new Collect, &family->s_Escape_Intermediate );
+    return Transition( shared::make_shared< Collect >(), &family->s_Escape_Intermediate );
   }
 
   if ( ( (0x30 <= ch) && (ch <= 0x4F) )
@@ -123,7 +124,7 @@ Transition Escape::input_state_rule( wchar_t ch ) const
        || ( ch == 0x5A )
        || ( ch == 0x5C )
        || ( (0x60 <= ch) && (ch <= 0x7E) ) ) {
-    return Transition( new Esc_Dispatch, &family->s_Ground );
+    return Transition( shared::make_shared< Esc_Dispatch >(), &family->s_Ground );
   }
 
   if ( ch == 0x5B ) {
@@ -148,42 +149,42 @@ Transition Escape::input_state_rule( wchar_t ch ) const
 Transition Escape_Intermediate::input_state_rule( wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
-    return Transition( new Execute );
+    return Transition( shared::make_shared< Execute >() );
   }
 
   if ( (0x20 <= ch) && (ch <= 0x2F) ) {
-    return Transition( new Collect );
+    return Transition( shared::make_shared< Collect >() );
   }
 
   if ( (0x30 <= ch) && (ch <= 0x7E) ) {
-    return Transition( new Esc_Dispatch, &family->s_Ground );
+    return Transition( shared::make_shared< Esc_Dispatch >(), &family->s_Ground );
   }
 
   return Transition();
 }
 
-Action *CSI_Entry::enter( void ) const
+ActionPointer CSI_Entry::enter( void ) const
 {
-  return new Clear;
+  return shared::make_shared< Clear >();
 }
 
 Transition CSI_Entry::input_state_rule( wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
-    return Transition( new Execute );
+    return Transition( shared::make_shared< Execute >() );
   }
 
   if ( (0x40 <= ch) && (ch <= 0x7E) ) {
-    return Transition( new CSI_Dispatch, &family->s_Ground );
+    return Transition( shared::make_shared< CSI_Dispatch >(), &family->s_Ground );
   }
 
   if ( ( (0x30 <= ch) && (ch <= 0x39) )
        || ( ch == 0x3B ) ) {
-    return Transition( new Param, &family->s_CSI_Param );
+    return Transition( shared::make_shared< Param >(), &family->s_CSI_Param );
   }
 
   if ( (0x3C <= ch) && (ch <= 0x3F) ) {
-    return Transition( new Collect, &family->s_CSI_Param );
+    return Transition( shared::make_shared< Collect >(), &family->s_CSI_Param );
   }
 
   if ( ch == 0x3A ) {
@@ -191,7 +192,7 @@ Transition CSI_Entry::input_state_rule( wchar_t ch ) const
   }
 
   if ( (0x20 <= ch) && (ch <= 0x2F) ) {
-    return Transition( new Collect, &family->s_CSI_Intermediate );
+    return Transition( shared::make_shared< Collect >(), &family->s_CSI_Intermediate );
   }
 
   return Transition();
@@ -200,11 +201,11 @@ Transition CSI_Entry::input_state_rule( wchar_t ch ) const
 Transition CSI_Param::input_state_rule( wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
-    return Transition( new Execute );
+    return Transition( shared::make_shared< Execute >() );
   }
 
   if ( ( (0x30 <= ch) && (ch <= 0x39) ) || ( ch == 0x3B ) ) {
-    return Transition( new Param );
+    return Transition( shared::make_shared< Param >() );
   }
 
   if ( ( ch == 0x3A ) || ( (0x3C <= ch) && (ch <= 0x3F) ) ) {
@@ -212,11 +213,11 @@ Transition CSI_Param::input_state_rule( wchar_t ch ) const
   }
 
   if ( (0x20 <= ch) && (ch <= 0x2F) ) {
-    return Transition( new Collect, &family->s_CSI_Intermediate );
+    return Transition( shared::make_shared< Collect >(), &family->s_CSI_Intermediate );
   }
 
   if ( (0x40 <= ch) && (ch <= 0x7E) ) {
-    return Transition( new CSI_Dispatch, &family->s_Ground );
+    return Transition( shared::make_shared< CSI_Dispatch >(), &family->s_Ground );
   }
 
   return Transition();
@@ -225,15 +226,15 @@ Transition CSI_Param::input_state_rule( wchar_t ch ) const
 Transition CSI_Intermediate::input_state_rule( wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
-    return Transition( new Execute );
+    return Transition( shared::make_shared< Execute >() );
   }
 
   if ( (0x20 <= ch) && (ch <= 0x2F) ) {
-    return Transition( new Collect );
+    return Transition( shared::make_shared< Collect >() );
   }
 
   if ( (0x40 <= ch) && (ch <= 0x7E) ) {
-    return Transition( new CSI_Dispatch, &family->s_Ground );
+    return Transition( shared::make_shared< CSI_Dispatch >(), &family->s_Ground );
   }
 
   if ( (0x30 <= ch) && (ch <= 0x3F) ) {
@@ -246,7 +247,7 @@ Transition CSI_Intermediate::input_state_rule( wchar_t ch ) const
 Transition CSI_Ignore::input_state_rule( wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
-    return Transition( new Execute );
+    return Transition( shared::make_shared< Execute >() );
   }
 
   if ( (0x40 <= ch) && (ch <= 0x7E) ) {
@@ -256,15 +257,15 @@ Transition CSI_Ignore::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Action *DCS_Entry::enter( void ) const
+ActionPointer DCS_Entry::enter( void ) const
 {
-  return new Clear;
+  return shared::make_shared< Clear >();
 }
 
 Transition DCS_Entry::input_state_rule( wchar_t ch ) const
 {
   if ( (0x20 <= ch) && (ch <= 0x2F) ) {
-    return Transition( new Collect, &family->s_DCS_Intermediate );
+    return Transition( shared::make_shared< Collect >(), &family->s_DCS_Intermediate );
   }
 
   if ( ch == 0x3A ) {
@@ -272,11 +273,11 @@ Transition DCS_Entry::input_state_rule( wchar_t ch ) const
   }
 
   if ( ( (0x30 <= ch) && (ch <= 0x39) ) || ( ch == 0x3B ) ) {
-    return Transition( new Param, &family->s_DCS_Param );
+    return Transition( shared::make_shared< Param >(), &family->s_DCS_Param );
   }
 
   if ( (0x3C <= ch) && (ch <= 0x3F) ) {
-    return Transition( new Collect, &family->s_DCS_Param );
+    return Transition( shared::make_shared< Collect >(), &family->s_DCS_Param );
   }
 
   if ( (0x40 <= ch) && (ch <= 0x7E) ) {
@@ -289,7 +290,7 @@ Transition DCS_Entry::input_state_rule( wchar_t ch ) const
 Transition DCS_Param::input_state_rule( wchar_t ch ) const
 {
   if ( ( (0x30 <= ch) && (ch <= 0x39) ) || ( ch == 0x3B ) ) {
-    return Transition( new Param );
+    return Transition( shared::make_shared< Param >() );
   }
 
   if ( ( ch == 0x3A ) || ( (0x3C <= ch) && (ch <= 0x3F) ) ) {
@@ -297,7 +298,7 @@ Transition DCS_Param::input_state_rule( wchar_t ch ) const
   }
 
   if ( (0x20 <= ch) && (ch <= 0x2F) ) {
-    return Transition( new Collect, &family->s_DCS_Intermediate );
+    return Transition( shared::make_shared< Collect >(), &family->s_DCS_Intermediate );
   }
 
   if ( (0x40 <= ch) && (ch <= 0x7E) ) {
@@ -310,7 +311,7 @@ Transition DCS_Param::input_state_rule( wchar_t ch ) const
 Transition DCS_Intermediate::input_state_rule( wchar_t ch ) const
 {
   if ( (0x20 <= ch) && (ch <= 0x2F) ) {
-    return Transition( new Collect );
+    return Transition( shared::make_shared< Collect >() );
   }
 
   if ( (0x40 <= ch) && (ch <= 0x7E) ) {
@@ -324,20 +325,20 @@ Transition DCS_Intermediate::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Action *DCS_Passthrough::enter( void ) const
+ActionPointer DCS_Passthrough::enter( void ) const
 {
-  return new Hook;
+  return shared::make_shared< Hook >();
 }
 
-Action *DCS_Passthrough::exit( void ) const
+ActionPointer DCS_Passthrough::exit( void ) const
 {
-  return new Unhook;
+  return shared::make_shared< Unhook >();
 }
 
 Transition DCS_Passthrough::input_state_rule( wchar_t ch ) const
 {
   if ( C0_prime( ch ) || ( (0x20 <= ch) && (ch <= 0x7E) ) ) {
-    return Transition( new Put );
+    return Transition( shared::make_shared< Put >() );
   }
 
   if ( ch == 0x9C ) {
@@ -356,20 +357,20 @@ Transition DCS_Ignore::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Action *OSC_String::enter( void ) const
+ActionPointer OSC_String::enter( void ) const
 {
-  return new OSC_Start;
+  return shared::make_shared< OSC_Start >();
 }
 
-Action *OSC_String::exit( void ) const
+ActionPointer OSC_String::exit( void ) const
 {
-  return new OSC_End;
+  return shared::make_shared< OSC_End >();
 }
 
 Transition OSC_String::input_state_rule( wchar_t ch ) const
 {
   if ( (0x20 <= ch) && (ch <= 0x7F) ) {
-    return Transition( new OSC_Put );
+    return Transition( shared::make_shared< OSC_Put >() );
   }
 
   if ( (ch == 0x9C) || (ch == 0x07) ) { /* 0x07 is xterm non-ANSI variant */

--- a/src/terminal/parserstate.h
+++ b/src/terminal/parserstate.h
@@ -50,8 +50,8 @@ namespace Parser {
   public:
     void setfamily( StateFamily *s_family ) { family = s_family; }
     Transition input( wchar_t ch ) const;
-    virtual Action *enter( void ) const { return new Ignore; }
-    virtual Action *exit( void ) const { return new Ignore; }
+    virtual ActionPointer enter( void ) const { return shared::make_shared< Ignore >(); }
+    virtual ActionPointer exit( void ) const { return shared::make_shared< Ignore >(); }
 
     State() : family( NULL ) {};
     virtual ~State() {};
@@ -65,7 +65,7 @@ namespace Parser {
   };
 
   class Escape : public State {
-    Action *enter( void ) const;
+    ActionPointer enter( void ) const;
     Transition input_state_rule( wchar_t ch ) const;
   };
 
@@ -74,7 +74,7 @@ namespace Parser {
   };
 
   class CSI_Entry : public State {
-    Action *enter( void ) const;
+    ActionPointer enter( void ) const;
     Transition input_state_rule( wchar_t ch ) const;
   };
   class CSI_Param : public State {
@@ -88,7 +88,7 @@ namespace Parser {
   };
   
   class DCS_Entry : public State {
-    Action *enter( void ) const;
+    ActionPointer enter( void ) const;
     Transition input_state_rule( wchar_t ch ) const;
   };
   class DCS_Param : public State {
@@ -98,18 +98,18 @@ namespace Parser {
     Transition input_state_rule( wchar_t ch ) const;
   };
   class DCS_Passthrough : public State {
-    Action *enter( void ) const;
+    ActionPointer enter( void ) const;
     Transition input_state_rule( wchar_t ch ) const;
-    Action *exit( void ) const;
+    ActionPointer exit( void ) const;
   };
   class DCS_Ignore : public State {
     Transition input_state_rule( wchar_t ch ) const;
   };
 
   class OSC_String : public State {
-    Action *enter( void ) const;
+    ActionPointer enter( void ) const;
     Transition input_state_rule( wchar_t ch ) const;
-    Action *exit( void ) const;
+    ActionPointer exit( void ) const;
   };
   class SOS_PM_APC_String : public State {
     Transition input_state_rule( wchar_t ch ) const;

--- a/src/terminal/parsertransition.h
+++ b/src/terminal/parsertransition.h
@@ -45,7 +45,7 @@ namespace Parser {
   public:
     // Transition is only a courier for an Action; it should
     // never create/delete one on its own.
-    Action *action;
+    ActionPointer action;
     State *next_state;
 
     Transition( const Transition &x )
@@ -58,20 +58,14 @@ namespace Parser {
 
       return *this;
     }
-    virtual ~Transition()
-    {
-      // Indicate to checkers that we don't own *action anymore
-      action = NULL;
-    }
-
-    Transition( Action *s_action=new Ignore, State *s_next_state=NULL )
+    Transition( ActionPointer s_action=shared::make_shared< Ignore >(), State *s_next_state=NULL )
       : action( s_action ), next_state( s_next_state )
     {}
 
     // This is only ever used in the 1-argument form;
     // we use this instead of an initializer to
     // tell Coverity the object never owns *action.
-    Transition( State *s_next_state, Action *s_action=new Ignore )
+    Transition( State *s_next_state, ActionPointer s_action=shared::make_shared< Ignore >() )
       : action( s_action ), next_state( s_next_state )
     {}
   };

--- a/src/tests/encrypt-decrypt.cc
+++ b/src/tests/encrypt-decrypt.cc
@@ -58,11 +58,10 @@ bool verbose = false;
 
 static std::string random_payload( void ) {
   const size_t len = prng.uint32() % MESSAGE_SIZE_MAX;
-  char *buf = new char[len];
+  char buf[ MESSAGE_SIZE_MAX ];
   prng.fill( buf, len );
 
   std::string payload( buf, len );
-  delete [] buf;
   return payload;
 }
 

--- a/src/util/shared.h
+++ b/src/util/shared.h
@@ -52,6 +52,12 @@ namespace shared {
   using std::tr1::shared_ptr;
 
   // make_shared emulation.
+  template<typename Tp>
+    inline shared_ptr<Tp>
+    make_shared()
+  {
+    return shared_ptr<Tp>(new Tp());
+  }
   template<typename Tp, typename A1>
     inline shared_ptr<Tp>
     make_shared(const A1& a1)


### PR DESCRIPTION
These changes nearly eliminate manual memory management (`new`/`delete`, `malloc`/`free`, C strings) from Mosh.  Most of these changes are simplifications and will not be controversial.  There's a couple of places where `unique_ptr`/`scoped_ptr` would be more appropriate.  I used `shared_ptr` instead because the performance impact in those cases was small and `unique_ptr`/`scoped_ptr` are not reliably available in Mosh's C++03/TR1 environment.

The one somewhat-arguable thing is the rework to use `shared_ptr` to track `Action`s.  This change does slow down Mosh's terminal emulator input slightly, current testing suggests by about 20% on high-speed output to mosh-server.  That slowdown should disappear for typical usage, where small updates are much more common. `shared_ptr` is rather heavyweight for this, but since `Action`s are message objects to begin with and don't have a single point of ownership, nothing simpler works.