### PR TITLE
Support for libgcrypt, and external OCB in OpenSSL and libgcrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -346,6 +346,43 @@ case "${with_crypto_library}" in
     ;;
 esac
 
+AC_ARG_WITH(
+  [external-ocb],
+  [AS_HELP_STRING([--with-external-ocb], [Use the OCB implementation from the selected crypto library @<:@no@:>@])],
+  [with_external_ocb="$withval"],
+  [with_external_ocb="no"])
+
+  AS_IF([test x"$with_external_ocb" != xno],
+    [
+      # push LDFLAGS/CFLAGS
+      old_LIBS="$LIBS"
+      old_CFLAGS="$CFLAGS"
+      # modify
+      LIBS="$LIBS $CRYPTO_LIBS"
+      CFLAGS="$CFLAGS $CRYPTO_CFLAGS"
+      # check for OCB
+      case "${with_crypto_library}" in
+	openssl)
+	AC_CHECK_DECL([EVP_aes_128_ocb],
+	  [AC_DEFINE([HAVE_OPENSSL_OCB], [1],
+	     [Define if the OCB AE algorithm is available in OpenSSL.])],
+	  [AS_IF([test x"$with_external_ocb" = xcheck],
+	    [AC_MSG_WARN([Unable to find OCB in OpenSSL.])],
+	    [AC_MSG_ERROR([--with-external-ocb was given but OCB implementation was not found in OpenSSL.])])],
+	  [[#include <openssl/evp.h>]])
+	;;
+	*)
+	  AS_IF([test x"$with_external_ocb" = xcheck],
+	   [AC_MSG_WARN([OCB unavailable in selected crypto library.])],
+	   [AC_MSG_ERROR([--with-external-ocb was given but OCB unavailable in selected crypto library.])])
+	;;
+      esac
+      # restore old LDFLAGS/CPPFLAGS
+      LIBS="$old_LIBS"
+      CFLAGS="$old_CFLAGS"
+    ],[])
+
+
 AC_CHECK_DECL([forkpty],
   [AC_DEFINE([FORKPTY_IN_LIBUTIL], [1],
      [Define if libutil.h necessary for forkpty().])],

--- a/configure.ac
+++ b/configure.ac
@@ -309,10 +309,10 @@ AC_CHECK_HEADERS([CommonCrypto/CommonCrypto.h],
 dnl Allow user to select over the default.
 AC_ARG_WITH(
   [crypto-library],
-  [AS_HELP_STRING([--with-crypto-library=library], [build with the given crypto library, TYPE=openssl|nettle|apple-common-crypto @<:@default=openssl@:>@])],
+  [AS_HELP_STRING([--with-crypto-library=library], [build with the given crypto library, TYPE=openssl|nettle|apple-common-crypto|libgcrypt @<:@default=openssl@:>@])],
   [
     case "${withval}" in
-      openssl|nettle|apple-common-crypto) ;;
+      openssl|nettle|apple-common-crypto|libgcrypt) ;;
       *) AC_MSG_ERROR([bad value ${withval} for --with-crypto-library]) ;;
     esac
   ],
@@ -344,6 +344,16 @@ case "${with_crypto_library}" in
       [AC_MSG_ERROR([Apple Common Crypto header not found])])
     AC_DEFINE([USE_APPLE_COMMON_CRYPTO_AES], [1], [Use Apple Common Crypto library])
     ;;
+  libgcrypt)
+    AC_CHECK_PROG([LIBGCRYPT_CONFIG], [libgcrypt-config], [yes], [no],,)
+    AS_IF([test x"$LIBGCRYPT_CONFIG" = x],
+      [AC_MSG_ERROR([cannot find libgcrypt-config])])
+    CRYPTO_LIBS=`libgcrypt-config --libs`
+    CRYPTO_CFLAGS=`libgcrypt-config --cflags`
+    AC_DEFINE([USE_LIBGCRYPT_AES], [1], [Use gcrypt library])
+    ;;
+  *)
+    AC_MSG_ERROR([Unknown crypto library])
 esac
 
 AC_ARG_WITH(

--- a/configure.ac
+++ b/configure.ac
@@ -381,6 +381,15 @@ AC_ARG_WITH(
 	    [AC_MSG_ERROR([--with-external-ocb was given but OCB implementation was not found in OpenSSL.])])],
 	  [[#include <openssl/evp.h>]])
 	;;
+	libgcrypt)
+	AC_CHECK_DECL([GCRY_CIPHER_MODE_OCB],
+	  [AC_DEFINE([HAVE_LIBGCRYPT_OCB], [1],
+	     [Define if the OCB AE algorithm is available in libgcrypt.])],
+	  [AS_IF([test x"$with_external_ocb" = xcheck],
+	    [AC_MSG_WARN([Unable to find OCB in libgcrypt.])],
+	    [AC_MSG_ERROR([--with-external-ocb was given but OCB implementation was not found in libgcrypt.])])],
+	  [[#include <gcrypt.h>]])
+	;;
 	*)
 	  AS_IF([test x"$with_external_ocb" = xcheck],
 	   [AC_MSG_WARN([OCB unavailable in selected crypto library.])],

--- a/src/crypto/ae.h
+++ b/src/crypto/ae.h
@@ -55,13 +55,9 @@ typedef struct _ae_ctx ae_ctx;
  *
  * ----------------------------------------------------------------------- */
 
-ae_ctx* ae_allocate  (void *misc);  /* Allocate ae_ctx, set optional ptr   */
-void    ae_free      (ae_ctx *ctx); /* Deallocate ae_ctx struct            */
 int     ae_clear     (ae_ctx *ctx); /* Undo initialization                 */
 int     ae_ctx_sizeof(void);        /* Return sizeof(ae_ctx)               */
-/* ae_allocate() allocates an ae_ctx structure, but does not initialize it.
- * ae_free() deallocates an ae_ctx structure, but does not zeroize it.
- * ae_clear() zeroes sensitive values associated with an ae_ctx structure
+/* ae_clear() zeroes sensitive values associated with an ae_ctx structure
  * and deallocates any auxiliary structures allocated during ae_init().
  * ae_ctx_sizeof() returns sizeof(ae_ctx), to aid in any static allocations.
  */

--- a/src/crypto/ocb.cc
+++ b/src/crypto/ocb.cc
@@ -45,6 +45,10 @@
 /* Set the AES key length to use and length of authentication tag to produce.
 /  Setting either to 0 requires the value be set at runtime via ae_init().
 /  Some optimizations occur for each when set to a fixed value.            */
+/*
+ * These values were adjustable in the original Rogaway/Krovetz code,
+ * but not in Mosh.
+ */
 #define OCB_KEY_LEN         16  /* 0, 16, 24 or 32. 0 means set in ae_init */
 #define OCB_TAG_LEN         16  /* 0 to 16. 0 means set in ae_init         */
 


### PR DESCRIPTION
This supersedes #790.

It adds support for libgcrypt's AES implementation.  It also supports the OCB implementations in libgcrypt and OpenSSL 1.1+, in place of the bundled Rogaway/Krovetz implementation.  There's autoconf support for all these permutations.  Unlike #790, the autoconf code defaults to the current behavior, and libgcrypt and/or external OCB must be manually selected.

The external-OCB support is done by adding shims that support the `ae_encrypt`/`ae_decrypt` API presented by the bundled code.  The shims are incomplete and do not support the full range of possible OCB encryption/decryption actions available in that API, or the full range of OCB cipher configurations.  However, they do support the straightforward OCB requests that Mosh makes, and likely many of the requests that other practical OCB-using programs will make.  The code passes all of Mosh's OCB tests, but does not pass the Krovetz/Rogaway test code at the bottom of `src/crypto/ocb.cc`.  I think this code might be useful for other projects even if Mosh never uses it.

The libgcrypt support has seen some testing on Linux, FreeBSD, and macOS.  The OpenSSL OCB code has only been tested on FreeBSD and needs verification on other platforms, once they take up OpenSSL 1.1+ more seriously.  So this is not yet really ready to pull into Mosh.