### PR TITLE
Add Perl compile

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -5,5 +5,6 @@ endif
 CLEANFILES = $(bin_SCRIPTS)
 
 mosh:	mosh.pl ../VERSION Makefile
+	perl -Mdiagnostics -c $(srcdir)/mosh.pl
 	@sed -e "s/\@VERSION\@/`cat ../VERSION`/" -e "s/\@PACKAGE_STRING\@/@PACKAGE_STRING@/" $(srcdir)/mosh.pl > mosh
 	@chmod a+x mosh


### PR DESCRIPTION
This helps catch Perl syntax/version/dependency issues at build time
rather than run time.  Addresses the issue brought up in #935.