### PR TITLE
Improved Unicode character width support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/unicode/google-libapps"]
+	path = src/unicode/google-libapps
+	url = https://chromium.googlesource.com/apps/libapps

--- a/configure.ac
+++ b/configure.ac
@@ -505,6 +505,7 @@ AC_CONFIG_FILES([
   src/protobufs/Makefile
   src/statesync/Makefile
   src/terminal/Makefile
+  src/unicode/Makefile
   src/util/Makefile
   scripts/Makefile
   src/examples/Makefile

--- a/man/mosh.1
+++ b/man/mosh.1
@@ -262,6 +262,13 @@ This option ignores any configuration in
 .B ssh_config
 for the same hostname.
 
+.TP
+.B \-\-widths\-file=\fIFILENAME\fP
+If this option is given, Mosh will load a Unicode character width
+table from the given file.  Otherwise, it defaults to
+"~/.mosh-widths".  This feature is currently under development and
+underdocumented.
+
 .SH ESCAPE SEQUENCES
 
 The default escape character used by Mosh is ASCII RS (decimal 30).

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = protobufs util crypto terminal network statesync frontend examples tests
+SUBDIRS = protobufs util crypto terminal network statesync frontend examples tests unicode

--- a/src/examples/Makefile.am
+++ b/src/examples/Makefile.am
@@ -15,11 +15,11 @@ decrypt_LDADD = ../crypto/libmoshcrypto.a $(CRYPTO_LIBS)
 
 parse_SOURCES = parse.cc
 parse_CPPFLAGS = -I$(srcdir)/../terminal -I$(srcdir)/../util
-parse_LDADD = ../terminal/libmoshterminal.a ../util/libmoshutil.a
+parse_LDADD = ../terminal/libmoshterminal.a ../util/libmoshutil.a ../network/libmoshnetwork.a
 
 termemu_SOURCES = termemu.cc
 termemu_CPPFLAGS = -I$(srcdir)/../terminal -I$(srcdir)/../util -I$(srcdir)/../statesync -I../protobufs
-termemu_LDADD = ../terminal/libmoshterminal.a ../util/libmoshutil.a ../statesync/libmoshstatesync.a ../protobufs/libmoshprotos.a $(TINFO_LIBS) $(protobuf_LIBS)
+termemu_LDADD = ../terminal/libmoshterminal.a ../util/libmoshutil.a ../statesync/libmoshstatesync.a ../protobufs/libmoshprotos.a ../network/libmoshnetwork.a $(TINFO_LIBS) $(protobuf_LIBS)
 
 ntester_SOURCES = ntester.cc
 ntester_CPPFLAGS = -I$(srcdir)/../util -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I$(srcdir)/../network -I$(srcdir)/../crypto -I../protobufs $(protobuf_CFLAGS)

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -88,6 +88,7 @@
 #include "select.h"
 #include "timestamp.h"
 #include "fatal_assert.h"
+#include "chwidth.h"
 
 #ifndef _PATH_BSHELL
 #define _PATH_BSHELL "/bin/sh"
@@ -364,6 +365,9 @@ int main( int argc, char *argv[] )
     }
   }
 
+  /* Set initial chwidth table to fixed base. */
+  chwidth_set_base( chwidth_get_reference() );
+  
   try {
     return run_server( desired_ip, desired_port, command_path, command_argv, colors, verbose, with_motd );
   } catch ( const Network::NetworkException &e ) {

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -51,6 +51,8 @@
 #include <util.h>
 #endif
 
+#include "chwidth.h"
+#include "compressor.h"
 #include "stmclient.h"
 #include "swrite.h"
 #include "completeterminal.h"
@@ -256,6 +258,17 @@ void STMClient::main_init( void )
 
   /* tell server the size of the terminal */
   network->get_current_state().push_back( Parser::Resize( window_size.ws_col, window_size.ws_row ) );
+
+  /* Set up the chwidth table-- first install the current default table, then apply the user's overlay. */
+  chwidth_set_base( chwidth_get_default() );
+  chwidth_set_overlay( chwidth_table );
+  /* Now generate the network overlay for the server (generated from the fixed base and the working table) */
+  // XXX handle/remove CryptoException
+  string network_overlay = chwidth_make_overlay( chwidth_get_reference(), chwidth_get_working() );
+  /* send server the wcwidth overlay */
+  network->get_current_state().
+    push_back( Parser::ChWidthOverlay( get_compressor().compress_str( network_overlay ) ) );
+
 
   /* be noisy as necessary */
   network->set_verbose( verbose );

--- a/src/frontend/stmclient.h
+++ b/src/frontend/stmclient.h
@@ -59,6 +59,8 @@ private:
 
   struct winsize window_size;
 
+  const std::string &chwidth_table;
+
   Terminal::Framebuffer local_framebuffer, new_state;
   Overlay::OverlayManager overlays;
   typedef Network::Transport< Network::UserStream, Terminal::Complete > NetworkType;
@@ -87,13 +89,14 @@ private:
   void resume( void ); /* restore state after SIGCONT */
 
 public:
-  STMClient( const char *s_ip, const char *s_port, const char *s_key, const char *predict_mode, unsigned int s_verbose, const char *predict_overwrite )
+  STMClient( const char *s_ip, const char *s_port, const char *s_key, const char *predict_mode, unsigned int s_verbose, const char *predict_overwrite, const std::string &chwidths )
     : ip( s_ip ? s_ip : "" ), port( s_port ? s_port : "" ),
     key( s_key ? s_key : "" ),
     escape_key( 0x1E ), escape_pass_key( '^' ), escape_pass_key2( '^' ),
     escape_requires_lf( false ), escape_key_help( L"?" ),
       saved_termios(), raw_termios(),
       window_size(),
+      chwidth_table( chwidths ),
       local_framebuffer( 1, 1 ),
       new_state( 1, 1 ),
       overlays(),

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -36,6 +36,7 @@
 #include <typeinfo>
 #include <limits.h>
 
+#include "chwidth.h"
 #include "terminaloverlay.h"
 
 using namespace Overlay;
@@ -264,10 +265,10 @@ void NotificationEngine::apply( Framebuffer &fb ) const
     }
 
     wchar_t ch = *i;
-    int chwidth = ch == L'\0' ? -1 : wcwidth( ch );
+    int width = ch == L'\0' ? -1 : chwidth( ch );
     Cell *this_cell = 0;
 
-    switch ( chwidth ) {
+    switch ( width ) {
     case 1: /* normal character */
     case 2: /* wide character */
       this_cell = fb.get_mutable_cell( 0, overlay_col );
@@ -277,10 +278,10 @@ void NotificationEngine::apply( Framebuffer &fb ) const
       this_cell->get_renditions().set_background_color( 4 );
       
       this_cell->append( ch );
-      this_cell->set_wide( chwidth == 2 );
+      this_cell->set_wide( width == 2 );
       combining_cell = this_cell;
 
-      overlay_col += chwidth;
+      overlay_col += width;
       break;
     case 0: /* combining character */
       if ( !combining_cell ) {
@@ -735,7 +736,7 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer &fb )
 	    }
 	  }
 	}
-      } else if ( (ch < 0x20) || (wcwidth( ch ) != 1) ) {
+      } else if ( (ch < 0x20) || (chwidth( ch ) != 1) ) {
 	/* unknown print */
 	become_tentative();
 	//	fprintf( stderr, "Unknown print 0x%x\n", ch );

--- a/src/protobufs/userinput.proto
+++ b/src/protobufs/userinput.proto
@@ -21,7 +21,13 @@ message ResizeMessage {
   optional int32 height = 6;
 }
 
+message ChWidthOverlayMessage {
+  optional int32 version = 8;
+  optional bytes overlay = 9;
+}
+
 extend Instruction {
   optional Keystroke keystroke = 2;
   optional ResizeMessage resize = 3;
+  optional ChWidthOverlayMessage overlay = 7;
 }

--- a/src/statesync/user.cc
+++ b/src/statesync/user.cc
@@ -94,6 +94,13 @@ string UserStream::diff_from( const UserStream &existing ) const
 	new_inst->MutableExtension( resize )->set_height( my_it->resize.height );
       }
       break;
+    case ChWidthOverlayType:
+      {
+	  Instruction *new_inst = output.add_instruction();
+	  new_inst->MutableExtension( overlay )->set_version( chwidth_version );
+	  new_inst->MutableExtension( overlay )->set_overlay( my_it->overlay.overlay );
+	}
+      break;
     default:
       assert( !"unexpected event type" );
       break;
@@ -119,6 +126,10 @@ void UserStream::apply_string( const string &diff )
     } else if ( input.instruction( i ).HasExtension( resize ) ) {
       actions.push_back( UserEvent( Resize( input.instruction( i ).GetExtension( resize ).width(),
 					    input.instruction( i ).GetExtension( resize ).height() ) ) );
+    } else if ( input.instruction( i ).HasExtension( overlay ) ) {
+      if ( input.instruction( i ).GetExtension( overlay ).version() == chwidth_version ) {
+	actions.push_back( UserEvent( ChWidthOverlay( input.instruction( i ).GetExtension( overlay ).overlay() ) ) );
+      }
     }
   }
 }
@@ -130,6 +141,8 @@ const Parser::Action &UserStream::get_action( unsigned int i ) const
     return actions[ i ].userbyte;
   case ResizeType:
     return actions[ i ].resize;
+  case ChWidthOverlayType:
+    return actions[ i ].overlay;
   default:
     assert( !"unexpected action type" );
     static const Parser::Ignore nothing = Parser::Ignore();

--- a/src/statesync/user.h
+++ b/src/statesync/user.h
@@ -47,8 +47,10 @@ using std::string;
 namespace Network {
   enum UserEventType {
     UserByteType = 0,
-    ResizeType = 1
+    ResizeType = 1,
+    ChWidthOverlayType = 2
   };
+  static const unsigned int chwidth_version = 0; // XXX change before commit to master
 
   class UserEvent
   {
@@ -56,9 +58,11 @@ namespace Network {
     UserEventType type;
     Parser::UserByte userbyte;
     Parser::Resize resize;
+    Parser::ChWidthOverlay overlay;
 
-    UserEvent( const Parser::UserByte & s_userbyte ) : type( UserByteType ), userbyte( s_userbyte ), resize( -1, -1 ) {}
-    UserEvent( const Parser::Resize & s_resize ) : type( ResizeType ), userbyte( 0 ), resize( s_resize ) {}
+    UserEvent( const Parser::UserByte & s_userbyte ) : type( UserByteType ), userbyte( s_userbyte ), resize( -1, -1 ), overlay( "" ) {}
+    UserEvent( const Parser::Resize & s_resize ) : type( ResizeType ), userbyte( 0 ), resize( s_resize ), overlay( "" ) {}
+    UserEvent( const Parser::ChWidthOverlay & s_overlay ) : type( ChWidthOverlayType ), userbyte( 0 ), resize( -1, -1 ), overlay( s_overlay ) {}
 
   private:
     UserEvent();
@@ -77,6 +81,7 @@ namespace Network {
     
     void push_back( const Parser::UserByte & s_userbyte ) { actions.push_back( UserEvent( s_userbyte ) ); }
     void push_back( const Parser::Resize & s_resize ) { actions.push_back( UserEvent( s_resize ) ); }
+    void push_back( const Parser::ChWidthOverlay & s_overlay ) { actions.push_back( UserEvent( s_overlay ) ); }
     
     bool empty( void ) const { return actions.empty(); }
     size_t size( void ) const { return actions.size(); }

--- a/src/terminal/Makefile.am
+++ b/src/terminal/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I$(srcdir)/../util $(TINFO_CFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/../util -I$(srcdir)/../crypto -I$(srcdir)/../network $(TINFO_CFLAGS)
 AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) $(HARDEN_CFLAGS) $(MISC_CXXFLAGS)
 
 noinst_LIBRARIES = libmoshterminal.a

--- a/src/terminal/parseraction.cc
+++ b/src/terminal/parseraction.cc
@@ -103,7 +103,13 @@ void Resize::act_on_terminal( Terminal::Emulator *emu ) const
 void ChWidthOverlay::act_on_terminal( Terminal::Emulator *emu ) const
 {
   // XXX handle/remove CryptoException
-  emu->chwidth_overlay( Network::get_compressor().
-			uncompress_str( overlay ));
+  Network::Compressor & compressor = Network::get_compressor();
+  std::string unpacked = compressor.uncompress_str( overlay );
+  std::string packed2 = compressor.compress_str( overlay );
+  emu->chwidth_overlay( unpacked );
+  fprintf( stderr, "chwidth overlay size = %llu compress1 = %llu compress2 = %llu\n",
+	   static_cast<unsigned long long>(unpacked.size() ),
+	   static_cast<unsigned long long>(overlay.size() ),
+	   static_cast<unsigned long long>(packed2.size() ) );
 }
 

--- a/src/terminal/parseraction.cc
+++ b/src/terminal/parseraction.cc
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <wctype.h>
 
+#include "compressor.h"
 #include "parseraction.h"
 #include "terminal.h"
 
@@ -98,3 +99,11 @@ void Resize::act_on_terminal( Terminal::Emulator *emu ) const
 {
   emu->resize( width, height );
 }
+
+void ChWidthOverlay::act_on_terminal( Terminal::Emulator *emu ) const
+{
+  // XXX handle/remove CryptoException
+  emu->chwidth_overlay( Network::get_compressor().
+			uncompress_str( overlay ));
+}
+

--- a/src/terminal/parseraction.h
+++ b/src/terminal/parseraction.h
@@ -161,6 +161,21 @@ namespace Parser {
       return ( width == other.width ) && ( height == other.height );
     }
   };
+  class ChWidthOverlay : public Action {
+    /* chwidth overlay string -- not part of the host-source state machine*/
+  public:
+    std::string overlay; /* The user-source byte. We don't try to interpret the charset */
+
+    std::string name( void ) { return std::string( "ChWidthOverlay" ); }
+    void act_on_terminal( Terminal::Emulator *emu ) const;
+
+    ChWidthOverlay( const std::string& d ) : overlay( d ) {}
+
+    bool operator==( const ChWidthOverlay &other ) const
+    {
+      return overlay == other.overlay;
+    }
+  };
 }
 
 #endif

--- a/src/terminal/terminal.cc
+++ b/src/terminal/terminal.cc
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <typeinfo>
 
+#include "chwidth.h"
 #include "terminal.h"
 
 using namespace Terminal;
@@ -66,11 +67,11 @@ void Emulator::print( const Parser::Print *act )
    * Check for printing ISO 8859-1 first, it's a cheap way to detect
    * some common narrow characters.
    */
-  const int chwidth = ch == L'\0' ? -1 : ( Cell::isprint_iso8859_1( ch ) ? 1 : wcwidth( ch ));
+  const int width = ch == L'\0' ? -1 : ( Cell::isprint_iso8859_1( ch ) ? 1 : chwidth( ch ));
 
   Cell *this_cell = fb.get_mutable_cell();
 
-  switch ( chwidth ) {
+  switch ( width ) {
   case 1: /* normal character */
   case 2: /* wide character */
     if ( fb.ds.auto_wrap_mode && fb.ds.next_print_will_wrap ) {
@@ -79,7 +80,7 @@ void Emulator::print( const Parser::Print *act )
       fb.move_rows_autoscroll( 1 );
       this_cell = NULL;
     } else if ( fb.ds.auto_wrap_mode
-		&& (chwidth == 2)
+		&& (width == 2)
 		&& (fb.ds.get_cursor_col() == fb.ds.get_width() - 1) ) {
       /* wrap 2-cell chars if no room, even without will-wrap flag */
       fb.reset_cell( this_cell );
@@ -94,7 +95,7 @@ void Emulator::print( const Parser::Print *act )
     }
 
     if ( fb.ds.insert_mode ) {
-      for ( int i = 0; i < chwidth; i++ ) {
+      for ( int i = 0; i < width; i++ ) {
 	fb.insert_cell( fb.ds.get_cursor_row(), fb.ds.get_cursor_col() );
       }
       this_cell = NULL;
@@ -106,15 +107,15 @@ void Emulator::print( const Parser::Print *act )
 
     fb.reset_cell( this_cell );
     this_cell->append( ch );
-    this_cell->set_wide( chwidth == 2 ); /* chwidth had better be 1 or 2 here */
+    this_cell->set_wide( width == 2 ); /* width had better be 1 or 2 here */
     fb.apply_renditions_to_cell( this_cell );
 
-    if ( chwidth == 2
+    if ( width == 2
       && fb.ds.get_cursor_col() + 1 < fb.ds.get_width() ) { /* erase overlapped cell */
       fb.reset_cell( fb.get_mutable_cell( fb.ds.get_cursor_row(), fb.ds.get_cursor_col() + 1 ) );
     }
 
-    fb.ds.move_col( chwidth, true, true );
+    fb.ds.move_col( width, true, true );
 
     break;
   case 0: /* combining character */
@@ -174,6 +175,11 @@ void Emulator::Esc_dispatch( const Parser::Esc_Dispatch *act )
 void Emulator::resize( size_t s_width, size_t s_height )
 {
   fb.resize( s_width, s_height );
+}
+
+void Emulator::chwidth_overlay( const std::string& diff )
+{
+  fb.chwidth_overlay( diff );
 }
 
 bool Emulator::operator==( Emulator const &x ) const

--- a/src/terminal/terminal.h
+++ b/src/terminal/terminal.h
@@ -59,6 +59,7 @@ namespace Terminal {
 
     friend void Parser::UserByte::act_on_terminal( Emulator * ) const;
     friend void Parser::Resize::act_on_terminal( Emulator * ) const;
+    friend void Parser::ChWidthOverlay::act_on_terminal( Emulator * ) const;
 
   private:
     Framebuffer fb;
@@ -72,6 +73,7 @@ namespace Terminal {
     void Esc_dispatch( const Parser::Esc_Dispatch *act );
     void OSC_end( const Parser::OSC_End *act );
     void resize( size_t s_width, size_t s_height );
+    void chwidth_overlay ( const std::string& diff );
 
   public:
     Emulator( size_t s_width, size_t s_height );

--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "chwidth.h"
 #include "terminalframebuffer.h"
 
 using namespace Terminal;
@@ -65,6 +66,7 @@ void DrawState::reinitialize_tabs( unsigned int start )
 
 DrawState::DrawState( int s_width, int s_height )
   : width( s_width ), height( s_height ),
+    chwidthoverlay(),
     cursor_col( 0 ), cursor_row( 0 ),
     combining_char_col( 0 ), combining_char_row( 0 ), default_tabs( true ), tabs( s_width ),
     scrolling_region_top_row( 0 ), scrolling_region_bottom_row( height - 1 ),
@@ -451,6 +453,16 @@ void DrawState::resize( int s_width, int s_height )
        || (combining_char_row >= height) ) {
     combining_char_col = combining_char_row = -1;
   }
+}
+
+void DrawState::chwidth_overlay( const std::string& s_overlay )
+{
+  if ( chwidthoverlay != s_overlay )
+    {
+      chwidth_set_base( chwidth_get_reference() );
+      chwidth_set_overlay( s_overlay ); // XXX handle error
+      chwidthoverlay = s_overlay;
+    }
 }
 
 Renditions::Renditions( color_type s_background )

--- a/src/terminal/terminalframebuffer.h
+++ b/src/terminal/terminalframebuffer.h
@@ -257,6 +257,10 @@ namespace Terminal {
   private:
     int width, height;
 
+    // XXX this should be a hash, or a reference/smartptr
+    // to a shared string
+    std::string chwidthoverlay;
+
     void new_grapheme( void );
     void snap_cursor_to_border( void );
 
@@ -342,6 +346,8 @@ namespace Terminal {
     void clear_saved_cursor( void ) { save = SavedCursor(); }
 
     void resize( int s_width, int s_height );
+
+    void chwidth_overlay( const std::string& overlay );
 
     DrawState( int s_width, int s_height );
 
@@ -460,6 +466,11 @@ namespace Terminal {
     void prefix_window_title( const title_type &s );
 
     void resize( int s_width, int s_height );
+
+    void chwidth_overlay( const std::string& overlay )
+    {
+      ds.chwidth_overlay( overlay );
+    }
 
     void reset_cell( Cell *c ) { c->reset( ds.get_background_rendition() ); }
     void reset_row( Row *r ) { r->reset( ds.get_background_rendition() ); }

--- a/src/tests/e2e-test
+++ b/src/tests/e2e-test
@@ -207,7 +207,7 @@ for run in $server_tests; do
     export MOSH_SERVER="$PWD/../frontend/mosh-server"
     export MOSH_E2E_TEST="$PWD/${test_dir}/${run}"
     # XXX need to quote special chars in server pathname here somehow
-    sut="../../scripts/mosh --client=${srcdir}/mosh-client --server=${srcdir}/mosh-server --local --bind-server=127.0.0.1 ${mosh_args} 127.0.0.1"
+    sut="../../scripts/mosh --client=${srcdir}/mosh-client --server=${srcdir}/mosh-server --local --bind-server=127.0.0.1 --widths-file=/dev/null ${mosh_args} 127.0.0.1"
     if [ "$run" = "direct" ]; then
 	sut=""
     fi

--- a/src/tests/unicode-later-combining.test
+++ b/src/tests/unicode-later-combining.test
@@ -5,6 +5,10 @@
 # page, a combining character drawn on a cell after returning the
 # cursor to that cell.
 #
+# We print 'COMBINING CIRCUMFLEX ACCENT' (U+0302) onto an unused cell.
+# We expect Mosh to output U+0020, U+0302 for that character cell (or
+# possibly U+00A0, U+0302).
+#
 # XXX This test is fragile because it depends on tmux's unicode rendering.
 # The baseline and variant tests produce different (but valid) outputs
 # that are visually identical.  The variant test is not run or validated.

--- a/src/unicode/Makefile.am
+++ b/src/unicode/Makefile.am
@@ -1,0 +1,34 @@
+EXTRA_DIST = \
+	make_widths.py edit_widths.py
+
+CLEANFILES = UCD.zip UnicodeData.txt PropList.txt EastAsianWidth.txt
+
+noinst_SCRIPTS=make_widths.py
+
+# This is a set of developer-only targets for rebuilding Unicode
+# information in Mosh.
+# They're not intended to be run as part of normal automake processing.
+# Dependencies which must be provided manually: git python3 unzip
+
+UCD.zip:
+	curl -O https://www.unicode.org/Public/10.0.0/ucd/UCD.zip
+
+google-libapps/libdot/third_party/wcwidth/ranges.py:
+	git submodule init
+	git submodule update
+
+ucd/PropList.txt ucd/UnicodeData.txt ucd/EastAsianWidth.txt: UCD.zip
+	mkdir -p ucd
+	unzip -D -o -d ucd UCD.zip
+	ln -fs ucd/PropList.txt ucd/UnicodeData.txt ucd/EastAsianWidth.txt .
+
+eaw_narrow_map eaw_wide_map: ucd/PropList.txt ucd/UnicodeData.txt ucd/EastAsianWidth.txt make_widths.py google-libapps/libdot/third_party/wcwidth/ranges.py
+	PYTHONPATH=$(PWD)/google-libapps/libdot/third_party/wcwidth/ python3 -Bs ./make_widths.py --narrow-table=eaw_narrow_map --wide-table=eaw_wide_map
+
+edit-tables: eaw_narrow_map edit_widths.py
+	python3 ./edit_widths.py ./eaw_narrow_map ../util/chwidth_tables.cc chwidth_default_table
+
+clean-local: clean-local-check
+.PHONY: clean-local-check
+clean-local-check:
+	rm -rf ucd/

--- a/src/unicode/edit_widths.py
+++ b/src/unicode/edit_widths.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#   Mosh: the mobile shell
+#   Copyright 2017 Keith Winstein
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#   In addition, as a special exception, the copyright holders give
+#   permission to link the code of portions of this program with the
+#   OpenSSL library under certain conditions as described in each
+#   individual source file, and distribute linked combinations including
+#   the two.
+#
+#   You must obey the GNU General Public License in all respects for all
+#   of the code used other than OpenSSL. If you modify file(s) with this
+#   exception, you may extend this exception to your version of the
+#   file(s), but you are not obligated to do so. If you do not wish to do
+#   so, delete this exception statement from your version. If you delete
+#   this exception statement from all source files in the program, then
+#   also delete it here.
+
+"""Helper for editing width tables into Mosh source
+
+Takes three arguments: input map file, output C++ source file, and
+array name.  Replaces the contents of the named array in the C++
+source with the input map file.
+"""
+
+# Library modules
+import argparse
+import codecs
+import re
+import sys
+
+# The entire Unicode space is defined as [0..10ffff].
+unicode_codespace = 0x110000
+
+def main(argv):
+    if len(argv) != 3:
+        sys.stderr.write("error:  need 3 args\n")
+        raise Exception
+
+    (mapfile, sourcefile, table_name) = argv
+
+    basemap = None
+    with codecs.open(mapfile, encoding='ascii') as f:
+        basemap = bytearray(f.read(), 'ascii')
+
+    # XXX allow smaller?
+    if len(basemap) != unicode_codespace:
+        sys.stderr.write("error: bad length for map\n")
+        raise Exception
+
+    # Generate a new table as a string.
+    lines = "%s[] =\n" % table_name + "{\n"
+    for i in range(0, unicode_codespace, 32):
+        lines += '    ' + ",".join([str(i) for i in basemap[i:i+32]]) + ','
+        if i % 256 == 0:
+            lines += " // {:06x}".format(i)
+        lines += "\n"
+    lines += "};\n"
+    text=''
+    # Edit chwidths.cc with the new table.
+    with open(sourcefile, 'r') as f:
+        text = f.read()
+    (text, count) = re.subn(r'%s\[\]\s*=\s*\{.*?\};\s*$' % table_name,
+                            lines,
+                            text,
+                            flags = re.MULTILINE|re.DOTALL)
+    if count == 0:
+        print ("substitute failed")
+        raise Exception
+    with open(sourcefile, 'w') as f:
+        f.write(text)
+
+    return None
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/src/unicode/make_widths.py
+++ b/src/unicode/make_widths.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#   Mosh: the mobile shell
+#   Copyright 2017 Keith Winstein
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#   In addition, as a special exception, the copyright holders give
+#   permission to link the code of portions of this program with the
+#   OpenSSL library under certain conditions as described in each
+#   individual source file, and distribute linked combinations including
+#   the two.
+#
+#   You must obey the GNU General Public License in all respects for all
+#   of the code used other than OpenSSL. If you modify file(s) with this
+#   exception, you may extend this exception to your version of the
+#   file(s), but you are not obligated to do so. If you do not wish to do
+#   so, delete this exception statement from your version. If you delete
+#   this exception statement from all source files in the program, then
+#   also delete it here.
+
+"""Helper for generating width tables for Mosh, from Unicode data
+files.
+
+Since the Google hterm/nassh projects have already done the hard work
+of figuring out what a Unicode wcwidth table should be, we stand on
+their shoulders to generate our Unicode widths table.
+
+The libapps distribution includes a JS reimplementation of the Markus
+Kuhn wcwidth implementation, which uses binary-search tables, and can
+regenerate them from Unicode source data files.
+
+This script takes the binary-search tables, transforms them into a
+useful form for Mosh, and in turn edits src/utils/chwidth_tables.cc to
+bring it up to date.
+
+"""
+
+# Library modules
+import argparse
+import re
+import sys
+
+# Unicode data from Google libapps
+import ranges
+
+# The entire Unicode space is defined as [0..10ffff].
+unicode_codespace = 0x110000
+
+
+valid_planes = [
+    [0x0000, 0x14fff],
+    [0x16000, 0x18fff],
+    [0x1b000, 0x1bfff],
+    [0x1d000, 0x2ffff],
+    [0xe0000, 0x10ffff],
+];
+
+# Invalid code points for UTF-8 wcwidth.
+# Mosh doesn't support combining surrogate code points encoded in
+# UTF-8.  It'll inevitably happen somewhere.
+invalid_code_points = [
+    [0, 0x1f], # controls
+    [0x7f, 0x9f], # DEL + 8 bit controls
+    [0xd800, 0xdfff], # surrogate code points
+];
+
+# Write a list of ranges onto a flat bytemap.
+def apply_table_to_map(map, table, width):
+    byte = ord(width)
+    for pair in table:
+        (first, last) = pair
+        for i in range(first, last + 1):
+            map[i] = byte
+
+def compose_base_set(uni_db):
+    all = set()
+    for i in uni_db:
+        all |= uni_db[i]
+    return all
+
+def main(argv):
+    argparser  = argparse.ArgumentParser(description='Generate Mosh character maps from Unicode data files')
+    argparser.add_argument('--narrow-table',
+                           help='Name for normal (ambiguous-narrow) map output file',
+                           default='eaw_narrow_map')
+    argparser.add_argument('--wide-table',
+                           help='Name for wide (ambiguous-wide) map output file',
+                           default='eaw_wide_map')
+    opts = argparser.parse_args(argv)
+
+    prop_db = ranges.load_proplist()
+    uni_db = ranges.load_unicode_data()
+    cjk_db = ranges.load_east_asian()
+
+    codepoints = ranges.gen_table(compose_base_set(uni_db))
+    combining = ranges.gen_combining(uni_db, prop_db)
+    east_asian = ranges.gen_east_asian(cjk_db)
+    east_asian_ambiguous = ranges.gen_east_asian_ambiguous(cjk_db)
+
+    # This set of overlays should result in a wcwidth map identical to
+    # libdot's, except that undefined codepoints return -1, not 1.
+    basemap = bytearray(b'-' * unicode_codespace)
+    apply_table_to_map(basemap, codepoints, '1')
+    apply_table_to_map(basemap, east_asian, '2')
+    apply_table_to_map(basemap, combining, '0')
+
+    # The following are Mosh overlays that diverge from libdot.
+
+    # In our wcwidth(), control and surrogate codepoints are invalid
+    # characters.
+    apply_table_to_map(basemap, invalid_code_points, '-')
+    # hterm's tables have SOFT HYPHEN as width 0, but most terminal emulators
+    # use width 1.
+    # basemap[0x00AD] = ord('1')
+
+    # Apple sets the PUA to width 1, and SPUA-A/SPUA-B to width 2.
+    # This seems reasonable and more useful then setting them to 0.
+    apply_table_to_map(basemap, [[0xe800, 0xf7ff]], '1')
+    apply_table_to_map(basemap,
+                       [[0x0f0000, 0x0ffffd], [0x100000, 0x10fffd]],
+                       '2')
+
+    # And this is the east asian width overlay from libdot.
+    eawwidemap = basemap.copy()
+    apply_table_to_map(eawwidemap, east_asian_ambiguous, '2')
+
+    with open(opts.narrow_table, 'w') as f:
+        f.write(basemap.decode())
+
+    with open(opts.wide_table, 'w') as f:
+        f.write(eawwidemap.decode())
+
+    return None
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -2,4 +2,4 @@ AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) $(HARDEN_CFLAGS) $(MISC_CXXF
 
 noinst_LIBRARIES = libmoshutil.a
 
-libmoshutil_a_SOURCES = locale_utils.cc locale_utils.h swrite.cc swrite.h dos_assert.h fatal_assert.h select.h select.cc timestamp.h timestamp.cc pty_compat.cc pty_compat.h shared.h
+libmoshutil_a_SOURCES = locale_utils.cc locale_utils.h swrite.cc swrite.h dos_assert.h fatal_assert.h select.h select.cc timestamp.h timestamp.cc pty_compat.cc pty_compat.h shared.h chwidth.cc chwidth.h chwidth_tables.cc

--- a/src/util/chwidth.cc
+++ b/src/util/chwidth.cc
@@ -1,0 +1,131 @@
+/*
+    Mosh: the mobile shell
+    Copyright 2017 Keith Winstein
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    In addition, as a special exception, the copyright holders give
+    permission to link the code of portions of this program with the
+    OpenSSL library under certain conditions as described in each
+    individual source file, and distribute linked combinations including
+    the two.
+
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do
+    so, delete this exception statement from your version. If you delete
+    this exception statement from all source files in the program, then
+    also delete it here.
+*/
+
+#include "config.h"
+
+#include <chwidth.h>
+
+static std::string& get_widths( void )
+{
+  static std::string widths( chwidth_reference_table );
+  return widths;
+}
+
+void chwidth_set_base( const std::string& new_widths )
+{
+  std::string& widths = get_widths();
+  widths = new_widths;
+}
+
+bool chwidth_set_overlay( const std::string& overlay )
+{
+  std::string& widths = get_widths();
+  std::string workingwidths( widths );
+  std::string::const_iterator ib = overlay.begin();
+  std::string::const_iterator ie = overlay.end();
+  for ( std::string::const_iterator i = ib; i < ie; i++ ) {
+    switch( *i ) {
+    case '=':
+      continue;
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+      {
+	size_t ix = i - ib;
+	if ( ix < workingwidths.size()) {
+	  workingwidths.at( ix ) = *i;
+	} else {
+	  return false;
+	}
+      }
+      break;
+    // XXX 'u': ?
+    default:
+      return false;
+    }
+  }
+  widths = workingwidths;
+  return true;
+}
+
+std::string chwidth_make_overlay( const std::string& base, const std::string& update )
+{
+  size_t overlaylen = std::min( base.size(), update.size());
+  std::string overlay;
+  overlay.reserve( overlaylen );
+  for ( size_t i = 0; i < overlaylen; i++ ) {
+    char b = base.at( i );
+    char u = update.at( i );
+    if ( b == u ) {
+      overlay.push_back( '=' );
+    } else {
+      overlay.push_back( u );
+    }
+  }
+  return overlay;
+}
+
+int chwidth( wchar_t wc )
+{
+  const std::string& widths = get_widths();
+  if (static_cast<size_t>( wc) > widths.size()) {
+    return -1;
+  }
+  char ch = widths.at( wc );
+  switch ( ch ) {
+  case '0':
+    return 0;
+  case '1':
+    return 1;
+  case '2':
+    return 2;
+  case '-':
+  default:
+    return -1;
+  }
+}
+
+const char* chwidth_get_reference( void )
+{
+  return chwidth_reference_table;
+}
+
+const char* chwidth_get_default( void )
+{
+  return chwidth_default_table;
+}
+
+std::string chwidth_get_working(  void )
+{
+  return get_widths();
+}

--- a/src/util/chwidth.h
+++ b/src/util/chwidth.h
@@ -1,0 +1,62 @@
+/*
+    Mosh: the mobile shell
+    Copyright 2017 Keith Winstein
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    In addition, as a special exception, the copyright holders give
+    permission to link the code of portions of this program with the
+    OpenSSL library under certain conditions as described in each
+    individual source file, and distribute linked combinations including
+    the two.
+
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do
+    so, delete this exception statement from your version. If you delete
+    this exception statement from all source files in the program, then
+    also delete it here.
+*/
+
+#ifndef CHWIDTH_H
+#define CHWIDTH_H
+
+#include <wchar.h>
+#include <string>
+
+extern const char chwidth_reference_table[];
+extern const char chwidth_default_table[];
+
+/* Range of expressible codepoints in Unicode. */
+static const unsigned int unicode_codespace = 0x110000;
+
+/* wcwidth, renamed. */
+int chwidth(wchar_t wc);
+
+/* Initialize the working chwidth map from the table passed in. */
+void chwidth_set_base( const std::string& widths );
+/* Update the working chwidth map from the overlay table passed in. */
+bool chwidth_set_overlay( const std::string& overlay );
+/* Construct an overlay table from the two tables passed in, base and new. */
+std::string chwidth_make_overlay( const std::string& base, const std::string& update );
+std::string chwidth_get_working( void );
+
+/* Retrieve the reference Unicode table embedded in all Mosh versions. */
+const char* chwidth_get_reference( void );
+/* Retrieve the Unicode table embedded in this version of Mosh.  It
+   may be a later version of Unicode than the base table, or vary in
+   other ways. */
+const char* chwidth_get_default( void );
+#endif


### PR DESCRIPTION
This is a first draft of flexible Unicode character width handling for Mosh.  It's not complete, and I'd love to get some comment on this.

There's two parts to this:
* Mosh itself gets Unicode tables, a `chwidth()` function to replace `wcwidth()`, and code to load Unicode tables or partial overlays in `mosh-client` and transmit them to `mosh-server`.

* Code to generate new Unicode tables is in `src/unicode`.  This only needs to be run when a new version of Unicode is released, and is not part of Mosh's normal build infrastructure.  A developer will need to run it and commit the resulting changed table, once a year or so, following Unicode.org's release schedule.  This code was also used to generate the tables in this pull request with a caveat noted below.  We depend on Google's libapps, which has some code to generate character width tables in Javascript, which is used in `hterm`.  (Many thanks to @vapier for doing this hard work of determining what a Unicode widths table for terminals should be in the first place, and for taking a small change that allows us to stand on his shoulders.)

# How This Works
This code adds two fixed Unicode tables to Mosh: a `reference` table, which will never change after its initial introduction to Mosh, and a `default` table, which will be updated with each new Unicode release.  Additionally, the user can overlay the default table with changes for some characters (like making East Asian Width Ambiguous characters wide instead of narrow), or replace the default table entirely with a complete table.

At startup, `mosh-client` creates a working table that is a combination of the default table, and whatever overlay/table the user has loaded.  It uses this to determine character widths locally.  It also compares the reference table and the working table to create an overlay with the difference between them.  It sends this overlay to `mosh-server`, which applies the overlay to its copy of the reference table to create a working table that is the same as the one on the client.  This overlay table is compressed before being added to a `Message`, and then the entire `Message` is compressed before being sent to the server.  This double compression results in a very small growth in that initial `Message`.

My plan is that at initial release, the reference table will be generated from the Unicode 10.0.0 data files, and until Unicode 11 is released, the default table will actually be exactly the same.  But for development and illustration, currently the reference table is Unicode 9.0 and the default table is 10.0.0.  For this pairing, the initial client-to-server message only grows about 43 bytes with the addition of the overlay table.  Since the Unicode organization keeps adding emoji, this differential will grow, but my hope is that it will still remain below the size of a Mosh-MTU packet for quite a while.

In this initial implementation, the in-core tables, the messages from client to server, and the user's custom files are all exactly the same format:  they are a string of 1114112 bytes or less, one character for each Unicode code point.  That character may be '0', '1', or '2' to represent a character width, '-' to represent an illegal code point, or (in an overlay table) '=' means "take this character from the base table".  Nothing says that any of these objects need to be this format, or the same format as one of the others.  It is a trivial format to parse for file input, and the extremely simple format is amenable to being compressed twice by zlib.  But I do think we need to come up with something better for the fixed tables stored in the executable, and the working table constructed at runtime-- perhaps a list of runs for the fixed tables, and a two-level table for the runtime lookup (as many wcwidth implementations do).

### Problems I think this helps solve:
* The problem of mismatching Unicode width maps from differing `wcwidth()` implementations on client and server, and mismatching with the terminal emulator's width map.
* Adding up to date width maps, and keeping them up to date.
* Going forward, having up-to-date width maps even on old servers with old distros and binaries.
* For older, already-existing versions of `mosh-server` with whatever width map the system gave them, it's possible to configure a client with a table that matches.
* Adding an East Asian ambiguous width characters switch usable at runtime.
* User configurability for private use area characters (Powerline).
* SOFT HYPHEN.  Some terminal emulators print them, some don't.
* Small/old systems without locale and/or Unicode support.  They can just send a map that only supports ISO-8859, the first 256 bytes.
* Since there's no standard width map for character terminals, whatever we do will be wrong for *somebody*-- but users can load whatever works for them.
* Integrated Mosh clients like Blink or Mosh-for-Chrome can load a table that exactly matches their terminal emulator's table.

### Issues:
* Documentation/comments in source code is a bit thin.
* No utilities to merge/delta chwidth table files (I have some Perl, want to convert to Python).
* I envision an `--eaw-is-wide` flag and/or automatic detection from locale variables in `mosh`, I haven't coded that up yet.
* With a little more work (basically adding a `utf8_to_utf32()` and `utf32_to_utf8()`) we can eliminate all of Mosh's dependencies on libc locale code.  This would improve portability, and allow mosh-server to merely warn of locale/charset issues on startup instead of terminating with an error.  This would also allow ripping out some of the cruft to work around slow libc locale handling.
* No effort at size or time optimization yet.  The binaries bloat from 300KB to 7MB on my Mac.
* `src/unicode/Makefile.am` is a barely-working, half-broken mess.  That functionality needs to be a bit better integrated into autoconf/automake too, and I'm not sure how the Git submodule should be handled.
* We need to define exactly what the reference and default chwidth tables should be.
* Figuring out how this might integrate with Blink, Mosh-for-Chrome, etc. would be nice. @rpwoodbu, @carloscabanero, your comments will be *greatly* appreciated.

### Requests:
* Comments on what people need from Mosh to make Unicode work better for them.
* Comments on the design/implementation of this pile of stuff.
* Testing!  I've barely used this in any kind of Unicode-heavy environment.  Remember, you will need this on both client and server, and this is very much experimental--  this functionality is guaranteed to break on or before merge to Mosh master.
* Comment from other developers in the Mosh ecosystem who use our code: @rpwoodbu, @carloscabanero and anyone else interested.