### PR TITLE
Improve(?) terminfo handling

### DIFF
--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -89,13 +89,20 @@ static void print_usage( FILE *file, const char *argv0 )
 static void print_colorcount( void )
 {
   /* check colors */
-  setupterm((char *)0, 1, (int *)0);
-
-  char colors_name[] = "colors";
-  int color_val = tigetnum( colors_name );
-  if ( color_val == -2 ) {
-    fprintf( stderr, "Invalid terminfo numeric capability: %s\n",
-	     colors_name );
+  int errret = -2;
+  int ret = setupterm((char *)0, 2, &errret);
+  int color_val = 256;
+  if ( ret != OK ) {
+    fprintf( stderr, "setupterm() failed (probably bad TERM variable or terminfo): ret = %d errret = %d\n", ret, errret );
+  } else {
+    const char *colors_name = "colors";
+    int colors = tigetnum( const_cast<char *>( colors_name ));
+    if ( colors == -2 ) {
+      fprintf( stderr, "Invalid terminfo numeric capability: %s\n",
+	       colors_name );
+    } else {
+      color_val = colors;
+    }
   }
 
   printf( "%d\n", color_val );

--- a/src/terminal/terminaldisplayinit.cc
+++ b/src/terminal/terminaldisplayinit.cc
@@ -81,23 +81,20 @@ static const char *ti_str( const char *capname )
 }
 
 Display::Display( bool use_environment )
-  : has_ech( true ), has_bce( true ), has_title( true ), smcup( NULL ), rmcup( NULL )
+  : has_ech( false ), has_bce( false ), has_title( false ), smcup( NULL ), rmcup( NULL )
 {
   if ( use_environment ) {
     int errret = -2;
-    int ret = setupterm( (char *)0, 1, &errret );
+    int ret = setupterm( (char *)0, 2, &errret );
 
     if ( ret != OK ) {
       switch ( errret ) {
       case 1:
 	throw std::runtime_error( "Terminal is hardcopy and cannot be used by curses applications." );
 	break;
-      case 0:
-	throw std::runtime_error( "Unknown terminal type." );
-	break;
-      case -1:
-	throw std::runtime_error( "Terminfo database could not be found." );
-	break;
+      case 0: // Unknown/generic terminal.
+      case -1: // terminfo database could not be found.
+	return;
       default:
 	throw std::runtime_error( "Unknown terminfo error." );
 	break;
@@ -118,17 +115,16 @@ Display::Display( bool use_environment )
       "xterm", "rxvt", "kterm", "Eterm", "screen"
     };
 
-    has_title = false;
     const char *term_type = getenv( "TERM" );
     if ( term_type ) {
       for ( size_t i = 0;
-            i < sizeof( title_term_types ) / sizeof( const char * );
-            i++ ) {
-        if ( 0 == strncmp( term_type, title_term_types[ i ],
-                           strlen( title_term_types[ i ] ) ) ) {
-          has_title = true;
-          break;
-        }
+	    i < sizeof( title_term_types ) / sizeof( const char * );
+	    i++ ) {
+	if ( 0 == strncmp( term_type, title_term_types[ i ],
+			   strlen( title_term_types[ i ] ) ) ) {
+	  has_title = true;
+	  break;
+	}
       }
     }
 


### PR DESCRIPTION
Fixes #959, or something.

This makes Mosh more generous in the face of an unknown `TERM` variable or otherwise bad terminfo configuration.  It allows Mosh to stumble onward, disabling all terminfo-driven features except 256-color mode.

I am somewhat divided about this "fix".  On the one hand, it'll break quite horribly on a non-ANSI terminal such as an ADM-3a or Televideo 970.  On the other hand, terminals that are truly incompatible with Mosh are rare now, and this might improve the user experience.  Anybody have strong feelings one way or the other?