### PR TITLE
Fix FreeBSD issue with bind(2), do some namespace/using cleanup

### DIFF
--- a/src/crypto/crypto.cc
+++ b/src/crypto/crypto.cc
@@ -44,7 +44,6 @@
 #include "fatal_assert.h"
 #include "prng.h"
 
-using namespace std;
 using namespace Crypto;
 
 long int myatoi( const char *str )

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -40,13 +40,13 @@
 #include <stdlib.h>
 #include <exception>
 
-using std::string;
 
 long int myatoi( const char *str );
 
 class PRNG;
 
 namespace Crypto {
+  using std::string;
 
   class CryptoException : public std::exception {
   public:

--- a/src/examples/decrypt.cc
+++ b/src/examples/decrypt.cc
@@ -37,7 +37,6 @@
 #include "crypto.h"
 
 using namespace Crypto;
-using namespace std;
 
 int main( int argc, char *argv[] )
 {
@@ -51,8 +50,8 @@ int main( int argc, char *argv[] )
     Session session( key );
 
     /* Read input */
-    ostringstream input;
-    input << cin.rdbuf();
+    std::ostringstream input;
+    input << std::cin.rdbuf();
 
     /* Decrypt message */
 
@@ -60,9 +59,9 @@ int main( int argc, char *argv[] )
 
     fprintf( stderr, "Nonce = %ld\n",
 	     (long)message.nonce.val() );
-    cout << message.text;
+    std::cout << message.text;
   } catch ( const CryptoException &e ) {
-    cerr << e.what() << endl;
+    std::cerr << e.what() << std::endl;
     exit( 1 );
   }
 

--- a/src/examples/encrypt.cc
+++ b/src/examples/encrypt.cc
@@ -37,7 +37,6 @@
 #include "crypto.h"
 
 using namespace Crypto;
-using namespace std;
 
 int main( int argc, char *argv[] )
 {
@@ -52,18 +51,18 @@ int main( int argc, char *argv[] )
     Nonce nonce( myatoi( argv[ 1 ] ) );
 
     /* Read input */
-    ostringstream input;
-    input << cin.rdbuf();
+    std::ostringstream input;
+    input << std::cin.rdbuf();
 
     /* Encrypt message */
 
     string ciphertext = session.encrypt( Message( nonce, input.str() ) );
 
-    cerr << "Key: " << key.printable_key() << endl;
+    std::cerr << "Key: " << key.printable_key() << std::endl;
 
-    cout << ciphertext;
+    std::cout << ciphertext;
   } catch ( const CryptoException &e ) {
-    cerr << e.what() << endl;
+    std::cerr << e.what() << std::endl;
     exit( 1 );
   }
 

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -107,7 +107,6 @@ static int run_server( const char *desired_ip, const char *desired_port,
 		       const string &command_path, char *command_argv[],
 		       const int colors, unsigned int verbose, bool with_motd );
 
-using namespace std;
 
 static void print_version( FILE *file )
 {
@@ -150,7 +149,7 @@ static string get_SSH_IP( void )
     fputs( "Warning: SSH_CONNECTION not found; binding to any interface.\n", stderr );
     return string( "" );
   }
-  istringstream ss( SSH_CONNECTION );
+  std::istringstream ss( SSH_CONNECTION );
   string dummy, local_interface_IP;
   ss >> dummy >> dummy >> local_interface_IP;
   if ( !ss ) {

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -682,11 +682,11 @@ static void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &
       int timeout = INT_MAX;
       uint64_t now = Network::timestamp();
 
-      timeout = min( timeout, network.wait_time() );
-      timeout = min( timeout, terminal.wait_time( now ) );
+      timeout = std::min( timeout, network.wait_time() );
+      timeout = std::min( timeout, terminal.wait_time( now ) );
       if ( (!network.get_remote_state_num())
 	   || network.shutdown_in_progress() ) {
-        timeout = min( timeout, 5000 );
+        timeout = std::min( timeout, 5000 );
       }
       /*
        * The server goes completely asleep if it has no remote peer.
@@ -701,7 +701,7 @@ static void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &
 	  /* 24 days might be too soon.  That's OK. */
 	  network_sleep = INT_MAX;
 	}
-	timeout = min( timeout, static_cast<int>(network_sleep) );
+	timeout = std::min( timeout, static_cast<int>(network_sleep) );
       }
 
       /* poll for events */

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -63,6 +63,8 @@
 
 #include "networktransport-impl.h"
 
+using std::wstring;
+
 void STMClient::resume( void )
 {
   /* Restore termios state */

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -439,11 +439,11 @@ bool STMClient::main( void )
     try {
       output_new_frame();
 
-      int wait_time = min( network->wait_time(), overlays.wait_time() );
+      int wait_time = std::min( network->wait_time(), overlays.wait_time() );
 
       /* Handle startup "Connecting..." message */
       if ( still_connecting() ) {
-	wait_time = min( 250, wait_time );
+	wait_time = std::min( 250, wait_time );
       }
 
       /* poll for events */

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -39,7 +39,6 @@
 #include "terminaloverlay.h"
 
 using namespace Overlay;
-using std::max;
 
 void ConditionalOverlayCell::apply( Framebuffer &fb, uint64_t confirmed_epoch, int row, bool flag ) const
 {

--- a/src/network/compressor.cc
+++ b/src/network/compressor.cc
@@ -36,6 +36,7 @@
 #include "dos_assert.h"
 
 using namespace Network;
+using std::string;
 
 string Compressor::compress_str( const string &input )
 {

--- a/src/network/compressor.cc
+++ b/src/network/compressor.cc
@@ -36,7 +36,6 @@
 #include "dos_assert.h"
 
 using namespace Network;
-using namespace std;
 
 string Compressor::compress_str( const string &input )
 {

--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -60,7 +60,6 @@
 #define AI_NUMERICSERV 0
 #endif
 
-using namespace std;
 using namespace Network;
 using namespace Crypto;
 

--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -332,7 +332,7 @@ bool Connection::try_bind( const char *addr, int port_low, int port_high )
       }
     }
 
-    if ( bind( sock(), &local_addr.sa, local_addr_len ) == 0 ) {
+    if ( ::bind( sock(), &local_addr.sa, local_addr_len ) == 0 ) {
       set_MTU( local_addr.sa.sa_family );
       return true;
     } // else fallthrough to below code, on last iteration.

--- a/src/network/networktransport-impl.h
+++ b/src/network/networktransport-impl.h
@@ -38,7 +38,6 @@
 #include "transportsender-impl.h"
 
 using namespace Network;
-using namespace std;
 
 template <class MyState, class RemoteState>
 Transport<MyState, RemoteState>::Transport( MyState &initial_state, RemoteState &initial_remote,

--- a/src/network/transportfragment.h
+++ b/src/network/transportfragment.h
@@ -39,11 +39,11 @@
 
 #include "transportinstruction.pb.h"
 
-using std::vector;
-using std::string;
-using namespace TransportBuffers;
-
 namespace Network {
+  using std::vector;
+  using std::string;
+  using namespace TransportBuffers;
+
   class Fragment
   {
   public:

--- a/src/network/transportsender-impl.h
+++ b/src/network/transportsender-impl.h
@@ -104,13 +104,13 @@ void TransportSender<MyState>::calculate_timers( void )
       mindelay_clock = now;
     }
 
-    next_send_time = max( mindelay_clock + SEND_MINDELAY,
-			  sent_states.back().timestamp + send_interval() );
+    next_send_time = std::max( mindelay_clock + SEND_MINDELAY,
+			       sent_states.back().timestamp + send_interval() );
   } else if ( !(current_state == assumed_receiver_state->state)
 	      && (last_heard + ACTIVE_RETRY_TIMEOUT > now) ) {
     next_send_time = sent_states.back().timestamp + send_interval();
     if ( mindelay_clock != uint64_t( -1 ) ) {
-      next_send_time = max( next_send_time, mindelay_clock + SEND_MINDELAY );
+      next_send_time = std::max( next_send_time, mindelay_clock + SEND_MINDELAY );
     }
   } else if ( !(current_state == sent_states.front().state )
 	      && (last_heard + ACTIVE_RETRY_TIMEOUT > now) ) {

--- a/src/network/transportsender-impl.h
+++ b/src/network/transportsender-impl.h
@@ -45,7 +45,6 @@
 #include <limits.h>
 
 using namespace Network;
-using namespace std;
 
 template <class MyState>
 TransportSender<MyState>::TransportSender( Connection *s_connection, MyState &initial_state )

--- a/src/network/transportsender.h
+++ b/src/network/transportsender.h
@@ -43,11 +43,11 @@
 #include "transportfragment.h"
 #include "prng.h"
 
-using std::list;
-using std::pair;
-using namespace TransportBuffers;
-
 namespace Network {
+  using std::list;
+  using std::pair;
+  using namespace TransportBuffers;
+
   /* timing parameters */
   const int SEND_INTERVAL_MIN = 20; /* ms between frames */
   const int SEND_INTERVAL_MAX = 250; /* ms between frames */

--- a/src/statesync/completeterminal.cc
+++ b/src/statesync/completeterminal.cc
@@ -161,7 +161,7 @@ bool Complete::set_echo_ack( uint64_t now )
 
 void Complete::register_input_frame( uint64_t n, uint64_t now )
 {
-  input_history.push_back( make_pair( n, now ) );
+  input_history.push_back( std::make_pair( n, now ) );
 }
 
 int Complete::wait_time( uint64_t now ) const

--- a/src/statesync/user.h
+++ b/src/statesync/user.h
@@ -40,11 +40,11 @@
 
 #include "parseraction.h"
 
-using std::deque;
-using std::list;
-using std::string;
-
 namespace Network {
+  using std::deque;
+  using std::list;
+  using std::string;
+
   enum UserEventType {
     UserByteType = 0,
     ResizeType = 1

--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -619,7 +619,7 @@ void Dispatcher::OSC_dispatch( const Parser::OSC_End *act __attribute((unused)),
     bool set_title = cmd_num == 0 || cmd_num == 2;
     if ( set_icon || set_title ) {
       fb->set_title_initialized();
-      int title_length = min(OSC_string.size(), (size_t)256);
+      int title_length = std::min(OSC_string.size(), (size_t)256);
       Terminal::Framebuffer::title_type newtitle( OSC_string.begin() + offset, OSC_string.begin() + title_length );
       if ( set_icon )  { fb->set_icon_name( newtitle ); }
       if ( set_title ) { fb->set_window_title( newtitle ); }

--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -40,7 +40,6 @@
 #include "parseraction.h"
 
 using namespace Terminal;
-using namespace std;
 
 /* Terminal functions -- routines activated by CSI, escape or a control char */
 

--- a/src/terminal/terminaluserinput.cc
+++ b/src/terminal/terminaluserinput.cc
@@ -34,7 +34,7 @@
 #include "terminaluserinput.h"
 
 using namespace Terminal;
-using namespace std;
+using std::string;
 
 string UserInput::input( const Parser::UserByte *act,
 			 bool application_mode_cursor_keys )

--- a/src/util/locale_utils.cc
+++ b/src/util/locale_utils.cc
@@ -45,12 +45,11 @@
 
 #include "locale_utils.h"
 
-using namespace std;
 
-const string LocaleVar::str( void ) const
+const std::string LocaleVar::str( void ) const
 {
   if ( name.empty() ) {
-    return string( "[no charset variables]" );
+    return std::string( "[no charset variables]" );
   }
   return name + "=" + value;
 }


### PR DESCRIPTION
This has got a trivial fix for a problem with `bind(2)` on FreeBSD + clang/libc++7, and some additional cleanup of namespace pollution in Mosh.  Usage of the `std` namespace is fairly clean now, but Mosh's major namespaces and classes are still messy (we control that, though).