### PR TITLE
Apply latest consecutive resize, not earliest.

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -739,12 +739,11 @@ static void serve( int host_fd, Terminal::Complete &terminal, ServerConnection &
 	    const Parser::Action &action = us.get_action( i );
 	    if ( typeid( action ) == typeid( Parser::Resize ) ) {
 	      /* apply only the last consecutive Resize action */
-	      while ( i < us.size() - 1 ) {
-		const Parser::Action &next  = us.get_action( i + 1 );
-		if ( typeid( next ) != typeid( Parser::Resize ) ) {
-		  break;
+	      if ( i < us.size() - 1 ) {
+		const Parser::Action &next = us.get_action( i + 1 );
+		if ( typeid( next ) == typeid( Parser::Resize ) ) {
+		  continue;
 		}
-		i++;
 	      }
 	      /* tell child process of resize */
 	      const Parser::Resize &res = static_cast<const Parser::Resize &>( action );


### PR DESCRIPTION
If there are consecutive resize events in the userstream to be applied in
"serve", we should apply the last/latest one in the sequence, not the
first/earliest one.

This fixes a problem where a flurry of resize events (eg, generated
by a window manager resizing the client), can cause mosh to have an
out-of-date idea as to what the physical geometry of the window is.