### PR TITLE
Move generated includes to their own directory to avoid conflicts.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = scripts src man conf
 EXTRA_DIST = autogen.sh ocb-license.html README.md COPYING.iOS
-BUILT_SOURCES = version.h
+BUILT_SOURCES = VERSION
 AM_DISTCHECK_CONFIGURE_FLAGS = --enable-compile-warnings=distcheck --enable-examples --enable-syslog
 
 # non-Automake defines
@@ -29,20 +29,13 @@ VERSION:
 	fi
 	@rm -f VERSION.dist VERSION.git
 
-version.h:	VERSION
-	@printf '#define BUILD_VERSION "%s"\n' "$$(cat VERSION)" > version.h.new
-	@set -e; if ! diff -q version.h version.h.new > /dev/null 2>&1; then \
-		mv -f version.h.new version.h; \
-	fi
-	@rm -f version.h.new
-
 clean-local:
-	@rm -rf version.h VERSION cov-int mosh-coverity.txz compile_commands.json
+	@rm -rf VERSION cov-int mosh-coverity.txz compile_commands.json
 
 # Linters and static checkers, for development only.  Not included in
 # build dependencies, and outside of Automake processing.
 cppcheck:
-	cppcheck $(CPPCHECK_FLAGS) -include config.h -I . \
+	cppcheck $(CPPCHECK_FLAGS) -include src/include/config.h -I src/include \
 		-I src/crypto -I src/frontend -I src/network -I src/protobufs \
 		-I src/statesync -I src/terminal -I src/util \
 		-I /usr/include -I /usr/include/google/protobuf -I/usr/include/openssl \

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AM_INIT_AUTOMAKE([foreign std-options -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_SRCDIR([src/frontend/mosh-client.cc])
 AC_CONFIG_MACRO_DIR([m4])
-AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_HEADERS([src/include/config.h])
 
 # Checks for programs.
 AC_PROG_CC([cc gcc clang])
@@ -559,6 +559,7 @@ AC_CONFIG_FILES([
   src/Makefile
   src/crypto/Makefile
   src/frontend/Makefile
+  src/include/Makefile
   src/network/Makefile
   src/protobufs/Makefile
   src/statesync/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = protobufs util crypto terminal network statesync frontend examples tests
+SUBDIRS = include protobufs util crypto terminal network statesync frontend examples tests

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -5,8 +5,8 @@ clean-local:
 	@rm -rf version.h
 
 version.h:	../../VERSION
-	@test -f $<
-	@printf '#define BUILD_VERSION "%s"\n' "$$(cat $<)" > version.h.new
+	@test -s $<
+	@printf '#define BUILD_VERSION "%s"\n' "$$(cat $<)" > $@.new
 	@set -e; if ! diff -q $@ $@.new > /dev/null 2>&1; then \
 		mv -f $@.new $@; \
 	fi

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -1,0 +1,14 @@
+BUILT_SOURCES = version.h
+nodist_INCLUDES = version.h
+
+clean-local:
+	@rm -rf version.h
+
+version.h:	../../VERSION
+	@test -f $<
+	@printf '#define BUILD_VERSION "%s"\n' "$$(cat $<)" > version.h.new
+	@set -e; if ! diff -q $@ $@.new > /dev/null 2>&1; then \
+		mv -f $@.new $@; \
+	fi
+	@rm -f $@.new
+


### PR DESCRIPTION
Fixes #1051, mosh fails to build on case-insensitive filesystems.

I think putting generated includes in a separate directory is the best strategy here to avoid having this come up again, but autoconf/automake do drop a couple of extension-less files in that directory (`Makefile`, `stamp-h1`).  Let's hope the C++ standard committee never adds includes with *those* names.