### PR TITLE
If exec()ing the remote command fails, pause briefly

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -599,7 +599,9 @@ static int run_server( const char *desired_ip, const char *desired_port,
     Crypto::reenable_dumping_core();
 
     if ( execvp( command_path.c_str(), command_argv ) < 0 ) {
-      err( 1, "execvp: %s", command_path.c_str() );
+      warn( "execvp: %s", command_path.c_str() );
+      sleep( 3 );
+      exit( 1 );
     }
   } else {
     /* parent */


### PR DESCRIPTION
This came up on IRC, where user concatime was asking why `mosh -p PORT NAME 'tmux attach -t irc'` didn't work.  (The correct command is `mosh -p PORT NAME -- tmux attach -t irc`).  I realized that it's hard to debug this because mosh-server prints an error message for the failed exec, but exits immediately, and normally mosh-client clears the screen on exit.

This adds a 3-second delay before exit, after `exec()` fails, so the error is visible.
