### PR TITLE
Also set datadir for bash-completion pkg-config query

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -513,7 +513,8 @@ AS_IF([test "$install_completion" != no],
      [if test "$prefix" = "NONE"; then
         completions="`pkg-config --variable=completionsdir bash-completion`"
       else
-        completions="`pkg-config --define-variable=prefix=$prefix --variable=completionsdir bash-completion`"
+        # bash-completion >= 2.10 uses datadir instead of prefix
+        completions="`pkg-config --define-variable=prefix=$prefix --define-variable=datadir=$datadir --variable=completionsdir bash-completion`"
       fi],
      [completions="${sysconfdir}/bash_completion.d"])
    AC_SUBST([completions])])


### PR DESCRIPTION
bash-completion >= 2.10 uses datadir for its prefix path. See https://github.com/scop/bash-completion/commit/0cc34e8de658bd11fa7f728eb9852c7e29d8d6d4.

Motivation: https://github.com/NixOS/nixpkgs/issues/85893