### PR TITLE
Mosh handle exitstatus

### DIFF
--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -31,6 +31,7 @@ displaytests = \
 	pty-deadlock.test \
 	repeat.test \
 	repeat-with-input.test \
+	server-failure.test \
 	server-network-timeout.test \
 	server-signal-timeout.test \
 	window-resize.test \

--- a/src/tests/e2e-test
+++ b/src/tests/e2e-test
@@ -237,21 +237,21 @@ for run in $server_tests; do
 	if [ "$server_rv" -ne 0 ]; then
 	    test_error "server harness exited with status %s\n" "$server_rv"
 	fi
-    fi
-    if [ "${run}" != "direct" ]; then
-	# Check for "round-trip" failures
-	if grep -q "round-trip Instruction verification failed" "${test_dir}/${run}.server.stderr"; then
-	    test_error "Round-trip Instruction verification failed on server during %s\n" "$run"
-	fi
-	# Check for 0-timeout select() issue
-	if egrep -q "(polls, rate limiting|consecutive polls)" "${test_dir}/${run}.server.stderr"; then
-	    if [ "osx" != "${TRAVIS_OS_NAME}" ]; then
-		test_error "select() with zero timeout called too often on server during %s\n" "$run"
+	if [ "${run}" != "direct" ]; then
+	    # Check for "round-trip" failures
+	    if grep -q "round-trip Instruction verification failed" "${test_dir}/${run}.server.stderr"; then
+		test_error "Round-trip Instruction verification failed on server during %s\n" "$run"
 	    fi
-	fi
-	# Check for assert()
-	if egrep -q "assertion.*failed" "${test_dir}/${run}.server.stderr"; then
-	    test_error "assertion during %s\n" "$run"
+	    # Check for 0-timeout select() issue
+	    if egrep -q "(polls, rate limiting|consecutive polls)" "${test_dir}/${run}.server.stderr"; then
+		if [ "osx" != "${TRAVIS_OS_NAME}" ]; then
+		    test_error "select() with zero timeout called too often on server during %s\n" "$run"
+		fi
+	    fi
+	    # Check for assert()
+	    if egrep -q "assertion.*failed" "${test_dir}/${run}.server.stderr"; then
+		test_error "assertion during %s\n" "$run"
+	    fi
 	fi
     fi
     # XXX We'd also like to check for "target state Instruction

--- a/src/tests/server-failure.test
+++ b/src/tests/server-failure.test
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+#
+# Run mosh with a bad server command, check that it reports this usefully.
+#
+
+# shellcheck source=e2e-test-subrs
+. "$(dirname "$0")/e2e-test-subrs"
+PATH=$PATH:.:$srcdir
+# Top-level wrapper.
+if [ $# -eq 0 ]; then
+    e2e-test "$0" baseline client server mosh-args post
+    exit
+fi
+
+# OK, we have arguments, we're one of the test hooks.
+if [ $# -lt 1 ]; then
+    fail "bad arguments %s\n" "$@"
+fi
+
+# The mosh session test command is never run.
+baseline()
+{
+    printf "@@@ done\n"
+}
+
+# Return inverted exitstatus from mosh-client.
+client()
+{
+    ! "$@"
+    exit
+}
+
+# Add a do-nothing server command, to disable the standard harness
+# checks in e2e-test.
+server()
+{
+    exit 0
+}
+
+# Make mosh.pl fail with a bad server.
+mosh_args()
+{
+    printf "%s\n" "--server false"
+}
+
+# Check for correct reporting of that failure.
+post()
+{
+    if ! grep 'server command failed with exitstatus' "$(basename "$0").d/baseline.tmux.log"; then
+	exit 1
+    fi
+}
+
+case $1 in
+    baseline)
+	baseline;;
+    client)
+	shift
+	client "$@";;
+    mosh-args)
+	mosh_args;;
+    post)
+	post;;
+    server)
+	server;;
+    *)
+	fail "unknown test argument %s\n" "$1";;
+esac


### PR DESCRIPTION
This hopefully helps with a long-time papercut:  If the command to start the remote Mosh server fails, the error reported may be "Did not find remote IP address (is SSH ProxyCommand disabled?)." or "Did not find mosh server startup message. (Have you installed mosh on your server?)"  The first message, especially, can be rather misleading to new Mosh users.  This change reports non-zero exitstatus instead, which I think will make things clearer.

