### PR TITLE
server: add option to stay in foreground

### DIFF
--- a/man/mosh-server.1
+++ b/man/mosh-server.1
@@ -20,6 +20,7 @@ mosh-server \- server-side helper for mosh
 .SH SYNOPSIS
 .B mosh-server
 new
+[\-D]
 [\-s]
 [\-v]
 [\-i \fIIP\fP]
@@ -53,6 +54,10 @@ and the client's current IP address.
 
 The argument "new" must be first on the command line to use
 command-line options.
+
+.TP
+.B \-D
+stay in the foreground instead of forking into the background
 
 .TP
 .B \-s


### PR DESCRIPTION
Adds an option (`-D`) to prevent forking into the background. Allows running `mosh-server` directly as a docker `ENTRYPOINT`[1]. The server can then be specified to use the container like:

```sh
mosh --server='function s() { CONTAINER=$((docker inspect --format={{.Id}} mosh 2> /dev/null || docker run -dti --rm -v /var/run/docker.sock:/var/run/docker.sock --name mosh --net=host jkoelker/mosh-server new -D -@ "$@") | sed '/^$/d') ; docker logs "${CONTAINER}"; }; s' [user@]host [command...]
```

This is particularly useful to mosh'ing into GCP Container-Optimized where the filesystem is readonly.

Fixes #1091

[1] https://github.com/jkoelker/dockerfiles/blob/mosh-server/Dockerfile#L32