### PR TITLE
Use CLOCK_MONOTONIC_RAW when available

### DIFF
--- a/src/util/timestamp.cc
+++ b/src/util/timestamp.cc
@@ -48,6 +48,12 @@
 #include <stdio.h>
 #endif
 
+#ifdef CLOCK_MONOTONIC_RAW
+#define CLOCKTYPE CLOCK_MONOTONIC_RAW
+#else
+#define CLOCKTYPE CLOCK_MONOTONIC
+#endif
+
 static uint64_t millis_cache = -1;
 
 uint64_t frozen_timestamp( void )
@@ -73,7 +79,7 @@ void freeze_timestamp( void )
       // Check for presence, for OS X SDK >= 10.12 and runtime < 10.12
       &clock_gettime != NULL &&
 #endif
-      clock_gettime( CLOCK_MONOTONIC, &tp ) == 0 ) {
+      clock_gettime( CLOCKTYPE, &tp ) == 0 ) {
     uint64_t millis = tp.tv_nsec / 1000000;
     millis += uint64_t( tp.tv_sec ) * 1000;
 

--- a/src/util/timestamp.cc
+++ b/src/util/timestamp.cc
@@ -48,7 +48,11 @@
 #include <stdio.h>
 #endif
 
-#ifdef CLOCK_MONOTONIC_RAW
+// On Apple systems CLOCK_MONOTONIC is unfortunately able to go
+// backwards in time. This breaks mosh when system is returning from
+// suspend as described in ticket #1014. To avoid this issue prefer
+// CLOCK_MONOTONIC_RAW on Apple systems when available.
+#if defined(__APPLE__) && defined(CLOCK_MONOTONIC_RAW)
 #define CLOCKTYPE CLOCK_MONOTONIC_RAW
 #else
 #define CLOCKTYPE CLOCK_MONOTONIC


### PR DESCRIPTION
Use CLOCK_MONOTONIC_RAW (when available) which isn't affected by system time adjustments (such as NTP or adjtime).
Overall I think this is a better fix for #1014 since this is a generic solution (this issue might also affect other platforms, not just Mac OS).

I think the reason CLOCK_MONOTONIC manifests this behaviour is due to Apple's libc clock_gettime() CLOCK_MONOTONIC implementation here: https://opensource.apple.com/source/Libc/Libc-1353.41.1/gen/clock_gettime.c.auto.html

clock_gettime() CLOCK_MONOTONIC code path uses _mach_boottime_usec() which and ends up using gettimeofday() - boottime. gettimeofday() is affected by system time changes. Thus the time returned may suddenly jump backwards.

CLOCK_MONOTONIC_RAW on the other hand uses mach_continuous_time() directly, which doesn't get adjusted by system time changes.

In my personal opinion this behaviour of CLOCK_MONOTONIC is wrong, and CLOCK_MONOTONIC should rather be made to behave identical to CLOCK_MONOTONIC_RAW instead. But I digress.