### PR TITLE
.gitignore: add autogenerated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,9 @@ compile_commands.json
 /ar-lib
 /autom4te.cache
 /compile
-/config.h
-/config.h.in
-/config.h.in~
+src/include/config.h
+src/include/config.h.in
+src/include/config.h.in~
 /config.log
 /config.status
 /configure
@@ -24,8 +24,8 @@ compile_commands.json
 /install-sh
 /missing
 /mosh-*.tar.gz
-/stamp-h1
+src/include/stamp-h1
 /test-driver
 /VERSION
 /scripts/mosh
-/version.h
+src/include/version.h

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Makefile
 Makefile.in
 .cproject
 .project
+compile_commands.json
 
 /INSTALL
 /aclocal.m4


### PR DESCRIPTION
After a build:
git show Untracked files below
  src/include/config.h
  src/include/config.h.in
  src/include/stamp-h1
  src/include/version.h