### PR TITLE
Don't sometimes hang just after launching ssh

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -439,8 +439,8 @@ if ( $pid == 0 ) { # child
       print "$_\n";
     }
   }
-  waitpid $pid, 0;
   close $pipe;
+  waitpid $pid, 0;
 
   if ( not defined $ip ) {
     if ( defined $sship ) {


### PR DESCRIPTION
sshd has a bug in which the sometimes it may get stuck trying to read from the client
even though the child process has already exited. This is visible at
https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/serverloop.c?annotate=1.226 line 274:
once the child is waited on, `child_terminated` is reset to 0, which causes it to use an infinite timeout 
in the select there.

This workaround causes mosh to disconnect from the server, thereby allowing sshd finish.

Fix bug #1152