### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-18.04, ubuntu-20.04]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: "setup linux build environment"
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      run: sudo apt install -y protobuf-compiler libprotobuf-dev libutempter-dev autoconf automake
+
+    - name: "setup macos build environment"
+      if: ${{ startsWith(matrix.os, 'macos') }}
+      run: brew install protobuf automake
+
+    - name: "generate build scripts"
+      run: ./autogen.sh
+
+    - name: "configure"
+      run: ./configure --enable-compile-warnings=error --enable-examples
+
+    - name: "build"
+      run: make V=1
+
+    - name: "test"
+      run: make V=1 check

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/mobile-shell/mosh.svg?branch=master)](https://travis-ci.org/mobile-shell/mosh)
+[![ci](https://github.com/mobile-shell/mosh/actions/workflows/ci.yml/badge.svg)](https://github.com/mobile-shell/mosh/actions/workflows/ci.yml)
 
 Mosh: the mobile shell
 ======================

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,9 @@ AC_ARG_ENABLE([compile-warnings],
        PICKY_CXXFLAGS="-Wextra -pedantic -Wno-long-long -Weffc++ -Wmissing-declarations"
        ;;
      error)
-       WARNING_CXXFLAGS="-Wall -Werror"
+       # remove -Wno-c++17-extensions once protocolbuffers/protobuf#9181 is
+       # resolved
+       WARNING_CXXFLAGS="-Wall -Werror -Wno-c++17-extensions"
        PICKY_CXXFLAGS="-Wextra -pedantic -Wno-long-long -Weffc++ -Wmissing-declarations"
        ;;
      distcheck)


### PR DESCRIPTION
This adds a github action to

- build
- test

Mosh on both macos and ubuntu

Currently, the macos build seems to be failing, ~~maybe due to 6fe7cde94db404e0a01a0af39cdd27c4646d067c, though this still requires further investigation~~ actually, I think the failure is due to [this protobuf commit](https://github.com/protocolbuffers/protobuf/commit/624d29d83306f3ce2c7e092dd44a891e04215e67) as discussed [here]( https://github.com/protocolbuffers/protobuf/issues/9181)