### PR TITLE
Unset stale SSH_TTY environment variable

### DIFF
--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -570,6 +570,12 @@ static int run_server( const char *desired_ip, const char *desired_port,
       exit( 1 );
     }
 
+    /* clear stale SSH_TTY environment variable */
+    if ( unsetenv( "SSH_TTY" ) < 0 ) {
+      perror( "unsetenv" );
+      exit( 1 );
+    }
+
     chdir_homedir();
 
     if ( with_motd && (!motd_hushed()) ) {


### PR DESCRIPTION
This variable would confuse devices that relied on it, such as the Clipetty extension for Emacs. See issue #1134.

Tested on my end, I can now use Clipetty without needing to detect Mosh's existence and unset the variable manually. LMK if I did anything incorrectly.