### PR TITLE
Import Debian changes 1.3.2-2.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+mosh (1.3.2-2.2) unstable; urgency=medium
+
+  * Non-maintainer upload.
+  * Lower warning level to distcheck to solve build against OpenSSL 3.0 with
+    permitted deprecated declarations. (Closes: #1005718)
+
+ -- Nicholas Guriev <guriev-ns@ya.ru>  Sat, 28 May 2022 10:01:51 +0300
+
+mosh (1.3.2-2.1) unstable; urgency=low
+
+  * Non-maintainer upload.
+  * Add upstream fix for FTBFS with gcc 8, thanks to Reiner Herrmann.
+    (Closes: #897813)
+
+ -- Adrian Bunk <bunk@debian.org>  Wed, 08 Aug 2018 20:45:44 +0300
+
 mosh (1.3.2-2) unstable; urgency=medium
 
   * Fix "mosh FTBFS with gcc 7" <remove default constructors>

--- a/debian/patches/0001-Fix-gcc8-snprintf-truncation-warning.patch
+++ b/debian/patches/0001-Fix-gcc8-snprintf-truncation-warning.patch
@@ -1,0 +1,24 @@
+From 2a5b5410b2a96d656544803809de109f474901f2 Mon Sep 17 00:00:00 2001
+From: John Hood <cgull@glup.org>
+Date: Wed, 11 Apr 2018 18:10:59 -0400
+Subject: Fix gcc8 snprintf truncation warning.
+
+---
+ src/frontend/mosh-server.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/frontend/mosh-server.cc b/src/frontend/mosh-server.cc
+index 7918c74..567252f 100644
+--- a/src/frontend/mosh-server.cc
++++ b/src/frontend/mosh-server.cc
+@@ -764,8 +764,8 @@ static void serve( int host_fd, Terminal
+ 	      throw NetworkException( std::string( "serve: getnameinfo: " ) + gai_strerror( errcode ), 0 );
+ 	    }
+ 
+-	    char tmp[ 64 ];
+-	    snprintf( tmp, 64, "%s via mosh [%d]", host, getpid() );
++	    char tmp[ 64 + NI_MAXHOST ];
++	    snprintf( tmp, 64 + NI_MAXHOST, "%s via mosh [%d]", host, getpid() );
+ 	    utempter_add_record( host_fd, tmp );
+ 
+ 	    connected_utmp = true;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-Fix-Debian-GCC7-FTBFS-remove-default-constructors.patch
+0001-Fix-gcc8-snprintf-truncation-warning.patch

--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,7 @@ override_dh_auto_configure:
 		--disable-silent-rules \
 		--enable-ufw \
 		--enable-completion \
-		--enable-compile-warnings=error
+		--enable-compile-warnings=distcheck
 
 override_dh_perl:
 	# mosh only uses Perl modules in perl-base.


### PR DESCRIPTION
mosh (1.3.2-2.2) unstable; urgency=medium
.
  * Non-maintainer upload.
  * Lower warning level to distcheck to solve build against OpenSSL 3.0 with
    permitted deprecated declarations. (Closes: #1005718)
.
mosh (1.3.2-2.1) unstable; urgency=low
.
  * Non-maintainer upload.
  * Add upstream fix for FTBFS with gcc 8, thanks to Reiner Herrmann.
    (Closes: #897813)