### PR TITLE
Put -lnettle back on the link line when using Nettle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -385,7 +385,7 @@ AS_CASE([$with_crypto_library],
        [AC_MSG_ERROR([OpenSSL crypto library not found])])
      AC_DEFINE([USE_OPENSSL_AES], [1], [Use OpenSSL library])
      AC_SUBST([CRYPTO_CFLAGS], ["$OpenSSL_CFLAGS"])
-     AC_SUBST([CRYPTO_LIBS], ["$OpenSSL_LDFLAGS -lcrypto"])])
+     AC_SUBST([CRYPTO_LIBS], ["$OpenSSL_LIBS -lcrypto"])])
 case "${with_crypto_library}" in
   openssl|openssl-with-internal-ocb)
     AS_IF([test "x$have_deprecated_openssl_aes" != xyes],
@@ -404,7 +404,7 @@ case "${with_crypto_library}" in
       [AC_MSG_ERROR([Nettle crypto library not found])])
     AC_DEFINE([USE_NETTLE_AES], [1], [Use Nettle library])
     AC_SUBST([CRYPTO_CFLAGS], ["$Nettle_CFLAGS"])
-    AC_SUBST([CRYPTO_LIBS], ["$Nettle_LDFLAGS"])
+    AC_SUBST([CRYPTO_LIBS], ["$Nettle_LIBS"])
     AM_CONDITIONAL([USE_AES_OCB_FROM_OPENSSL], [false])
     human_readable_cryptography_description='internal OCB, Nettle AES'
     ;;


### PR DESCRIPTION
bacc02408325db9650e60207407bb055100e627e inadvertently stopped propagating `pkg-config --libs` output into the link line. This didn’t affect OpenSSL (since configure.ac puts -lcrypto there manually) or Apple Common Crypto (since it’s not a separate dylib), but it broke Nettle builds. Fix Nettle builds by ensuring that `pkg-config --libs` output actually makes it to the linker.