### PR TITLE
OCB: Make primitive AES API explicit

### DIFF
--- a/src/crypto/ocb_internal.cc
+++ b/src/crypto/ocb_internal.cc
@@ -388,11 +388,6 @@ typedef struct {
 	CCCryptorRef ref;
 	uint8_t b[4096];
 } AES_KEY;
-#if (OCB_KEY_LEN == 0)
-#define ROUNDS(ctx) ((ctx)->rounds)
-#else
-#define ROUNDS(ctx) (6+OCB_KEY_LEN/4)
-#endif
 
 static inline void AES_set_encrypt_key(unsigned char *handle, const int bits, AES_KEY *key)
 {
@@ -473,11 +468,6 @@ static inline void AES_ecb_decrypt_blks(block *blks, unsigned nblks, AES_KEY *ke
 #include <nettle/aes.h>
 
 typedef struct aes_ctx AES_KEY;
-#if (OCB_KEY_LEN == 0)
-#define ROUNDS(ctx) ((ctx)->rounds)
-#else
-#define ROUNDS(ctx) (6+OCB_KEY_LEN/4)
-#endif
 
 static inline void AES_set_encrypt_key(unsigned char *handle, const int bits, AES_KEY *key)
 {


### PR DESCRIPTION
Explicitly define the primitive AES API used by the internal OCB implementation, and move it into its own namespace (`ocb_aes`). This will ease future implementation changes.

Delete the unused `ROUNDS` macro. This macro was used in the reference and AES-NI AES implementations, both of which were deleted in a563093f16be3fca2127224d5c6db36db60c79ca.

Bug: https://github.com/mobile-shell/mosh/issues/1174