### PR TITLE
Fixes for distcheck

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,8 @@ MISC_CXXFLAGS=""
 AC_ARG_ENABLE([fuzzing],
   [AS_HELP_STRING([--enable-fuzzing],
     [Enable compiler and linker options to enable fuzz testing @<:@no/yes/libfuzzer@:>@])],
-  [case "$enableval" in
+  [fuzzing="$enableval"
+   case "$enableval" in
     no)
       ;;
     '' | yes | libfuzzer)
@@ -86,9 +87,10 @@ AC_ARG_ENABLE([fuzzing],
      AC_MSG_ERROR(["Unknown argument '$enableval' to --enable-fuzzing])
      ;;
   esac],
-  [])
+  [fuzzing="no"])
 AC_SUBST([FUZZING_CFLAGS])
 AC_SUBST([MISC_CXXFLAGS])
+AM_CONDITIONAL([ENABLE_FUZZING], [test x"$fuzzing" != xno])
 
 AC_ARG_ENABLE([asan],
   [AS_HELP_STRING([--enable-asan],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = include protobufs util crypto terminal network statesync frontend examples tests
+SUBDIRS = include protobufs util crypto terminal network statesync frontend examples tests fuzz

--- a/src/fuzz/Makefile.am
+++ b/src/fuzz/Makefile.am
@@ -1,6 +1,8 @@
 AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) $(HARDEN_CFLAGS) $(MISC_CXXFLAGS) $(CODE_COVERAGE_CXXFLAGS) $(FUZZING_CFLAGS)
 
-noinst_PROGRAMS = terminal_parser_fuzzer terminal_fuzzer
+if ENABLE_FUZZING
+  noinst_PROGRAMS = terminal_parser_fuzzer terminal_fuzzer
+endif
 
 terminal_parser_fuzzer_CPPFLAGS = -I$(srcdir)/../terminal -I$(srcdir)/../util
 terminal_parser_fuzzer_LDADD = ../terminal/libmoshterminal.a ../util/libmoshutil.a


### PR DESCRIPTION
When fuzzing support was added, I failed to add the `fuzz` directory to SUBDIRs. This resulted in some small bugs.