### PR TITLE
Revert "Disable clang warning in order to mitigate protocolbuffers/protobuf#9181"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,9 +43,7 @@ AC_ARG_ENABLE([compile-warnings],
        PICKY_CXXFLAGS="-Wextra -pedantic -Wno-long-long -Weffc++ -Wmissing-declarations"
        ;;
      error)
-       # remove -Wno-c++17-extensions once protocolbuffers/protobuf#9181 is
-       # resolved
-       WARNING_CXXFLAGS="-Wall -Werror -Wno-c++17-extensions"
+       WARNING_CXXFLAGS="-Wall -Werror"
        PICKY_CXXFLAGS="-Wextra -pedantic -Wno-long-long -Weffc++ -Wmissing-declarations"
        ;;
      distcheck)


### PR DESCRIPTION
This reverts commit dbe419d0e069df3fedc212d456449f64d0280c76.

Since https://github.com/protocolbuffers/protobuf/issues/9181 hase been
resolved, this workaround should no longer be needed.
