### PR TITLE
Switch macOS multi-arch to x86_64+arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,44 @@ on:
       - "mosh-*.*.*"
 
 jobs:
+  macports-cache:
+    runs-on: macos-12
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: "Install gtar wrapper"
+      run: |
+        sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
+        sudo cp macosx/gtar /usr/local/bin/gtar
+        sudo chmod +x /usr/local/bin/gtar
+
+    - name: Cache macports
+      id: cache-macports
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-macports
+      with:
+        path: /opt/local
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('macosx/port-deps.sh') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: "setup MacPorts environment"
+      run: |
+        curl -L "https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2-12-Monterey.pkg" --output macports.pkg
+        sudo installer -pkg macports.pkg -target /
+        ./macosx/port-deps.sh deps
+
   release:
+    needs: macports-cache
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-12]
 
     steps:
     - uses: actions/checkout@v2
@@ -21,17 +53,34 @@ jobs:
     - name: "ensure version bumped"
       run: |
         expected_tag=$(echo ${{ github.ref }} | cut -d'/' -f3)
-        have_tag=$(sed -n 's/AC_INIT(\[[^]]*\], \[\([^]]*\)\].*/\1/p' <configure.ac)
+        have_tag="mosh-$(sed -n 's/AC_INIT(\[[^]]*\], \[\([^]]*\)\].*/\1/p' <configure.ac)"
         echo "Expected tag <$expected_tag>, got <$have_tag>"
-        [[ "$expected_tag" != "$have_tag" ]] && exit 1
+        if [[ "$expected_tag" != "$have_tag" ]]; then exit 1; fi
 
     - name: "setup linux build environment"
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: sudo apt install -y protobuf-compiler libprotobuf-dev libutempter-dev autoconf automake nettle-dev
 
-    - name: "setup macos build environment"
+    - name: "Install gtar wrapper"
       if: ${{ startsWith(matrix.os, 'macos') }}
-      run: brew install protobuf automake
+      run: |
+        sudo mv /usr/local/bin/gtar /usr/local/bin/gtar.orig
+        sudo cp macosx/gtar /usr/local/bin/gtar
+        sudo chmod +x /usr/local/bin/gtar
+
+    - name: Restore macports cache
+      id: cache-macports
+      if: ${{ startsWith(matrix.os, 'macos') }}
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-macports
+      with:
+        path: /opt/local
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('macosx/port-deps.sh') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
 
     - name: "describe macos build environment"
       if: ${{ startsWith(matrix.os, 'macos') }}
@@ -39,13 +88,13 @@ jobs:
         BUILD_TAG=$(echo ${{ github.ref }} | cut -d'/' -f3)
         mkdir macosx/build-report &&
         pushd macosx/build-report &&
-        ../brew-deps.sh describe &&
+        ../port-deps.sh describe &&
         ../osx-xcode.sh describe &&
         tar -cjf "../${BUILD_TAG}-osx-build-report.tbz" . &&
         popd
 
     - name: "generate build scripts"
-      run: ./autogen.sh
+      run: PATH=/opt/local/bin:$PATH ./autogen.sh
 
     - name: "configure"
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
@@ -58,16 +107,16 @@ jobs:
     - name: "test"
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: make V=1 distcheck -j
-    
+
     - name: "unshallow git repository for git describe"
-      if: ${{ startsWith(matrix.os, 'macos') }}     
+      if: ${{ startsWith(matrix.os, 'macos') }}
       run: git fetch --tags --unshallow
-      
+
     - name: "macOS package build"
       if: ${{ startsWith(matrix.os, 'macos') }}
       run: |
         pushd macosx &&
-        env ZERO_AR_DATE=1 MACOSX_DEPLOYMENT_TARGET=10.12 ./build.sh &&
+        env ZERO_AR_DATE=1 MACOSX_DEPLOYMENT_TARGET=11.0 PATH=/opt/local/bin:$PATH ./build.sh &&
         popd
 
     - name: "Upload Release"
@@ -83,4 +132,3 @@ jobs:
           mosh-*.tar.gz
           macosx/*.pkg
           macosx/*-osx-build-report.tbz
-

--- a/macosx/build.sh
+++ b/macosx/build.sh
@@ -39,7 +39,8 @@ echo "Building into prefix..."
 #
 PREFIX="$(pwd)/prefix"
 
-ARCHS=" ppc ppc64 i386 x86_64"
+HOST="x86_64-apple-macosx${MACOSX_DEPLOYMENT_TARGET}"
+ARCH_TRIPLES="x86_64-apple-macosx arm64-apple-macos"
 
 pushd .. > /dev/null
 
@@ -52,16 +53,18 @@ fi
 #
 # Build archs one by one.
 #
-for arch in $ARCHS; do
+for triple in $ARCH_TRIPLES; do
+    arch=$(echo $triple | cut -d- -f1)
     echo "Building for ${arch}..."
     prefix="${PREFIX}_${arch}"
     rm -rf "${prefix}"
     mkdir "${prefix}"
-    if ./configure --prefix="${prefix}/local" \
+    if ./configure --prefix="${prefix}/local" --build="${triple}${MACOSX_DEPLOYMENT_TARGET}"\
+		   --host="${HOST}" \
 		   CC="cc -arch ${arch}" CPP="cc -arch ${arch} -E" CXX="c++ -arch ${arch}" \
 		   TINFO_LIBS=-lncurses &&
 	    make clean &&
-	    make install -j8 &&
+	    make install -j8 V=1 &&
 	    rm -f "${prefix}/etc"
     then
 	# mosh-client built with Xcode 3.1.2 bus-errors if the binary is stripped.

--- a/macosx/gtar
+++ b/macosx/gtar
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec sudo /usr/local/bin/gtar.orig "$@"

--- a/macosx/port-deps.sh
+++ b/macosx/port-deps.sh
@@ -1,0 +1,16 @@
+describe() {
+    /opt/local/bin/port version > port-version.txt
+    /opt/local/bin/port -v -q installed > port-packages.txt
+}
+
+deps() {
+    # Set up macports to respect the deployment target before building universal packages
+    echo "macosx_deployment_target 11.0" | sudo tee -a /opt/local/etc/macports/macports.conf
+    sudo /opt/local/bin/port install protobuf3-cpp +universal
+    sudo /opt/local/bin/port install ncurses +universal
+    sudo /opt/local/bin/port install pkgconfig
+    sudo /opt/local/bin/port install autoconf automake
+}
+
+set -e
+"$@"


### PR DESCRIPTION
The previous CI attemtped to use Homebrew for builds, but
unfortunately Homebrew has dropped support for universal packages aka
multiarch (fat) binaries. This means that in order to build an arm64 +
x86_64 package, macports has to be used instead of homebrew.

Unlike Homebrew, MacPorts is not installed by default on the GitHub
Actions runners, so we need to install it ourselves. This means
managing our own instance of the cache, which itself produces
challenges as the `gtar` binary run by the action doesn't have enough
permissions to restore the MacPorts checkout. So we have to shim gtar
with a sudo wrapper.

With this commit, we produce a Mosh package that works on macOS 11.0
and newer, on both arm64 and x86_64 architectures. The protobuf
library is statically linked, but all other libraries are provided by
the system.