### PR TITLE
Fetch forcibly while fetching tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: "unshallow git repository for git describe"
       if: ${{ startsWith(matrix.os, 'macos') }}
-      run: git fetch --tags --unshallow
+      run: git fetch --tags --unshallow -f
 
     - name: "macOS package build"
       if: ${{ startsWith(matrix.os, 'macos') }}


### PR DESCRIPTION
`git fetch --tags --unshallow`, run as part of the CI for `git
describe` to do the right thing, ran into the error:

```
 ! [rejected]        mosh-1.4.0-rc0   -> mosh-1.4.0-rc0  (would clobber existing tag)
```

This is because mosh uses annotated tags, whereas the initial fetch
command run by actions/checkout@v2 ends up creating an *unannotated*
tag of the same name.

This means that any time the release CI runs, it would fail.

The resolution is straightforward: --force so that the line becomes

```
 t [tag update]      mosh-1.4.0-rc0 -> mosh-1.4.0-rc0
```

and the annotation is brought in.