### PR TITLE
Release for Debian experimental, take 2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-mosh (1.3.2.95rc2-1) unstable; urgency=medium
+mosh (1.3.2.95rc2-1) experimental; urgency=medium
 
   * New upstream release candidate.
 
- -- Benjamin Barenblat <bbaren@debian.org>  Wed, 26 Oct 2022 20:15:07 -0400
+ -- Benjamin Barenblat <bbaren@debian.org>  Wed, 26 Oct 2022 20:37:12 -0400
 
 mosh (1.3.2-2) unstable; urgency=medium
 


### PR DESCRIPTION
experimental is spelled “experimental”, not “unstable”. Oops. Fix 3006ce6d041fc57e43b104472bf41fe9a1ae77d8’s debian/changelog.