### PR TITLE
Report errors from mosh-server startup to the user

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -409,61 +409,61 @@ if ( $pid == 0 ) { # child
   my @exec_argv = ( @ssh, @sshopts, $userhost, '--', $ssh_connection . "$server " . shell_quote( @server ) );
   exec @exec_argv;
   die "Cannot exec ssh: $!\n";
-} else { # parent
-  my ( $sship, $port, $key );
-  my $bad_udp_port_warning = 0;
-  LINE: while ( <$pipe> ) {
-    chomp;
-    if ( m{^MOSH IP } ) {
-      if ( defined $ip ) {
-	die "$0 error: detected attempt to redefine MOSH IP.\n";
-      }
-      ( $ip ) = m{^MOSH IP (\S+)\s*$} or die "Bad MOSH IP string: $_\n";
-    } elsif ( m{^MOSH SSH_CONNECTION } ) {
-      my @words = split;
-      if ( scalar @words == 6 ) {
-	$sship = $words[4];
-      } else {
-	die "Bad MOSH SSH_CONNECTION string: $_\n";
-      }
-    } elsif ( m{^MOSH CONNECT } ) {
-      if ( ( $port, $key ) = m{^MOSH CONNECT (\d+?) ([A-Za-z0-9/+]{22})\s*$} ) {
-	last LINE;
-      } else {
-	die "Bad MOSH CONNECT string: $_\n";
-      }
-    } else {
-      if ( defined $port_request and $port_request =~ m{:} and m{Bad UDP port} ) {
-	$bad_udp_port_warning = 1;
-      }
-      print "$_\n";
-    }
-  }
-  close $pipe;
-  waitpid $pid, 0;
-
-  if ( not defined $ip ) {
-    if ( defined $sship ) {
-      warn "$0: Using remote IP address ${sship} from \$SSH_CONNECTION for hostname ${userhost}\n";
-      $ip = $sship;
-    } else {
-      die "$0: Did not find remote IP address (is SSH ProxyCommand disabled?).\n";
-    }
-  }
-
-  if ( not defined $key or not defined $port ) {
-    if ( $bad_udp_port_warning ) {
-      die "$0: Server does not support UDP port range option.\n";
-    }
-    die "$0: Did not find mosh server startup message. (Have you installed mosh on your server?)\n";
-  }
-
-  # Now start real mosh client
-  $ENV{ 'MOSH_KEY' } = $key;
-  $ENV{ 'MOSH_PREDICTION_DISPLAY' } = $predict;
-  $ENV{ 'MOSH_NO_TERM_INIT' } = '1' if !$term_init;
-  exec {$client} ("$client", "-# @cmdline |", $ip, $port);
 }
+# parent
+my ( $sship, $port, $key );
+my $bad_udp_port_warning = 0;
+LINE: while ( <$pipe> ) {
+  chomp;
+  if ( m{^MOSH IP } ) {
+    if ( defined $ip ) {
+      die "$0 error: detected attempt to redefine MOSH IP.\n";
+    }
+    ( $ip ) = m{^MOSH IP (\S+)\s*$} or die "Bad MOSH IP string: $_\n";
+  } elsif ( m{^MOSH SSH_CONNECTION } ) {
+    my @words = split;
+    if ( scalar @words == 6 ) {
+      $sship = $words[4];
+    } else {
+      die "Bad MOSH SSH_CONNECTION string: $_\n";
+    }
+  } elsif ( m{^MOSH CONNECT } ) {
+    if ( ( $port, $key ) = m{^MOSH CONNECT (\d+?) ([A-Za-z0-9/+]{22})\s*$} ) {
+      last LINE;
+    } else {
+      die "Bad MOSH CONNECT string: $_\n";
+    }
+  } else {
+    if ( defined $port_request and $port_request =~ m{:} and m{Bad UDP port} ) {
+      $bad_udp_port_warning = 1;
+    }
+    print "$_\n";
+  }
+}
+waitpid $pid, 0;
+close $pipe;
+
+if ( not defined $ip ) {
+  if ( defined $sship ) {
+    warn "$0: Using remote IP address ${sship} from \$SSH_CONNECTION for hostname ${userhost}\n";
+    $ip = $sship;
+  } else {
+    die "$0: Did not find remote IP address (is SSH ProxyCommand disabled?).\n";
+  }
+}
+
+if ( not defined $key or not defined $port ) {
+  if ( $bad_udp_port_warning ) {
+    die "$0: Server does not support UDP port range option.\n";
+  }
+  die "$0: Did not find mosh server startup message. (Have you installed mosh on your server?)\n";
+}
+
+# Now start real mosh client
+$ENV{ 'MOSH_KEY' } = $key;
+$ENV{ 'MOSH_PREDICTION_DISPLAY' } = $predict;
+$ENV{ 'MOSH_NO_TERM_INIT' } = '1' if !$term_init;
+exec {$client} ("$client", "-# @cmdline |", $ip, $port);
 
 sub shell_quote { join ' ', map {(my $a = $_) =~ s/'/'\\''/g; "'$a'"} @_ }
 

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -31,6 +31,7 @@ displaytests = \
 	pty-deadlock.test \
 	repeat.test \
 	repeat-with-input.test \
+	server-failure.test \
 	server-network-timeout.test \
 	server-signal-timeout.test \
 	window-resize.test \

--- a/src/tests/e2e-test
+++ b/src/tests/e2e-test
@@ -237,21 +237,21 @@ for run in $server_tests; do
 	if [ "$server_rv" -ne 0 ]; then
 	    test_error "server harness exited with status %s\n" "$server_rv"
 	fi
-    fi
-    if [ "${run}" != "direct" ]; then
-	# Check for "round-trip" failures
-	if grep -q "round-trip Instruction verification failed" "${test_dir}/${run}.server.stderr"; then
-	    test_error "Round-trip Instruction verification failed on server during %s\n" "$run"
-	fi
-	# Check for 0-timeout select() issue
-	if egrep -q "(polls, rate limiting|consecutive polls)" "${test_dir}/${run}.server.stderr"; then
-	    if [ "osx" != "${TRAVIS_OS_NAME}" ]; then
-		test_error "select() with zero timeout called too often on server during %s\n" "$run"
+	if [ "${run}" != "direct" ]; then
+	    # Check for "round-trip" failures
+	    if grep -q "round-trip Instruction verification failed" "${test_dir}/${run}.server.stderr"; then
+		test_error "Round-trip Instruction verification failed on server during %s\n" "$run"
 	    fi
-	fi
-	# Check for assert()
-	if egrep -q "assertion.*failed" "${test_dir}/${run}.server.stderr"; then
-	    test_error "assertion during %s\n" "$run"
+	    # Check for 0-timeout select() issue
+	    if egrep -q "(polls, rate limiting|consecutive polls)" "${test_dir}/${run}.server.stderr"; then
+		if [ "osx" != "${TRAVIS_OS_NAME}" ]; then
+		    test_error "select() with zero timeout called too often on server during %s\n" "$run"
+		fi
+	    fi
+	    # Check for assert()
+	    if egrep -q "assertion.*failed" "${test_dir}/${run}.server.stderr"; then
+		test_error "assertion during %s\n" "$run"
+	    fi
 	fi
     fi
     # XXX We'd also like to check for "target state Instruction

--- a/src/tests/server-failure.test
+++ b/src/tests/server-failure.test
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+#
+# Run mosh with a bad server command, check that it reports this usefully.
+#
+
+# shellcheck source=e2e-test-subrs
+. "$(dirname "$0")/e2e-test-subrs"
+PATH=$PATH:.:$srcdir
+# Top-level wrapper.
+if [ $# -eq 0 ]; then
+    e2e-test "$0" baseline client server mosh-args post
+    exit
+fi
+
+# OK, we have arguments, we're one of the test hooks.
+if [ $# -lt 1 ]; then
+    fail "bad arguments %s\n" "$@"
+fi
+
+# The mosh session test command is never run.
+baseline()
+{
+    printf "@@@ done\n"
+}
+
+# Return inverted exitstatus from mosh-client.
+client()
+{
+    ! "$@"
+    exit
+}
+
+# Add a do-nothing server command, to disable the standard harness
+# checks in e2e-test.
+server()
+{
+    exit 0
+}
+
+# Make mosh.pl fail with a bad server.
+mosh_args()
+{
+    printf "%s\n" "--server false"
+}
+
+# Check for correct reporting of that failure.
+post()
+{
+    if ! grep 'server command failed with exitstatus' "$(basename "$0").d/baseline.tmux.log"; then
+	exit 1
+    fi
+}
+
+case $1 in
+    baseline)
+	baseline;;
+    client)
+	shift
+	client "$@";;
+    mosh-args)
+	mosh_args;;
+    post)
+	post;;
+    server)
+	server;;
+    *)
+	fail "unknown test argument %s\n" "$1";;
+esac


### PR DESCRIPTION
This pull request mostly fixes a longtime irritant in Mosh-- the lack of error reporting when `mosh-server` goes sideways.  It does this by rearranging some code in `mosh-server` so the session information is sent before the server forks, and rearranging some code code in `mosh.pl` so that the session information is captured in the parent, not the child.  When those two things are done, then `mosh-server` can report some errors before it forks off into the sunset, and `mosh.pl` can usefully capture the exitstatus of the ssh command.  There's a new test to check some of that too.

fixes #1042 
partially addresses #1005 
and would have prevented countless questions on IRC.
