### PR TITLE
update for obsolete autoconf macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -322,7 +322,7 @@ PKG_CHECK_MODULES([TINFO], [tinfo],
         AC_SUBST([TINFO_LIBS], ["$TINFO_LDFLAGS -ltinfo"])],)])])
 
 # Then try to find it in a specific install dir
-AC_ARG_WITH(curses, [AC_HELP_STRING([--with-curses=DIR], [Where curses is installed])],
+AC_ARG_WITH(curses, [AS_HELP_STRING([--with-curses=DIR], [Where curses is installed])],
     [if test $withval != yes; then
         cv_curses=$withval
     fi


### PR DESCRIPTION
Seen on FreeBSD + latest ports and MacOS + Homebrew, both on autoconf 2.71:

```jhood@lister:/home/jhood/src/mosh-keithw 0 $ ./autogen.sh 
configure.ac:325: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:325: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1553: AC_ARG_WITH is expanded from...
configure.ac:325: the top level
```
This fixes that, with the autoupdate changes minimized to the 1-character change that's actually required here.