### PR TITLE
Portability: restore check for system OpenSSL libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -381,7 +381,10 @@ PKG_CHECK_MODULES([OpenSSL], [openssl],
   [have_openssl=yes
     AC_CHECK_LIB([crypto], [AES_encrypt], [have_deprecated_openssl_aes=yes])
     AC_CHECK_LIB([crypto], [EVP_aes_128_ocb], [have_evp_aes_ocb=yes])],
-  [:])
+  [AX_CHECK_LIBRARY([crypto], [openssl/aes.h], [crypto],
+    [have_openssl=yes
+      AC_CHECK_LIB([crypto], [AES_encrypt], [have_deprecated_openssl_aes=yes])
+      AC_CHECK_LIB([crypto], [EVP_aes_128_ocb], [have_evp_aes_ocb=yes])])])
 PKG_CHECK_MODULES([Nettle], [nettle], [have_nettle=yes], [:])
 AS_CASE([$with_crypto_library],
   [openssl*],

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -5,8 +5,8 @@ clean-local:
 	@rm -rf version.h
 
 version.h:	../../VERSION
-	@test -s $<
-	@printf '#define BUILD_VERSION "%s"\n' "$$(cat $<)" > $@.new
+	@test -s $?
+	@printf '#define BUILD_VERSION "%s"\n' "$$(cat $?)" > $@.new
 	@set -e; if ! diff -q $@ $@.new > /dev/null 2>&1; then \
 		mv -f $@.new $@; \
 	fi


### PR DESCRIPTION
Some non-Linux systems, most notably FreeBSD and the other *BSDs, have OpenSSL as part of the base OS.  FreeBSD, at least, does not have a pkg-config `.pc` file, because it's not actually a package.  (All the *BSDs also have various OpenSSL versions and its forks available in packages as well.  But using them can cause various kinds of pain dealing with multiple versions, and it's better to avoid them if they're not needed.)

There was a check using `AX_CHECK_LIBRARY()` that got lost in commit bacc0240.  This brings it back, and also removes extended GNU Make syntax that I accidentally put in `src/include/Makefile.ac` that OpenBSD `make` refused to put up with.
