### PR TITLE
configure.ac: add support of protobuf 4.22.x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,10 @@ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AS_IF([pkg-config --atleast-version 3.6.0 protobuf],
   [AX_CXX_COMPILE_STDCXX([11])])
 
+# If current protobuf 4.22+ update the requires to C++14.
+AS_IF([pkg-config --atleast-version 4.22.0 protobuf],
+  [AX_CXX_COMPILE_STDCXX([14])])
+
 WARNING_CXXFLAGS=""
 PICKY_CXXFLAGS=""
 DISTCHECK_CXXFLAGS=""
@@ -310,6 +314,10 @@ AC_CHECK_FUNCS(m4_normalize([
   pselect
   pledge
   ]))
+
+AS_IF([pkg-config --atleast-version 4.22.0 protobuf],
+  [PKG_CHECK_MODULES([ABSL_LOG_INTERNAL_CHECK_OP], [absl_log_internal_check_op],[],
+     [AC_MSG_ERROR([Missing abseil-cpp library.])])])
 
 # Start by trying to find the needed tinfo parts by pkg-config
 PKG_CHECK_MODULES([TINFO], [tinfo],

--- a/src/frontend/Makefile.am
+++ b/src/frontend/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I$(srcdir)/../network -I$(srcdir)/../crypto -I../protobufs -I$(srcdir)/../util $(TINFO_CFLAGS) $(protobuf_CFLAGS) $(CRYPTO_CFLAGS)
 AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) $(HARDEN_CFLAGS) $(MISC_CXXFLAGS) $(CODE_COVERAGE_CXXFLAGS)
 AM_LDFLAGS  = $(HARDEN_LDFLAGS) $(CODE_COVERAGE_LIBS)
-LDADD = ../crypto/libmoshcrypto.a ../network/libmoshnetwork.a ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../util/libmoshutil.a ../protobufs/libmoshprotos.a -lm $(TINFO_LIBS) $(protobuf_LIBS) $(CRYPTO_LIBS)
+LDADD = ../crypto/libmoshcrypto.a ../network/libmoshnetwork.a ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../util/libmoshutil.a ../protobufs/libmoshprotos.a -lm $(TINFO_LIBS) $(protobuf_LIBS) $(CRYPTO_LIBS) $(ABSL_LOG_INTERNAL_CHECK_OP_LIBS)
 
 mosh_server_LDADD = $(LDADD)
 


### PR DESCRIPTION
the protobuf 4.22x is using c++14 as default, this caused the mosh cannot compile anymore and report following error:

....
/usr/include/google/protobuf/port_def.inc:200:15: error: static assertion failed: Protobuf only supports C++14 and newer.
|   200 | static_assert(PROTOBUF_CPLUSPLUS_MIN(201402L), "Protobuf only supports C++14 and newer.");
|       |               ^~~~~~~~~~~~~~~~~~~~~~
....