### PR TITLE
A patch which makes mosh can be built in Windows

### DIFF
--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -1,0 +1,37 @@
+# Build Windows
+
+## Steps
+
+
+1. Download and install msys2 following the [instruction](https://www.msys2.org/#installation).
+2. Install dependencies.
+    ```
+    pacman -S mingw-w64-ucrt-x86_64-gcc
+    pacman -S mingw-w64-ucrt-x86_64-protobuf
+    pacman -S mingw-w64-ucrt-x86_64-ncurses
+    pacman -S mingw-w64-ucrt-x86_64-crypto++
+    pacman -S mingw-w64-ucrt-x86_64-openssl
+    pacman -S mingw-w64-ucrt-x86_64-autotools
+    ```
+3. Clone the repo and checkout the target branch.
+4. Run `./autogen.sh`.
+5. Run `./configure --enable-static-libraries --disable-server  --disable-examples`.
+6. Open `src/include/config.h`and find the following macro and make them defined.
+    ```
+    /* Define to 1 if you have the `cfmakeraw' function. */
+    #define HAVE_CFMAKERAW
+    
+    /* Define if you have forkpty(). */
+    #define HAVE_FORKPTY
+    ```
+7. Open `src/frontend/Makefile` and find the following libs definition and add libraries `-lws2_32 -lncursew`.
+    ```
+    LIBS = -Wl,-Bstatic -lz -Wl,-Bdynamic -lws2_32 -lncursesw
+    ```
+8. Open `Makefile` and find var`SUBDIRS`and remove unnecessary directories.
+    ```
+    SUBDIRS = scripts src man conf
+    👇
+    SUBDIRS = src
+    ```
+9. Run `make` and build successfully.

--- a/src/crypto/crypto.cc
+++ b/src/crypto/crypto.cc
@@ -35,7 +35,9 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifndef _WIN32
 #include <sys/resource.h>
+#endif
 #include <fstream>
 
 #include "byteorder.h"
@@ -285,11 +287,14 @@ const Message Session::decrypt( const char *str, size_t len )
   return ret;
 }
 
+#ifndef _WIN32
 static rlim_t saved_core_rlimit;
+#endif
 
 /* Disable dumping core, as a precaution to avoid saving sensitive data
    to disk. */
 void Crypto::disable_dumping_core( void ) {
+  #ifndef _WIN32
   struct rlimit limit;
   if ( 0 != getrlimit( RLIMIT_CORE, &limit ) ) {
     /* We don't throw CryptoException because this is called very early
@@ -304,13 +309,16 @@ void Crypto::disable_dumping_core( void ) {
     perror( "setrlimit(RLIMIT_CORE)" );
     exit( 1 );
   }
+  #endif
 }
 
 void Crypto::reenable_dumping_core( void ) {
   /* Silent failure is safe. */
+  #ifndef _WIN32
   struct rlimit limit;
   if ( 0 == getrlimit( RLIMIT_CORE, &limit ) ) {
     limit.rlim_cur = saved_core_rlimit;
     setrlimit( RLIMIT_CORE, &limit );
   }
+  #endif
 }

--- a/src/frontend/Makefile.am
+++ b/src/frontend/Makefile.am
@@ -15,5 +15,5 @@ if BUILD_SERVER
   bin_PROGRAMS += mosh-server
 endif
 
-mosh_client_SOURCES = mosh-client.cc stmclient.cc stmclient.h terminaloverlay.cc terminaloverlay.h
+mosh_client_SOURCES = mosh-client.cc stmclient.cc stmclient.h terminaloverlay.cc terminaloverlay.h tncon.cc tncon.h
 mosh_server_SOURCES = mosh-server.cc

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -181,10 +181,12 @@ int main( int argc, char *argv[] )
 
   string key( env_key );
 
+  #ifndef _WIN32
   if ( unsetenv( "MOSH_KEY" ) < 0 ) {
     perror( "unsetenv" );
     exit( 1 );
   }
+  #endif
 
   /* Adopt native locale */
   set_native_locale();

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -179,6 +179,15 @@ static std::string human_readable_duration( int num_seconds, const std::string &
   return tmp;
 }
 
+#ifdef _WIN32
+// TODO: wcwidth is not available on Windows (should provide character width)
+namespace {
+int wcwidth(wchar_t c) {
+    return 1;
+}
+}
+#endif
+
 void NotificationEngine::apply( Framebuffer &fb ) const
 {
   uint64_t now = timestamp();

--- a/src/frontend/tncon.cc
+++ b/src/frontend/tncon.cc
@@ -1,0 +1,831 @@
+/*
+* Author: Ray Hayes <ray.hayes@microsoft.com>
+* ANSI TTY Reader - Maps Windows console input events to ANSI stream
+*
+* Author: Balu <bagajjal@microsoft.com>
+* Misc fixes and code cleanup
+*
+* Copyright (c) 2017 Microsoft Corp.
+* All rights reserved
+*
+* This file is responsible for console reading calls for building an emulator
+* over Windows Console.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+* notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+* notice, this list of conditions and the following disclaimer in the
+* documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <windows.h>
+#include <wincon.h>
+//#include "ansiprsr.h"
+#include "tncon.h"
+//#include "tnnet.h"
+
+#define true TRUE
+#define false FALSE
+#define bool BOOL
+
+#define ENUM_CRLF 0
+#define ENUM_LF 1
+#define ENUM_CR 2
+
+bool gbVTAppMode;
+BOOL isAnsiParsingRequired = false;
+char *glob_out = NULL;
+int glob_outlen = 0;
+int glob_space = 0;
+unsigned char  NAWSSTR[] = { "\xff\xfa\x1f\x00\x00\x00\x00\xff\xf0" };
+extern int ScreenY;
+extern int ScreenX;
+extern int ScrollTop;
+extern int ScrollBottom;
+char tmp_buf[30];
+
+typedef struct _TelParams
+{
+    int fLogging;
+    FILE *fplogfile;
+
+    char *pInputFile;
+
+    char *szDebugInputFile;
+    BOOL fDebugWait;
+
+    int timeOut;
+    int fLocalEcho;
+    int fTreatLFasCRLF;
+    int	fSendCROnly;
+    int nReceiveCRLF;
+
+    char sleepChar;
+    char menuChar;
+
+    SOCKET Socket;
+    BOOL bVT100Mode;
+
+    char *pAltKey;
+
+} TelParams;
+
+/* terminal global switches*/
+TelParams Parameters = {
+	0,		/* int fLogging */
+	NULL,		/* FILE *fplogfile */
+	NULL,		/* char *pInputFile */
+	NULL,		/* char *szDebugInputFile */
+	FALSE,		/* BOOL fDebugWait */
+	0,		/* int timeOut */
+	0,		/* int fLocalEcho */
+	0,		/* int fTreatLFasCRLF */
+	0,		/* int	fSendCROnly */
+	ENUM_LF,	/* int nReceiveCRLF */
+	'`',		/* char sleepChar */
+	'\035',		/* char menuChar; // CTRL-]  */
+	0,		/* SOCKET Socket */
+	FALSE,		/* BOOL bVT100Mode */
+	"\x01",		/* char *pAltKey */
+};
+
+TelParams* pParams = &Parameters;
+
+//void queue_terminal_window_change_event();
+
+/*
+* For our case, in NetWriteString2(), we do not use socket, but write the out going data to
+* a global buffer setup by ReadConsoleForTermEmul().
+*/
+int
+NetWriteString2(SOCKET sock, char* source, size_t len, int options)
+{
+	while (len > 0) {
+		if (glob_outlen >= glob_space)
+			return glob_outlen;
+		*glob_out++ = *source++;
+		len--;
+		glob_outlen++;
+	}
+	return glob_outlen;
+}
+
+BOOL
+DataAvailable(HANDLE h)
+{
+	DWORD dwRet = WaitForSingleObject(h, INFINITE);
+	if (dwRet == WAIT_OBJECT_0)
+		return TRUE;
+	if (dwRet == WAIT_FAILED)
+		return FALSE;
+	return FALSE;
+}
+
+int
+GetModifierKey(DWORD dwControlKeyState)
+{
+	int modKey = 0;
+	if ((dwControlKeyState & LEFT_ALT_PRESSED) || (dwControlKeyState & RIGHT_ALT_PRESSED))
+		modKey += 2;
+
+	if (dwControlKeyState & SHIFT_PRESSED)
+		modKey += 1;
+
+	if ((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED))
+		modKey += 4;
+
+	if (modKey){
+		memset(tmp_buf, 0, sizeof(tmp_buf));
+		modKey++;
+	}		
+
+	return modKey;
+}
+
+int
+ReadConsoleForTermEmul(HANDLE hInput, char *destin, int destinlen, const std::function<void()> resizeHandler)
+{
+	HANDLE hHandle[] = { hInput, NULL };
+	DWORD nHandle = 1;
+	DWORD dwInput = 0;
+	DWORD dwControlKeyState = 0;
+	DWORD dwAltGrFlags = LEFT_CTRL_PRESSED | RIGHT_ALT_PRESSED;
+	DWORD rc = 0;
+	unsigned char octets[20];	
+	char aChar = 0;
+	INPUT_RECORD InputRecord;
+	BOOL bCapsOn = FALSE;
+	BOOL bShift = FALSE;
+	int modKey = 0;
+    const char* FN_KEY = NULL;
+    const char *SHIFT_FN_KEY = NULL;
+    const char *ALT_FN_KEY = NULL;
+    const char *CTRL_FN_KEY = NULL;
+    const char *SHIFT_ALT_FN_KEY = NULL;
+    const char *SHIFT_CTRL_FN_KEY = NULL;
+    const char *ALT_CTRL_FN_KEY = NULL;
+    const char *SHIFT_ALT_CTRL_FN_KEY = NULL;
+
+	glob_out = destin;
+	glob_space = destinlen;
+	glob_outlen = 0;
+	while (DataAvailable(hInput)) {
+		if (glob_outlen >= destinlen)
+			return glob_outlen;
+		ReadConsoleInputW(hInput, &InputRecord, 1, &dwInput);
+		switch (InputRecord.EventType) {
+		case WINDOW_BUFFER_SIZE_EVENT:
+		    resizeHandler();
+			break;
+
+		case FOCUS_EVENT:
+			/* FALLTHROUGH */
+		case MENU_EVENT:
+			break;
+
+		case KEY_EVENT:
+			bCapsOn = (InputRecord.Event.KeyEvent.dwControlKeyState & CAPSLOCK_ON);
+			bShift = (InputRecord.Event.KeyEvent.dwControlKeyState & SHIFT_PRESSED);
+			dwControlKeyState = InputRecord.Event.KeyEvent.dwControlKeyState &
+				~(CAPSLOCK_ON | ENHANCED_KEY | NUMLOCK_ON | SCROLLLOCK_ON);
+
+			/* ignore the AltGr flags*/
+			if ((dwControlKeyState & dwAltGrFlags) == dwAltGrFlags)
+				dwControlKeyState = dwControlKeyState & ~dwAltGrFlags;
+
+			modKey = GetModifierKey(dwControlKeyState);
+			if (InputRecord.Event.KeyEvent.bKeyDown) {
+			    int n;
+
+			    if( (dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) != 0 && InputRecord.Event.KeyEvent.wVirtualKeyCode == 0x36 ) {
+                                // handle Ctrl+^
+                                *octets = '\x1E';
+                                n = 1;
+                            } else {
+                                n = WideCharToMultiByte(
+                                        CP_UTF8,
+                                        0,
+                                        &(InputRecord.Event.KeyEvent.uChar.UnicodeChar),
+                                        1,
+                                        (LPSTR) octets,
+                                        20,
+                                        NULL,
+                                        NULL);
+                            }
+                //if (pParams->fLocalEcho)
+                //	ConWriteString((char *)octets, n);
+
+				switch (InputRecord.Event.KeyEvent.uChar.UnicodeChar) {
+				case 0xd:
+					if (pParams->nReceiveCRLF == ENUM_LF)
+						NetWriteString2(pParams->Socket, "\r", 1, 0);
+					else
+						NetWriteString2(pParams->Socket, "\r\n", 2, 0);
+					break;
+
+				case VK_ESCAPE:
+					NetWriteString2(pParams->Socket, (char *)ESCAPE_KEY, 1, 0);
+					break;
+
+				default:
+					switch (InputRecord.Event.KeyEvent.wVirtualKeyCode) {
+					case VK_UP:
+						if(!modKey)
+							NetWriteString2(pParams->Socket, (char *)(gbVTAppMode ? APP_UP_ARROW : UP_ARROW), 3, 0);
+						else {
+							/* ^[[1;mA */
+                            const char p[] = "\033[1;";
+							strcpy_s(tmp_buf, sizeof(tmp_buf), p);
+							size_t index = strlen(p);
+							tmp_buf[index++] = modKey + '0';
+							tmp_buf[index] = 'A';
+							
+							NetWriteString2(pParams->Socket, tmp_buf, index+1, 0);
+						}
+						break;
+					case VK_DOWN:
+						if(!modKey)
+							NetWriteString2(pParams->Socket, (char *)(gbVTAppMode ? APP_DOWN_ARROW : DOWN_ARROW), 3, 0);
+						else {
+							/* ^[[1;mB */
+							char *p = "\033[1;";
+							strcpy_s(tmp_buf, sizeof(tmp_buf), p);
+							size_t index = strlen(p);
+							tmp_buf[index++] = modKey + '0';
+							tmp_buf[index] = 'B';
+
+							NetWriteString2(pParams->Socket, tmp_buf, index+1, 0);
+						}
+						break;
+					case VK_RIGHT:
+						if(!modKey)
+							NetWriteString2(pParams->Socket, (char *)(gbVTAppMode ? APP_RIGHT_ARROW : RIGHT_ARROW), 3, 0);
+						else {
+							/* ^[[1;mC */
+							char *p = "\033[1;";			
+							strcpy_s(tmp_buf, sizeof(tmp_buf), p);
+							size_t index = strlen(p);
+							tmp_buf[index++] = modKey + '0';
+							tmp_buf[index] = 'C';
+							
+							NetWriteString2(pParams->Socket, tmp_buf, index+1, 0);
+						}
+						break;
+					case VK_LEFT:
+						if(!modKey)
+							NetWriteString2(pParams->Socket, (char *)(gbVTAppMode ? APP_LEFT_ARROW : LEFT_ARROW), 3, 0);
+						else {
+							/* ^[[1;mD */
+							char *p = "\033[1;";
+							strcpy_s(tmp_buf, sizeof(tmp_buf), p);
+							size_t index = strlen(p);
+							tmp_buf[index++] = modKey + '0';
+							tmp_buf[index] = 'D';
+
+							NetWriteString2(pParams->Socket, tmp_buf, index+1, 0);
+						}
+						break;
+					case VK_END:
+						if(!modKey)
+							NetWriteString2(pParams->Socket, (char *)SELECT_KEY, 4, 0);
+						else {
+							/* ^[[1;mF */
+							char *p = "\033[1;";
+							strcpy_s(tmp_buf, sizeof(tmp_buf), p);
+							size_t index = strlen(p);
+							tmp_buf[index++] = modKey + '0';
+							tmp_buf[index] = 'F';
+
+							NetWriteString2(pParams->Socket, tmp_buf, index+1, 0);
+						}
+						break;
+					case VK_HOME:
+						if(!modKey)
+							NetWriteString2(pParams->Socket, (char *)FIND_KEY, 4, 0);
+						else {
+							/* ^[[1;mH */
+							char *p = "\033[1;";
+							strcpy_s(tmp_buf, sizeof(tmp_buf), p);
+							size_t index = strlen(p);
+							tmp_buf[index++] = modKey + '0';
+							tmp_buf[index] = 'H';
+
+							NetWriteString2(pParams->Socket, tmp_buf, index+1, 0);
+						}
+						break;
+					case VK_INSERT:
+						if(!modKey)
+							NetWriteString2(pParams->Socket, (char *)INSERT_KEY, 4, 0);
+						else {
+							/* ^[[2;m~ */
+							char *p = "\033[2;";
+							strcpy_s(tmp_buf, sizeof(tmp_buf), p);
+							size_t index = strlen(p);
+							tmp_buf[index++] = modKey + '0';
+							tmp_buf[index] = '~';
+
+							NetWriteString2(pParams->Socket, tmp_buf, index+1, 0);
+						}
+						break;
+					case VK_DELETE:
+						if(!modKey)
+							NetWriteString2(pParams->Socket, (char *)REMOVE_KEY, 4, 0);
+						else {
+							/* ^[[3;m~ */
+							char *p = "\033[3;";
+							strcpy_s(tmp_buf, sizeof(tmp_buf), p);
+							size_t index = strlen(p);
+							tmp_buf[index++] = modKey + '0';
+							tmp_buf[index] = '~';
+
+							NetWriteString2(pParams->Socket, tmp_buf, index+1, 0);
+						}
+						break;
+					case VK_PRIOR: /* page up */
+						if (!modKey)
+							NetWriteString2(pParams->Socket, (char *)PREV_KEY, 4, 0);
+						else {
+							/* ^[[5;m~ */
+							char *p = "\033[5;";
+							strcpy_s(tmp_buf, sizeof(tmp_buf), p);
+							size_t index = strlen(p);
+							tmp_buf[index++] = modKey + '0';
+							tmp_buf[index] = '~';
+
+							NetWriteString2(pParams->Socket, tmp_buf, index+1, 0);
+						}
+						break;
+					case VK_NEXT: /* page down */
+						if(!modKey)
+							NetWriteString2(pParams->Socket, (char *)NEXT_KEY, 4, 0);
+						else {
+							/* ^[[6;m~  */
+							char *p = "\033[6;";
+							strcpy_s(tmp_buf, sizeof(tmp_buf), p);
+							size_t index = strlen(p);
+							tmp_buf[index++] = modKey + '0';
+							tmp_buf[index] = '~';
+
+							NetWriteString2(pParams->Socket, tmp_buf, index+1, 0);
+						}
+						break;
+					case VK_BACK:
+						NetWriteString2(pParams->Socket, (char *)BACKSPACE_KEY, 1, 0);
+						break;
+					case VK_TAB:
+						if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_TAB_KEY, 3, 0);
+						else
+							NetWriteString2(pParams->Socket, (char *)octets, n, 0);
+						break;
+					case VK_ESCAPE:
+						NetWriteString2(pParams->Socket, (char *)ESCAPE_KEY, 1, 0);
+						break;
+					case VK_SHIFT:
+					case VK_CONTROL:
+					case VK_CAPITAL:
+						break; /* NOP on these */
+					case VK_F1:
+						/* If isAnsiParsingRequired is false then we use XTERM VT sequence */
+						FN_KEY = isAnsiParsingRequired ? PF1_KEY : XTERM_PF1_KEY;
+						SHIFT_FN_KEY = isAnsiParsingRequired ? SHIFT_PF1_KEY : XTERM_SHIFT_PF1_KEY;
+						ALT_FN_KEY = isAnsiParsingRequired ? ALT_PF1_KEY : XTERM_ALT_PF1_KEY;
+						CTRL_FN_KEY = isAnsiParsingRequired ? CTRL_PF1_KEY : XTERM_CTRL_PF1_KEY;
+						SHIFT_ALT_FN_KEY = isAnsiParsingRequired ? SHIFT_ALT_PF1_KEY : XTERM_SHIFT_ALT_PF1_KEY;
+						SHIFT_CTRL_FN_KEY = isAnsiParsingRequired ? SHIFT_CTRL_PF1_KEY : XTERM_SHIFT_CTRL_PF1_KEY;
+						ALT_CTRL_FN_KEY = isAnsiParsingRequired ? ALT_CTRL_PF1_KEY : XTERM_ALT_CTRL_PF1_KEY;
+						SHIFT_ALT_CTRL_FN_KEY = isAnsiParsingRequired ? SHIFT_ALT_CTRL_PF1_KEY : XTERM_SHIFT_ALT_CTRL_PF1_KEY;
+
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)FN_KEY, strlen(FN_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_FN_KEY, strlen(SHIFT_FN_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_FN_KEY, strlen(CTRL_FN_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_FN_KEY, strlen(ALT_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_FN_KEY, strlen(SHIFT_ALT_CTRL_FN_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_FN_KEY, strlen(ALT_CTRL_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_FN_KEY, strlen(SHIFT_ALT_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_FN_KEY, strlen(SHIFT_CTRL_FN_KEY), 0);
+
+						break;
+					case VK_F2:
+						/* If isAnsiParsingRequired is false then we use XTERM VT sequence */
+						FN_KEY = isAnsiParsingRequired ? PF2_KEY : XTERM_PF2_KEY;
+						SHIFT_FN_KEY = isAnsiParsingRequired ? SHIFT_PF2_KEY : XTERM_SHIFT_PF2_KEY;
+						ALT_FN_KEY = isAnsiParsingRequired ? ALT_PF2_KEY : XTERM_ALT_PF2_KEY;
+						CTRL_FN_KEY = isAnsiParsingRequired ? CTRL_PF2_KEY : XTERM_CTRL_PF2_KEY;
+						SHIFT_ALT_FN_KEY = isAnsiParsingRequired ? SHIFT_ALT_PF2_KEY : XTERM_SHIFT_ALT_PF2_KEY;
+						SHIFT_CTRL_FN_KEY = isAnsiParsingRequired ? SHIFT_CTRL_PF2_KEY : XTERM_SHIFT_CTRL_PF2_KEY;
+						ALT_CTRL_FN_KEY = isAnsiParsingRequired ? ALT_CTRL_PF2_KEY : XTERM_ALT_CTRL_PF2_KEY;
+						SHIFT_ALT_CTRL_FN_KEY = isAnsiParsingRequired ? SHIFT_ALT_CTRL_PF2_KEY : XTERM_SHIFT_ALT_CTRL_PF2_KEY;
+
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)FN_KEY, strlen(FN_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_FN_KEY, strlen(SHIFT_FN_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_FN_KEY, strlen(CTRL_FN_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_FN_KEY, strlen(ALT_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_FN_KEY, strlen(SHIFT_ALT_CTRL_FN_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_FN_KEY, strlen(ALT_CTRL_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_FN_KEY, strlen(SHIFT_ALT_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_FN_KEY, strlen(SHIFT_CTRL_FN_KEY), 0);
+
+						break;
+					case VK_F3:
+						/* If isAnsiParsingRequired is false then we use XTERM VT sequence */
+						FN_KEY = isAnsiParsingRequired ? PF3_KEY : XTERM_PF3_KEY;
+						SHIFT_FN_KEY = isAnsiParsingRequired ? SHIFT_PF3_KEY : XTERM_SHIFT_PF3_KEY;
+						ALT_FN_KEY = isAnsiParsingRequired ? ALT_PF3_KEY : XTERM_ALT_PF3_KEY;
+						CTRL_FN_KEY = isAnsiParsingRequired ? CTRL_PF3_KEY : XTERM_CTRL_PF3_KEY;
+						SHIFT_ALT_FN_KEY = isAnsiParsingRequired ? SHIFT_ALT_PF3_KEY : XTERM_SHIFT_ALT_PF3_KEY;
+						SHIFT_CTRL_FN_KEY = isAnsiParsingRequired ? SHIFT_CTRL_PF3_KEY : XTERM_SHIFT_CTRL_PF3_KEY;
+						ALT_CTRL_FN_KEY = isAnsiParsingRequired ? ALT_CTRL_PF3_KEY : XTERM_ALT_CTRL_PF3_KEY;
+						SHIFT_ALT_CTRL_FN_KEY = isAnsiParsingRequired ? SHIFT_ALT_CTRL_PF3_KEY : XTERM_SHIFT_ALT_CTRL_PF3_KEY;
+
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)FN_KEY, strlen(FN_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_FN_KEY, strlen(SHIFT_FN_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_FN_KEY, strlen(CTRL_FN_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_FN_KEY, strlen(ALT_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_FN_KEY, strlen(SHIFT_ALT_CTRL_FN_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_FN_KEY, strlen(ALT_CTRL_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_FN_KEY, strlen(SHIFT_ALT_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_FN_KEY, strlen(SHIFT_CTRL_FN_KEY), 0);
+
+						break;
+					case VK_F4:
+						/* If isAnsiParsingRequired is false then we use XTERM VT sequence */
+						FN_KEY = isAnsiParsingRequired ? PF4_KEY : XTERM_PF4_KEY;
+						SHIFT_FN_KEY = isAnsiParsingRequired ? SHIFT_PF4_KEY : XTERM_SHIFT_PF4_KEY;
+						ALT_FN_KEY = isAnsiParsingRequired ? ALT_PF4_KEY : XTERM_ALT_PF4_KEY;
+						CTRL_FN_KEY = isAnsiParsingRequired ? CTRL_PF4_KEY : XTERM_CTRL_PF4_KEY;
+						SHIFT_ALT_FN_KEY = isAnsiParsingRequired ? SHIFT_ALT_PF4_KEY : XTERM_SHIFT_ALT_PF4_KEY;
+						SHIFT_CTRL_FN_KEY = isAnsiParsingRequired ? SHIFT_CTRL_PF4_KEY : XTERM_SHIFT_CTRL_PF4_KEY;
+						ALT_CTRL_FN_KEY = isAnsiParsingRequired ? ALT_CTRL_PF4_KEY : XTERM_ALT_CTRL_PF4_KEY;
+						SHIFT_ALT_CTRL_FN_KEY = isAnsiParsingRequired ? SHIFT_ALT_CTRL_PF4_KEY : XTERM_SHIFT_ALT_CTRL_PF4_KEY;
+
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)FN_KEY, strlen(FN_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_FN_KEY, strlen(SHIFT_FN_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_FN_KEY, strlen(CTRL_FN_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_FN_KEY, strlen(ALT_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_FN_KEY, strlen(SHIFT_ALT_CTRL_FN_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_FN_KEY, strlen(ALT_CTRL_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_FN_KEY, strlen(SHIFT_ALT_FN_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_FN_KEY, strlen(SHIFT_CTRL_FN_KEY), 0);
+
+						break;
+					case VK_F5:
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)PF5_KEY, strlen(PF5_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_PF5_KEY, strlen(SHIFT_PF5_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_PF5_KEY, strlen(CTRL_PF5_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_PF5_KEY, strlen(ALT_PF5_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_PF5_KEY, strlen(SHIFT_ALT_CTRL_PF5_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_PF5_KEY, strlen(ALT_CTRL_PF5_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_PF5_KEY, strlen(SHIFT_ALT_PF5_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_PF5_KEY, strlen(SHIFT_CTRL_PF5_KEY), 0);
+						break;
+					case VK_F6:
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)PF6_KEY, strlen(PF6_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_PF6_KEY, strlen(SHIFT_PF6_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_PF6_KEY, strlen(CTRL_PF6_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_PF6_KEY, strlen(ALT_PF6_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_PF6_KEY, strlen(SHIFT_ALT_CTRL_PF6_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_PF6_KEY, strlen(ALT_CTRL_PF6_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_PF6_KEY, strlen(SHIFT_ALT_PF6_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_PF6_KEY, strlen(SHIFT_CTRL_PF6_KEY), 0);
+						break;
+					case VK_F7:
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)PF7_KEY, strlen(PF7_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_PF7_KEY, strlen(SHIFT_PF7_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_PF7_KEY, strlen(CTRL_PF7_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_PF7_KEY, strlen(ALT_PF7_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_PF7_KEY, strlen(SHIFT_ALT_CTRL_PF7_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_PF7_KEY, strlen(ALT_CTRL_PF7_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_PF7_KEY, strlen(SHIFT_ALT_PF7_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_PF7_KEY, strlen(SHIFT_CTRL_PF7_KEY), 0);
+						break;
+					case VK_F8:
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)PF8_KEY, strlen(PF8_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_PF8_KEY, strlen(SHIFT_PF8_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_PF8_KEY, strlen(CTRL_PF8_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_PF8_KEY, strlen(ALT_PF8_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_PF8_KEY, strlen(SHIFT_ALT_CTRL_PF8_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_PF8_KEY, strlen(ALT_CTRL_PF8_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_PF8_KEY, strlen(SHIFT_ALT_PF8_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_PF8_KEY, strlen(SHIFT_CTRL_PF8_KEY), 0);
+						break;
+					case VK_F9:
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)PF9_KEY, strlen(PF9_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_PF9_KEY, strlen(SHIFT_PF9_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_PF9_KEY, strlen(CTRL_PF9_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_PF9_KEY, strlen(ALT_PF9_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_PF9_KEY, strlen(SHIFT_ALT_CTRL_PF9_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_PF9_KEY, strlen(ALT_CTRL_PF9_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_PF9_KEY, strlen(SHIFT_ALT_PF9_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_PF9_KEY, strlen(SHIFT_CTRL_PF9_KEY), 0);
+						break;
+					case VK_F10:
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)PF10_KEY, strlen(PF10_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_PF10_KEY, strlen(SHIFT_PF10_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_PF10_KEY, strlen(CTRL_PF10_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_PF10_KEY, strlen(ALT_PF10_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_PF10_KEY, strlen(SHIFT_ALT_CTRL_PF10_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_PF10_KEY, strlen(ALT_CTRL_PF10_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_PF10_KEY, strlen(SHIFT_ALT_PF10_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_PF10_KEY, strlen(SHIFT_CTRL_PF10_KEY), 0);
+						break;
+					case VK_F11:
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)PF11_KEY, strlen(PF11_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_PF11_KEY, strlen(SHIFT_PF11_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_PF11_KEY, strlen(CTRL_PF11_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_PF11_KEY, strlen(ALT_PF11_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_PF11_KEY, strlen(SHIFT_ALT_CTRL_PF11_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_PF11_KEY, strlen(ALT_CTRL_PF11_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_PF11_KEY, strlen(SHIFT_ALT_PF11_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_PF11_KEY, strlen(SHIFT_CTRL_PF11_KEY), 0);
+						break;
+					case VK_F12:
+						if (dwControlKeyState == 0)
+							NetWriteString2(pParams->Socket, (char *)PF12_KEY, strlen(PF12_KEY), 0);
+
+						else if (dwControlKeyState == SHIFT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)SHIFT_PF12_KEY, strlen(SHIFT_PF12_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_CTRL_PRESSED || dwControlKeyState == RIGHT_CTRL_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)CTRL_PF12_KEY, strlen(CTRL_PF12_KEY), 0);
+
+						else if (dwControlKeyState == LEFT_ALT_PRESSED || dwControlKeyState == RIGHT_ALT_PRESSED)
+							NetWriteString2(pParams->Socket, (char *)ALT_PF12_KEY, strlen(ALT_PF12_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_CTRL_PF12_KEY, strlen(SHIFT_ALT_CTRL_PF12_KEY), 0);
+
+						else if ((dwControlKeyState & RIGHT_ALT_PRESSED) || (dwControlKeyState & LEFT_ALT_PRESSED) &&
+							((dwControlKeyState & LEFT_CTRL_PRESSED) || (dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)ALT_CTRL_PF12_KEY, strlen(ALT_CTRL_PF12_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & RIGHT_ALT_PRESSED) ||
+							(dwControlKeyState & LEFT_ALT_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_ALT_PF12_KEY, strlen(SHIFT_ALT_PF12_KEY), 0);
+
+						else if ((dwControlKeyState & SHIFT_PRESSED) && ((dwControlKeyState & LEFT_CTRL_PRESSED) ||
+							(dwControlKeyState & RIGHT_CTRL_PRESSED)))
+							NetWriteString2(pParams->Socket, (char *)SHIFT_CTRL_PF12_KEY, strlen(SHIFT_CTRL_PF12_KEY), 0);
+						break;
+					default:
+						if(n > 0) { //(strcmp((char *) octets, "")) {
+							if ((dwControlKeyState & LEFT_ALT_PRESSED) || (dwControlKeyState & RIGHT_ALT_PRESSED)) {								
+								memset(tmp_buf, 0, sizeof(tmp_buf));
+								tmp_buf[0] = '\x1b';
+								memcpy(tmp_buf + 1, (char *)octets, n);
+								NetWriteString2(pParams->Socket, tmp_buf, n + 1, 0);								
+							}
+							else
+								NetWriteString2(pParams->Socket, (char *)octets, n, 0);
+						}							
+						break;
+					}
+				}
+			}
+			break;
+		}
+		break;
+	}
+
+	return glob_outlen;
+}

--- a/src/frontend/tncon.h
+++ b/src/frontend/tncon.h
@@ -1,0 +1,228 @@
+/*
+ * Author: Microsoft Corp.
+ *
+ * Copyright (c) 2015 Microsoft Corp.
+ * All rights reserved
+ *
+ * Microsoft openssh win32 port
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/* tncon.h
+ * 
+ * Contains terminal emulation console related key definition
+ *
+ */ 
+//#ifndef __TNCON_H
+//#define __TNCON_H
+
+#include <functional>
+//#include "console.h"
+#include "windows.h"
+
+#define UP_ARROW                    "\x1b[A"
+#define DOWN_ARROW                  "\x1b[B"
+#define RIGHT_ARROW                 "\x1b[C"
+#define LEFT_ARROW                  "\x1b[D"
+
+#define APP_UP_ARROW                "\x1bOA"
+#define APP_DOWN_ARROW              "\x1bOB"
+#define APP_RIGHT_ARROW             "\x1bOC"
+#define APP_LEFT_ARROW              "\x1bOD"
+
+#define FIND_KEY                    "\x1b[1~"
+#define INSERT_KEY                  "\x1b[2~"
+#define REMOVE_KEY                  "\x1b[3~"
+#define SELECT_KEY                  "\x1b[4~"
+#define PREV_KEY                    "\x1b[5~"
+#define NEXT_KEY                    "\x1b[6~"
+#define SHIFT_TAB_KEY               "\x1b[~"
+#define SHIFT_ALT_Q                 "\x1b?"
+#define ESCAPE_KEY		    "\x1b"
+#define BACKSPACE_KEY               "\x7f"
+
+// VT100 Function Key's
+#define VT100_PF1_KEY               "\x1bO2"
+#define VT100_PF2_KEY               "\x1bO3"
+#define VT100_PF3_KEY               "\x1bO4"
+#define VT100_PF4_KEY               "\x1bO5"
+#define VT100_PF5_KEY               "\x1bO6"
+#define VT100_PF6_KEY               "\x1bO7"
+#define VT100_PF7_KEY               "\x1bO8"
+#define VT100_PF8_KEY               "\x1bO9"
+#define VT100_PF9_KEY               "\x1bO:"
+#define VT100_PF10_KEY              "\x1bO;"
+
+// VT420 Key's
+#define PF1_KEY                     "\x1b[11~"
+#define PF2_KEY                     "\x1b[12~"
+#define PF3_KEY                     "\x1b[13~"
+#define PF4_KEY                     "\x1b[14~"
+#define PF5_KEY                     "\x1b[15~"
+#define PF6_KEY                     "\x1b[17~"
+#define PF7_KEY                     "\x1b[18~"
+#define PF8_KEY                     "\x1b[19~"
+#define PF9_KEY                     "\x1b[20~"
+#define PF10_KEY                    "\x1b[21~"
+#define PF11_KEY                    "\x1b[23~"
+#define PF12_KEY                    "\x1b[24~"
+
+#define SHIFT_PF1_KEY               "\x1b[11;2~"
+#define SHIFT_PF2_KEY               "\x1b[12;2~"
+#define SHIFT_PF3_KEY               "\x1b[13;2~"
+#define SHIFT_PF4_KEY               "\x1b[14;2~"
+#define SHIFT_PF5_KEY               "\x1b[15;2~"
+#define SHIFT_PF6_KEY               "\x1b[17;2~"
+#define SHIFT_PF7_KEY               "\x1b[18;2~"
+#define SHIFT_PF8_KEY               "\x1b[19;2~"
+#define SHIFT_PF9_KEY               "\x1b[20;2~"
+#define SHIFT_PF10_KEY              "\x1b[21;2~"
+#define SHIFT_PF11_KEY              "\x1b[23;2~"
+#define SHIFT_PF12_KEY              "\x1b[24;2~"
+
+#define ALT_PF1_KEY                 "\x1b[11;3~"
+#define ALT_PF2_KEY                 "\x1b[12;3~"
+#define ALT_PF3_KEY                 "\x1b[13;3~"
+#define ALT_PF4_KEY                 "\x1b[14;3~"
+#define ALT_PF5_KEY                 "\x1b[15;3~"
+#define ALT_PF6_KEY                 "\x1b[17;3~"
+#define ALT_PF7_KEY                 "\x1b[18;3~"
+#define ALT_PF8_KEY                 "\x1b[19;3~"
+#define ALT_PF9_KEY                 "\x1b[20;3~"
+#define ALT_PF10_KEY                "\x1b[21;3~"
+#define ALT_PF11_KEY                "\x1b[23;3~"
+#define ALT_PF12_KEY                "\x1b[24;3~"
+
+#define CTRL_PF1_KEY                "\x1b[11;5~"
+#define CTRL_PF2_KEY                "\x1b[12;5~"
+#define CTRL_PF3_KEY                "\x1b[13;5~"
+#define CTRL_PF4_KEY                "\x1b[14;5~"
+#define CTRL_PF5_KEY                "\x1b[15;5~"
+#define CTRL_PF6_KEY                "\x1b[17;5~"
+#define CTRL_PF7_KEY                "\x1b[18;5~"
+#define CTRL_PF8_KEY                "\x1b[19;5~"
+#define CTRL_PF9_KEY                "\x1b[20;5~"
+#define CTRL_PF10_KEY               "\x1b[21;5~"
+#define CTRL_PF11_KEY               "\x1b[23;5~"
+#define CTRL_PF12_KEY               "\x1b[24;5~"
+
+#define SHIFT_CTRL_PF1_KEY          "\x1b[11;6~"
+#define SHIFT_CTRL_PF2_KEY          "\x1b[12;6~"
+#define SHIFT_CTRL_PF3_KEY          "\x1b[13;6~"
+#define SHIFT_CTRL_PF4_KEY          "\x1b[14;6~"
+#define SHIFT_CTRL_PF5_KEY          "\x1b[15;6~"
+#define SHIFT_CTRL_PF6_KEY          "\x1b[17;6~"
+#define SHIFT_CTRL_PF7_KEY          "\x1b[18;6~"
+#define SHIFT_CTRL_PF8_KEY          "\x1b[19;6~"
+#define SHIFT_CTRL_PF9_KEY          "\x1b[20;6~"
+#define SHIFT_CTRL_PF10_KEY         "\x1b[21;6~"
+#define SHIFT_CTRL_PF11_KEY         "\x1b[23;6~"
+#define SHIFT_CTRL_PF12_KEY         "\x1b[24;6~"
+
+#define SHIFT_ALT_PF1_KEY           "\x1b[11;4~"
+#define SHIFT_ALT_PF2_KEY           "\x1b[12;4~"
+#define SHIFT_ALT_PF3_KEY           "\x1b[13;4~"
+#define SHIFT_ALT_PF4_KEY           "\x1b[14;4~"
+#define SHIFT_ALT_PF5_KEY           "\x1b[15;4~"
+#define SHIFT_ALT_PF6_KEY           "\x1b[17;4~"
+#define SHIFT_ALT_PF7_KEY           "\x1b[18;4~"
+#define SHIFT_ALT_PF8_KEY           "\x1b[19;4~"
+#define SHIFT_ALT_PF9_KEY           "\x1b[20;4~"
+#define SHIFT_ALT_PF10_KEY          "\x1b[21;4~"
+#define SHIFT_ALT_PF11_KEY          "\x1b[23;4~"
+#define SHIFT_ALT_PF12_KEY          "\x1b[24;4~"
+
+#define ALT_CTRL_PF1_KEY            "\x1b[11;7~"
+#define ALT_CTRL_PF2_KEY            "\x1b[12;7~"
+#define ALT_CTRL_PF3_KEY            "\x1b[13;7~"
+#define ALT_CTRL_PF4_KEY            "\x1b[14;7~"
+#define ALT_CTRL_PF5_KEY            "\x1b[15;7~"
+#define ALT_CTRL_PF6_KEY            "\x1b[17;7~"
+#define ALT_CTRL_PF7_KEY            "\x1b[18;7~"
+#define ALT_CTRL_PF8_KEY            "\x1b[19;7~"
+#define ALT_CTRL_PF9_KEY            "\x1b[20;7~"
+#define ALT_CTRL_PF10_KEY           "\x1b[21;7~"
+#define ALT_CTRL_PF11_KEY           "\x1b[23;7~"
+#define ALT_CTRL_PF12_KEY           "\x1b[24;7~"
+
+#define SHIFT_ALT_CTRL_PF1_KEY      "\x1b[11;8~"
+#define SHIFT_ALT_CTRL_PF2_KEY      "\x1b[12;8~"
+#define SHIFT_ALT_CTRL_PF3_KEY      "\x1b[13;8~"
+#define SHIFT_ALT_CTRL_PF4_KEY      "\x1b[14;8~"
+#define SHIFT_ALT_CTRL_PF5_KEY      "\x1b[15;8~"
+#define SHIFT_ALT_CTRL_PF6_KEY      "\x1b[17;8~"
+#define SHIFT_ALT_CTRL_PF7_KEY      "\x1b[18;8~"
+#define SHIFT_ALT_CTRL_PF8_KEY      "\x1b[19;8~"
+#define SHIFT_ALT_CTRL_PF9_KEY      "\x1b[20;8~"
+#define SHIFT_ALT_CTRL_PF10_KEY     "\x1b[21;8~"
+#define SHIFT_ALT_CTRL_PF11_KEY     "\x1b[23;8~"
+#define SHIFT_ALT_CTRL_PF12_KEY     "\x1b[24;8~"
+
+/* XTERM (https://github.com/mintty/mintty/wiki/Keycodes#function-keys) */
+#define XTERM_PF1_KEY               "\x1bOP"
+#define XTERM_PF2_KEY               "\x1bOQ"
+#define XTERM_PF3_KEY               "\x1bOR"
+#define XTERM_PF4_KEY               "\x1bOS"
+
+#define XTERM_SHIFT_PF1_KEY         "\x1b[1;2P"
+#define XTERM_SHIFT_PF2_KEY         "\x1b[1;2Q"
+#define XTERM_SHIFT_PF3_KEY         "\x1b[1;2R"
+#define XTERM_SHIFT_PF4_KEY         "\x1b[1;2S"
+
+#define XTERM_ALT_PF1_KEY           "\x1b[1;3P"
+#define XTERM_ALT_PF2_KEY           "\x1b[1;3Q"
+#define XTERM_ALT_PF3_KEY           "\x1b[1;3R"
+#define XTERM_ALT_PF4_KEY           "\x1b[1;3S"
+
+#define XTERM_CTRL_PF1_KEY          "\x1b[1;5P"
+#define XTERM_CTRL_PF2_KEY          "\x1b[1;5Q"
+#define XTERM_CTRL_PF3_KEY          "\x1b[1;5R"
+#define XTERM_CTRL_PF4_KEY          "\x1b[1;5S"
+
+#define XTERM_SHIFT_ALT_PF1_KEY     "\x1b[1;4P"
+#define XTERM_SHIFT_ALT_PF2_KEY     "\x1b[1;4Q"
+#define XTERM_SHIFT_ALT_PF3_KEY     "\x1b[1;4R"
+#define XTERM_SHIFT_ALT_PF4_KEY     "\x1b[1;4S"
+
+#define XTERM_SHIFT_CTRL_PF1_KEY    "\x1b[1;6P"
+#define XTERM_SHIFT_CTRL_PF2_KEY    "\x1b[1;6Q"
+#define XTERM_SHIFT_CTRL_PF3_KEY    "\x1b[1;6R"
+#define XTERM_SHIFT_CTRL_PF4_KEY    "\x1b[1;6S"
+
+#define XTERM_ALT_CTRL_PF1_KEY      "\x1b[1;7P"
+#define XTERM_ALT_CTRL_PF2_KEY      "\x1b[1;7Q"
+#define XTERM_ALT_CTRL_PF3_KEY      "\x1b[1;7R"
+#define XTERM_ALT_CTRL_PF4_KEY      "\x1b[1;7S"
+
+#define XTERM_SHIFT_ALT_CTRL_PF1_KEY      "\x1b[1;8P"
+#define XTERM_SHIFT_ALT_CTRL_PF2_KEY      "\x1b[1;8Q"
+#define XTERM_SHIFT_ALT_CTRL_PF3_KEY      "\x1b[1;8R"
+#define XTERM_SHIFT_ALT_CTRL_PF4_KEY      "\x1b[1;8S"
+
+#define TERMINAL_ID                 "\x1b[?1;2c"
+#define STATUS_REPORT               "\x1b[2;5R"
+#define CURSOR_REPORT_FORMAT_STRING "\x1b[%d;%dR"
+#define VT52_TERMINAL_ID            "\x1b/Z"
+
+int ReadConsoleForTermEmul(HANDLE hInput, char *destin, int destinlen, std::function<void()> resizeHandler);
+
+//#endif

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -35,8 +35,14 @@
 
 #include <stdint.h>
 #include <deque>
+#ifndef _WIN32
 #include <sys/socket.h>
 #include <netinet/in.h>
+#else
+#include "winsock2.h"
+#include "ws2ipdef.h"
+#include "ws2tcpip.h"
+#endif
 #include <string>
 #include <math.h>
 #include <vector>
@@ -59,7 +65,11 @@ namespace Network {
   public:
     string function;
     int the_errno;
+  #ifndef _WIN32
   private:
+  #else
+  protected:
+  #endif
     string my_what;
   public:
     NetworkException( string s_function="<none>", int s_errno=0)
@@ -68,6 +78,16 @@ namespace Network {
     const char *what() const throw () { return my_what.c_str(); }
     ~NetworkException() throw () {}
   };
+
+  #ifdef _WIN32
+  class WSAException : public NetworkException {
+  public:
+      WSAException(string s_function, int wsaError) : NetworkException(s_function, 0) {
+          //TODO: use FormatMessage() to get correct error message
+          my_what = function + ": Error " + std::to_string(wsaError);
+      }
+  };
+  #endif
 
   enum Direction {
     TO_SERVER = 0,

--- a/src/terminal/terminal.cc
+++ b/src/terminal/terminal.cc
@@ -56,6 +56,15 @@ void Emulator::execute( const Parser::Execute *act )
   dispatch.dispatch( CONTROL, act, &fb );
 }
 
+#ifdef _WIN32
+// TODO: wcwidth is not available on Windows (should provide character width)
+namespace {
+int wcwidth(wchar_t c) {
+    return 1;
+}
+}
+#endif
+
 void Emulator::print( const Parser::Print *act )
 {
   assert( act->char_present );

--- a/src/util/locale_utils.cc
+++ b/src/util/locale_utils.cc
@@ -69,6 +69,7 @@ const LocaleVar get_ctype( void )
 
 const char *locale_charset( void )
 {
+#if HAVE_LANGINFO_H
   static const char ASCII_name[] = "US-ASCII";
 
   /* Produce more pleasant name of US-ASCII */
@@ -79,6 +80,9 @@ const char *locale_charset( void )
   }
 
   return ret;
+#else
+  return NULL;
+#endif
 }
 
 bool is_utf8_locale( void ) {
@@ -109,6 +113,7 @@ void set_native_locale( void ) {
 }
 
 void clear_locale_variables( void ) {
+  #if HAVE_LANGINFO_H
   unsetenv( "LANG" );
   unsetenv( "LANGUAGE" );
   unsetenv( "LC_CTYPE" );
@@ -124,4 +129,5 @@ void clear_locale_variables( void ) {
   unsetenv( "LC_MEASUREMENT" );
   unsetenv( "LC_IDENTIFICATION" );
   unsetenv( "LC_ALL" );
+  #endif
 }

--- a/src/util/select.cc
+++ b/src/util/select.cc
@@ -32,7 +32,9 @@
 
 #include "select.h"
 
+#ifndef _WIN32
 fd_set Select::dummy_fd_set;
+#endif
 
 sigset_t Select::dummy_sigset;
 
@@ -46,3 +48,14 @@ void Select::handle_signal( int signum )
   Select &sel = get_instance();
   sel.got_signal[ signum ] = 1;
 }
+
+#ifdef _WIN32
+int
+w32_sigprocmask(int how, const sigset_t *set, sigset_t *oldset)
+{
+    /* this is only used by sshd to block SIGCHLD while doing waitpid() */
+    /* our implementation of waidpid() is never interrupted, so no need to implement this for now*/
+    //debug3("sigprocmask() how:%d", how);
+    return 0;
+}
+#endif

--- a/src/util/select.h
+++ b/src/util/select.h
@@ -36,11 +36,99 @@
 #include <string.h>
 #include <errno.h>
 #include <signal.h>
+#ifndef _WIN32
 #include <sys/select.h>
+#endif
 #include <assert.h>
 
 #include "fatal_assert.h"
 #include "timestamp.h"
+#ifdef _WIN32
+#include <sys/types.h>
+#include <winsock2.h>
+#include <vector>
+#include <string>
+
+/* signal related defs*/
+/* supported signal types */
+#define W32_SIGINT		0
+#define W32_SIGSEGV		1
+
+#define W32_SIGPIPE		2
+#define W32_SIGCHLD		3
+#define W32_SIGALRM		4
+#define W32_SIGTSTP		5
+
+#define W32_SIGHUP		6
+#define W32_SIGQUIT		7
+#define W32_SIGTERM		8
+#define W32_SIGTTIN		9
+#define W32_SIGTTOU		10
+#define W32_SIGWINCH	        11
+
+/* singprocmask "how" codes*/
+#define SIG_BLOCK		0
+#define SIG_UNBLOCK		1
+#define SIG_SETMASK		2
+
+typedef void(*sighandler_t)(int);
+typedef int sigset_t;
+#define sigemptyset(set) (memset( (set), 0, sizeof(sigset_t)))
+#define sigaddset(set, sig) ( (*(set)) |= (0x80000000 >> (sig)))
+#define sigismember(set, sig) ( (*(set) & (0x80000000 >> (sig)))?1:0 )
+#define sigdelset(set, sig) ( (*(set)) &= (~( 0x80000000 >> (sig)) ) )
+
+int w32_sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
+#define sigprocmask(a,b,c) w32_sigprocmask((a), (b), (c))
+
+#ifndef SIGINT
+#define SIGINT	W32_SIGINT
+#endif
+
+#ifndef SIGSEGV
+#define SIGSEGV	W32_SIGSEGV
+#endif
+
+#ifndef SIGPIPE
+#define SIGPIPE	W32_SIGPIPE
+#endif
+
+#ifndef SIGCHLD
+#define SIGCHLD	W32_SIGCHLD
+#endif
+
+#ifndef SIGALRM
+#define SIGALRM	W32_SIGALRM
+#endif
+
+#ifndef SIGTSTP
+#define SIGTSTP	W32_SIGTSTP
+#endif
+
+#ifndef SIGHUP
+#define SIGHUP	W32_SIGHUP
+#endif
+
+#ifndef SIGQUIT
+#define SIGQUIT	W32_SIGQUIT
+#endif
+
+#ifndef SIGTERM
+#define SIGTERM	W32_SIGTERM
+#endif
+
+#ifndef SIGTTIN
+#define SIGTTIN	W32_SIGTTIN
+#endif
+
+#ifndef SIGTTOU
+#define SIGTTOU	W32_SIGTTOU
+#endif
+
+#ifndef SIGWINCH
+#define SIGWINCH W32_SIGWINCH
+#endif
+#endif
 
 /* Convenience wrapper for pselect(2).
 
@@ -57,19 +145,37 @@ public:
 
 private:
   Select()
+  #ifndef _WIN32
     : max_fd( -1 )
+  #else
+    : socketHandles()
+    , eventHandles()
+    , waitableHandles()
+  #endif
     /* These initializations are not used; they are just
        here to appease -Weffc++. */
+    #ifndef _WIN32
     , all_fds( dummy_fd_set )
     , read_fds( dummy_fd_set )
+    #endif
     , empty_sigset( dummy_sigset )
     , consecutive_polls( 0 )
   {
+    #ifndef _WIN32
     FD_ZERO( &all_fds );
     FD_ZERO( &read_fds );
 
     clear_got_signal();
     fatal_assert( 0 == sigemptyset( &empty_sigset ) );
+    #else
+    // just to minimize allocations
+    socketHandles.reserve(10);
+    eventHandles.reserve(WSA_MAXIMUM_WAIT_EVENTS);
+    waitableHandles.reserve(10);
+
+    clear_got_signal();
+    sigemptyset( &empty_sigset );//fatal_assert( 0 == sigemptyset( &empty_sigset ) );
+    #endif
   }
 
   void clear_got_signal( void )
@@ -86,6 +192,7 @@ private:
   Select &operator=( const Select & );
 
 public:
+  #ifndef _WIN32
   void add_fd( int fd )
   {
     if ( fd > max_fd ) {
@@ -98,6 +205,44 @@ public:
   {
     FD_ZERO( &all_fds );
   }
+  #else
+
+  //
+  // Adds socket to wait on
+  void add_socket( SOCKET socket )
+  {
+      socketHandles.push_back(socket);
+
+      WSAEVENT hEvent = WSACreateEvent();
+
+      if(WSAEventSelect(socket, hEvent, FD_READ | FD_CONNECT | FD_CLOSE) == SOCKET_ERROR) {
+          throw ("WSAEventSelect: Error " + std::to_string(WSAGetLastError()));
+      }
+
+      eventHandles.push_back(hEvent);
+  }
+
+  //
+  // Adds other handle (non-socket) to wait on.
+  // This can be any waitable handle, e.g. a file handle, an event handle, or even a thread handle
+  void add_waitable_handle( HANDLE fd )
+  {
+      waitableHandles.push_back(fd);
+  }
+
+  void clear_handles( void )
+  {
+      // Remember that the Select object does not own socketHandles and waitableHandles,
+      // but it does own events, so we're destroying all event objects we have created.
+      for (std::vector<WSAEVENT>::const_iterator it = eventHandles.begin(); it != eventHandles.end(); it++) {
+          WSACloseEvent(*it);
+      }
+      eventHandles.clear();
+
+      socketHandles.clear();
+      waitableHandles.clear();
+  }
+  #endif
 
   static void add_signal( int signum )
   {
@@ -106,6 +251,7 @@ public:
 
     /* Block the signal so we don't get it outside of pselect(). */
     sigset_t to_block;
+    #ifndef _WIN32
     fatal_assert( 0 == sigemptyset( &to_block ) );
     fatal_assert( 0 == sigaddset( &to_block, signum ) );
     fatal_assert( 0 == sigprocmask( SIG_BLOCK, &to_block, NULL ) );
@@ -117,12 +263,19 @@ public:
     sa.sa_handler = &handle_signal;
     fatal_assert( 0 == sigfillset( &sa.sa_mask ) );
     fatal_assert( 0 == sigaction( signum, &sa, NULL ) );
+    #else
+    sigemptyset( &to_block );
+    sigaddset( &to_block, signum );
+    sigprocmask( SIG_BLOCK, &to_block, NULL );
+    #endif
   }
 
   /* timeout unit: milliseconds; negative timeout means wait forever */
   int select( int timeout )
   {
+    #ifndef _WIN32
     memcpy( &read_fds,  &all_fds, sizeof( read_fds  ) );
+    #endif
     clear_got_signal();
 
     /* Rate-limit and warn about polls. */
@@ -153,6 +306,7 @@ public:
 
     int ret = ::pselect( max_fd + 1, &read_fds, NULL, NULL, tsp, &empty_sigset );
 #else
+#ifndef _WIN32
     struct timeval tv;
     struct timeval *tvp = NULL;
     sigset_t old_sigset;
@@ -168,8 +322,34 @@ public:
       ret = ::select( max_fd + 1, &read_fds, NULL, NULL, tvp );
       sigprocmask( SIG_SETMASK, &old_sigset, NULL );
     }
+#else
+      sigset_t old_sigset;
+
+      int ret = sigprocmask(SIG_SETMASK, &empty_sigset, &old_sigset);
+      if (ret != -1) {
+          std::vector<HANDLE> objectsToWait;
+          objectsToWait.reserve(eventHandles.size() + waitableHandles.size());
+          objectsToWait.insert(objectsToWait.end(), eventHandles.begin(), eventHandles.end());
+          objectsToWait.insert(objectsToWait.end(), waitableHandles.begin(), waitableHandles.end());
+
+          DWORD rc = WSAWaitForMultipleEvents(objectsToWait.size(), objectsToWait.data(), FALSE, timeout, FALSE);
+          if (rc == WSA_WAIT_FAILED) {
+              int errorNr = WSAGetLastError();
+              fprintf(stderr, "%s: got error 0x%.8X from WSAWaitForMultipleEvents()\n", __func__, errorNr);
+              return -1;
+          }
+
+          if (rc == WSA_WAIT_TIMEOUT) {
+              ret = 0;
+          } else {
+              ret = 1;
+          }
+          sigprocmask(SIG_SETMASK, &old_sigset, NULL);
+      }
+#endif
 #endif
 
+  #ifndef _WIN32
     if ( ret == 0 || ( ret == -1 && errno == EINTR ) ) {
       /* Look for and report Cygwin select() bug. */
       if ( ret == 0 ) {
@@ -183,12 +363,14 @@ public:
       FD_ZERO( &read_fds );
       ret = 0;
     }
+  #endif
 
     freeze_timestamp();
 
     return ret;
   }
 
+#ifndef _WIN32
   bool read( int fd )
 #if FD_ISSET_IS_CONST
     const
@@ -197,6 +379,20 @@ public:
     assert( FD_ISSET( fd, &all_fds ) );
     return FD_ISSET( fd, &read_fds );
   }
+#else
+  bool isSocketReady( SOCKET socket ) {
+      WSANETWORKEVENTS networkEvents = {};
+      for (std::vector<SOCKET>::size_type idx = 0; idx < socketHandles.size(); idx++) {
+          if (socketHandles[idx] == socket && idx < eventHandles.size()) {
+              if (WSAEnumNetworkEvents(socket, eventHandles[idx], &networkEvents) == SOCKET_ERROR) {
+                  throw ("WSAEnumNetworkEvents: Error " + std::to_string(WSAGetLastError()));
+              }
+          }
+      }
+
+      return (networkEvents.lNetworkEvents & (FD_READ | FD_CONNECT | FD_CLOSE)) != 0;
+  }
+#endif
 
   /* This method consumes a signal notification. */
   bool signal( int signum )
@@ -235,14 +431,23 @@ private:
      concurrent signal handlers. */
   volatile sig_atomic_t got_signal[ MAX_SIGNAL_NUMBER + 1 ];
 
+  #ifndef _WIN32
   fd_set all_fds, read_fds;
+  #endif
 
   sigset_t empty_sigset;
 
+  #ifndef _WIN32
   static fd_set dummy_fd_set;
+  #endif
   static sigset_t dummy_sigset;
   int consecutive_polls;
   static unsigned int verbose;
+  #ifdef _WIN32
+  std::vector<SOCKET> socketHandles;
+  std::vector<WSAEVENT> eventHandles;
+  std::vector<HANDLE> waitableHandles;
+  #endif
 };
 
 #endif


### PR DESCRIPTION
I have made a patch which can make mosh be built in Windows. 

I used the code of project [mosh-windows-wrappers](https://github.com/maxhora/mosh-windows-wrappers) directly and made some modifcations.

I wrote a build guide in [BUILD-WIN.md](BUILD-WIN.md) and tested in Windows 11 msys2.

There's some bugs when connectting to the server. I need some help to make network works. I'm not familiar with Windows network programming. The error is 
```
mosh did not make a successful connection to xx.xx.xx.xx:60003.
Please verify that UDP port 60003 is not firewalled and can reach the server.

(By default, mosh uses a UDP port between 60000 and 61000. The -p option
selects a specific UDP port number.)
Error: basic_string::_M_replace
[mosh is exiting.]
```
