### PR TITLE
Bump C++ version to C++17

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,9 +22,9 @@ AS_IF([test x"$PROTOC" = x],
 # automake 1.12 seems to require this, but automake 1.11 doesn't recognize it
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
-# Protobuf 3.6+ requires C++11.
-AS_IF([pkg-config --atleast-version 3.6.0 protobuf],
-  [AX_CXX_COMPILE_STDCXX([11])])
+# Protobuf transitively requires at least C++14, get ahead of the
+# curve and require at least C++17.
+AX_CXX_COMPILE_STDCXX([17])
 
 WARNING_CXXFLAGS=""
 PICKY_CXXFLAGS=""


### PR DESCRIPTION
Protobuf versions since 3.6.0 have long had a C++11 dependency; even more recent versions have picked up an Abseil dependency bumping that to C++14. Since it is now 2023, defaulting to C++17 is reasonable, so remove the conditional C++ standards version check that mosh previously had and replace it with an unconditional C++17 check.

This means that all future commits can use C++17 features. According to https://en.cppreference.com/w/cpp/compiler_support/17 this means that minimum effective compiler versions for mosh become:

gcc 7 (May 2017)
clang 5 (September 2017)

This, in turn, implies that future versions of mosh will no longer be available for RHEL/CentOS 7 (June 2014).

Closes: #1267