### PR TITLE
Update ubuntu runner images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-latest, ubuntu-20.04, ubuntu-22.04]
         crypto: [auto]
         include:
           - crypto: nettle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-22.04, macos-12]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
ubuntu-18.04 is no longer available on Github Actions; replace it with ubuntu-22.04.