### PR TITLE
Clang formatting traces

### DIFF
--- a/src/crypto/base64.cc
+++ b/src/crypto/base64.cc
@@ -106,7 +106,7 @@ void base64_encode( const uint8_t* raw, const size_t raw_len, char* b64, const s
     b64[0] = table[( bytes >> 18 ) & 0x3f];
     b64[1] = table[( bytes >> 12 ) & 0x3f];
     b64[2] = table[( bytes >> 6 ) & 0x3f];
-    b64[3] = table[(bytes)&0x3f];
+    b64[3] = table[( bytes ) & 0x3f];
     raw += 3;
     b64 += 4;
   }

--- a/src/crypto/byteorder.h
+++ b/src/crypto/byteorder.h
@@ -79,7 +79,7 @@ inline uint64_t htobe64( uint64_t x )
                     static_cast<uint8_t>( ( x >> 24 ) & 0xFF ),
                     static_cast<uint8_t>( ( x >> 16 ) & 0xFF ),
                     static_cast<uint8_t>( ( x >> 8 ) & 0xFF ),
-                    static_cast<uint8_t>( (x)&0xFF ) };
+                    static_cast<uint8_t>( ( x ) & 0xFF ) };
   union {
     const uint8_t* p8;
     const uint64_t* p64;
@@ -102,7 +102,7 @@ inline uint64_t be64toh( uint64_t x )
 
 inline uint16_t htobe16( uint16_t x )
 {
-  uint8_t xs[2] = { static_cast<uint8_t>( ( x >> 8 ) & 0xFF ), static_cast<uint8_t>( (x)&0xFF ) };
+  uint8_t xs[2] = { static_cast<uint8_t>( ( x >> 8 ) & 0xFF ), static_cast<uint8_t>( ( x ) & 0xFF ) };
   union {
     const uint8_t* p8;
     const uint16_t* p16;

--- a/src/util/select.h
+++ b/src/util/select.h
@@ -214,10 +214,7 @@ public:
     return rv;
   }
 
-  static void set_verbose( unsigned int s_verbose )
-  {
-    verbose = s_verbose;
-  }
+  static void set_verbose( unsigned int s_verbose ) { verbose = s_verbose; }
 
 private:
   static const int MAX_SIGNAL_NUMBER = 64;


### PR DESCRIPTION
When applying the new formatting from our side, I noticed these three files (one line each), had been left over.