### PR TITLE
Update README.md missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To start contributing to Mosh, install the following dependencies:
 Debian, Windows Subsystem for Linux:
 
 ```
-$ sudo apt install -y build-essential protobuf-compiler \
+$ sudo apt install -y build-essential autoconf protobuf-compiler \
     libprotobuf-dev pkg-config libutempter-dev zlib1g-dev libncurses5-dev \
     libssl-dev bash-completion tmux less
 ```


### PR DESCRIPTION
Add autoconf to the apt install list, needed to execute the autogen.sh script (at least on ubuntu 24.04.1 LTS).