### PR TITLE
Allow manual re-resolving of server hostname

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -69,6 +69,7 @@ my $predict = undef;
 my $overwrite = 0;
 
 my $bind_ip = undef;
+my $host = undef;
 
 my $use_remote_ip = 'proxy';
 
@@ -245,6 +246,7 @@ if ( ! defined $fake_proxy ) {
   }
   $userhost = shift;
   @command = @ARGV;
+  (my $user, $host) = $userhost =~ /^((?:.*@)?)(.*)$/;
   if ( not defined $bind_ip or $bind_ip =~ m{^ssh$}i ) {
     if ( not defined $localhost ) {
       push @bind_arguments, '-s';
@@ -334,7 +336,7 @@ $ENV{ 'MOSH_CLIENT_PID' } = $$; # We don't support this, but it's useful for tes
 my $ip;
 if ( $use_remote_ip eq 'local' ) {
   # "parse" the host from what the user gave us
-  my ($user, $host) = $userhost =~ /^((?:.*@)?)(.*)$/;
+  (my $user, $host) = $userhost =~ /^((?:.*@)?)(.*)$/;
   # get list of addresses
   my @res = resolvename( $host, 22, $family );
   # Use only the first address as the Mosh IP
@@ -462,7 +464,7 @@ if ( $pid == 0 ) { # child
   $ENV{ 'MOSH_KEY' } = $key;
   $ENV{ 'MOSH_PREDICTION_DISPLAY' } = $predict;
   $ENV{ 'MOSH_NO_TERM_INIT' } = '1' if !$term_init;
-  exec {$client} ("$client", "-# @cmdline |", $ip, $port);
+  exec {$client} ("$client", "-# @cmdline |", "-n", "$host", $ip, $port);
 }
 
 sub shell_quote { join ' ', map {(my $a = $_) =~ s/'/'\\''/g; "'$a'"} @_ }

--- a/src/frontend/mosh-client.cc
+++ b/src/frontend/mosh-client.cc
@@ -85,7 +85,7 @@ static void print_usage( FILE* file, const char* argv0 )
 {
   print_version( file );
   fprintf( file,
-           "\nUsage: %s [-# 'ARGS'] IP PORT\n"
+           "\nUsage: %s [-# 'ARGS'] [-n hostname] IP PORT\n"
            "       %s -c\n",
            argv0,
            argv0 );
@@ -126,8 +126,10 @@ int main( int argc, char* argv[] )
     }
   }
 
+  char *hostname = NULL;
+
   int opt;
-  while ( ( opt = getopt( argc, argv, "#:cv" ) ) != -1 ) {
+  while ( ( opt = getopt( argc, argv, "#:cvn:" ) ) != -1 ) {
     switch ( opt ) {
       case '#':
         // Ignore the original arguments to mosh wrapper
@@ -138,6 +140,9 @@ int main( int argc, char* argv[] )
         break;
       case 'v':
         verbose++;
+        break;
+      case 'n':
+        hostname = optarg;
         break;
       default:
         print_usage( stderr, argv[0] );
@@ -190,7 +195,7 @@ int main( int argc, char* argv[] )
 
   bool success = false;
   try {
-    STMClient client( ip, desired_port, key.c_str(), predict_mode, verbose, predict_overwrite );
+    STMClient client( hostname, ip, desired_port, key.c_str(), predict_mode, verbose, predict_overwrite );
     client.init();
 
     try {

--- a/src/frontend/stmclient.h
+++ b/src/frontend/stmclient.h
@@ -47,6 +47,7 @@
 class STMClient
 {
 private:
+  std::string hostname;
   std::string ip;
   std::string port;
   std::string key;
@@ -89,16 +90,18 @@ private:
   void resume( void ); /* restore state after SIGCONT */
 
 public:
-  STMClient( const char* s_ip,
+  STMClient( const char* s_hostname,
+             const char* s_ip,
              const char* s_port,
              const char* s_key,
              const char* predict_mode,
              unsigned int s_verbose,
              const char* predict_overwrite )
-    : ip( s_ip ? s_ip : "" ), port( s_port ? s_port : "" ), key( s_key ? s_key : "" ), escape_key( 0x1E ),
-      escape_pass_key( '^' ), escape_pass_key2( '^' ), escape_requires_lf( false ), escape_key_help( L"?" ),
-      saved_termios(), raw_termios(), window_size(), local_framebuffer( 1, 1 ), new_state( 1, 1 ), overlays(),
-      network(), display( true ) /* use TERM environment var to initialize display */, connecting_notification(),
+    : hostname( s_hostname ? s_hostname : "" ), ip( s_ip ? s_ip : "" ), port( s_port ? s_port : "" ),
+      key( s_key ? s_key : "" ), escape_key( 0x1E ), escape_pass_key( '^' ), escape_pass_key2( '^' ),
+      escape_requires_lf( false ), escape_key_help( L"?" ), saved_termios(), raw_termios(), window_size(),
+      local_framebuffer( 1, 1 ), new_state( 1, 1 ), overlays(), network(),
+      display( true ) /* use TERM environment var to initialize display */, connecting_notification(),
       repaint_requested( false ), lf_entered( false ), quit_sequence_started( false ), clean_shutdown( false ),
       verbose( s_verbose )
   {

--- a/src/network/network.cc
+++ b/src/network/network.cc
@@ -364,6 +364,24 @@ Connection::Connection( const char* key_str, const char* ip, const char* port ) 
   set_MTU( remote_addr.sa.sa_family );
 }
 
+void Connection::set_remote_addr( const struct sockaddr* addr, socklen_t len )
+{
+  fatal_assert( len <= sizeof( remote_addr ) );
+
+  bool family_changed = ( remote_addr.sa.sa_family != addr->sa_family );
+
+  remote_addr_len = len;
+  memcpy( &remote_addr.sa, addr, remote_addr_len );
+
+  has_remote_addr = true;
+
+  if ( family_changed ) {
+    socks.push_back( Socket( remote_addr.sa.sa_family ) );
+  }
+
+  set_MTU( remote_addr.sa.sa_family );
+}
+
 void Connection::send( const std::string& s )
 {
   if ( !has_remote_addr ) {

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -233,6 +233,7 @@ public:
 
   const Addr& get_remote_addr( void ) const { return remote_addr; }
   socklen_t get_remote_addr_len( void ) const { return remote_addr_len; }
+  void set_remote_addr( const struct sockaddr* addr, socklen_t len );
 
   std::string& get_send_error( void ) { return send_error; }
 

--- a/src/network/networktransport.h
+++ b/src/network/networktransport.h
@@ -126,6 +126,7 @@ public:
 
   const Addr& get_remote_addr( void ) const { return connection.get_remote_addr(); }
   socklen_t get_remote_addr_len( void ) const { return connection.get_remote_addr_len(); }
+  void set_remote_addr( const struct sockaddr* addr, socklen_t len ) { connection.set_remote_addr( addr, len ); }
 
   std::string& get_send_error( void ) { return connection.get_send_error(); }
 };


### PR DESCRIPTION
This feature is designed to solve one specific use case that I personally have:  roaming the client on and off ZScaler ZPA as I move my laptop between home and the office.

The way ZPA works is that when have it enabled, all DNS lookups for ZPA-protected hostnames are intercepted and converted into IP address for ZScaler endpoints (which then proxy the packets to the actual mosh-server host).

When ZPA is disabled (when you're inside a trusted corporate network), DNS lookups for the mosh-server host resolve to the "normal" IP address.

So this looks a lot like a roaming server.

This commit adds a new "re-resolve" command to trigger a manual DNS lookup.  This is just a boring call to `getaddrinfo` (so no new fancy async resolver), and it's fully manual, so there's no attempts to automatically figure out when a new DNS lookup is needed.

This has been working well for my use case.  Note that this approach is not general enough to work for everyone.  For example, it doesn't handle the case where the actual hostname is known only to your ssh_config.  And I've made no attempts to test anything other than IPv4.  So this PR is marked as a "Draft" and will probably never be merged in its current form.  But I'm sharing it here anyway because I'm sure others will find it useful.

Most of the code in this commit was written by Gemini AI.