### PR TITLE
Clarify port ranges in mosh-server(1) man page.

### DIFF
--- a/man/mosh-server.1
+++ b/man/mosh-server.1
@@ -38,8 +38,8 @@ detaches from the terminal, and waits for the \fBmosh-client\fP to
 establish a connection. It will exit if no client has contacted
 it within 60 seconds.
 
-By default, \fBmosh-server\fP binds to a port between 60000 and
-61000 and executes the user's login shell.
+By default, \fBmosh-server\fP binds to a port between 60001 and
+60999 (inclusive) and executes the user's login shell.
 
 On platforms with \fButempter\fP, \fBmosh-server\fP maintains an entry
 in the
@@ -71,8 +71,8 @@ IP address of the local interface to bind (for multihomed hosts)
 
 .TP
 .B \-p \fIPORT\fP[:\fIPORT2\fP]
-UDP port number or port-range to bind.  \fB\-p 0\fP will let the
-operating system pick an available UDP port.
+UDP port number or port-range to bind.  Both ends of the range are inclusive.
+\fB\-p 0\fP will let the operating system pick an available UDP port.
 
 .TP
 .B \-c \fICOLORS\fP


### PR DESCRIPTION
The man page for mosh-server says that -p says it takes a "port or port-range" without specifying whether the range is exclusive or inclusive. It is inclusive.

The man page also says that mosh-server binds to a port "between 60000 and 61000" by default without stating whether the endpoints are included. They are not; the range is exclusive.

That is, the default is equivalent to -p 60001:60999, not -p 60000:61000 as one might reasonably suppose.

Clarify the manual by sticking to inclusive ranges in both cases and stating explicitly that they are inclusive instead of leaving it up to the reader to guess.