### PR TITLE
Add support for SGR 2 faint and SGR 9 strikethrough

### DIFF
--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -489,11 +489,17 @@ void Renditions::set_rendition( color_type num )
     return;
   }
 
-  bool value = num < 9;
+  bool value = num < 10;
   switch ( num ) {
     case 1:
+      set_attribute( bold, value );
+      break;
+    case 2:
+      set_attribute( faint, value );
+      break;
     case 22:
       set_attribute( bold, value );
+      set_attribute( faint, value );
       break;
     case 3:
     case 23:
@@ -514,6 +520,10 @@ void Renditions::set_rendition( color_type num )
     case 8:
     case 28:
       set_attribute( invisible, value );
+      break;
+    case 9:
+    case 29:
+      set_attribute( strikethrough, value );
       break;
     default:
       break; /* ignore unknown rendition */
@@ -546,6 +556,8 @@ std::string Renditions::sgr( void ) const
   ret.append( "\033[0" );
   if ( get_attribute( bold ) )
     ret.append( ";1" );
+  if ( get_attribute( faint ) )
+    ret.append( ";2" );
   if ( get_attribute( italic ) )
     ret.append( ";3" );
   if ( get_attribute( underlined ) )
@@ -556,6 +568,8 @@ std::string Renditions::sgr( void ) const
     ret.append( ";7" );
   if ( get_attribute( invisible ) )
     ret.append( ";8" );
+  if ( get_attribute( strikethrough ) )
+    ret.append( ";9" );
 
   if ( foreground_color ) {
     // Since foreground_color is a 25-bit field, it is promoted to an int when

--- a/src/terminal/terminalframebuffer.h
+++ b/src/terminal/terminalframebuffer.h
@@ -60,6 +60,7 @@ public:
     blink,
     inverse,
     invisible,
+    strikethrough,
     SIZE
   } attribute_type;
 

--- a/src/tests/emulation-attributes.test
+++ b/src/tests/emulation-attributes.test
@@ -127,6 +127,12 @@ baseline()
             test_true_color
             echo "Bold:"
             test_true_color 1
+            echo "Bold, then normal intensity:"
+            test_true_color 1 22
+            echo "Faint:"
+            test_true_color 2
+            echo "Faint, then normal intensity:"
+            test_true_color 2 22
             echo "Italic:"
             test_true_color 3
             echo "Underline:"
@@ -137,6 +143,10 @@ baseline()
             test_true_color 7
             echo "Invisible:"
             test_true_color 8
+            echo "Strikethrough:"
+            test_true_color 9
+            echo "Strikethrough, then not crossed out:"
+            test_true_color 9 29
             echo "Bold, italic and underline:"
             test_true_color 1 3 4
             ;;


### PR DESCRIPTION
This adds support for the ECMA-48 SGR attributes for faint (`2`) and
strikethrough (`9`), along with their reset sequences.

In particular:

- `2` enables faint / decreased intensity
- `9` enables strikethrough / crossed-out
- `22` clears both bold and faint
- `29` clears strikethrough

The implementation is intentionally small and only touches:

- `src/terminal/terminalframebuffer.h`
- `src/terminal/terminalframebuffer.cc`
- `src/tests/emulation-attributes.test`

It wires the already-defined `faint` attribute into the SGR parser/emitter and
adds `strikethrough` to the rendition enum so both attributes are parsed and
re-emitted correctly.

Test coverage extends the existing `emulation-attributes` regression test with
cases for:

- `2`
- `9`
- `1;22`
- `2;22`
- `9;29`

This is a current rebase of the older #1059 change onto current `master`.
