### PR TITLE
select: include missing config.h

### DIFF
--- a/src/util/select.h
+++ b/src/util/select.h
@@ -33,6 +33,8 @@
 #ifndef SELECT_HPP
 #define SELECT_HPP
 
+#include "src/include/config.h"
+
 #include <cassert>
 #include <cerrno>
 #include <csignal>


### PR DESCRIPTION
This header uses HAVE_xxx defines, so make sure we include config.h to get consistent behavior.  Otherwise, select.cc doesn't include it, and we always compile the old select codepath, and then when we use the header in other files, we compile the new pselect codepath.