### PR TITLE
Add CSI XDA support

### DIFF
--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -38,6 +38,7 @@
 
 #include <unistd.h>
 
+#include "src/include/config.h"
 #include "src/terminal/parseraction.h"
 #include "src/terminal/terminalframebuffer.h"
 #include "terminaldispatcher.h"
@@ -151,6 +152,14 @@ static void CSI_SDA( Framebuffer* fb __attribute( ( unused ) ), Dispatcher* disp
 }
 
 static Function func_CSI_SDA( CSI, ">c", CSI_SDA );
+
+/* extended device attributes */
+static void CSI_XDA( Framebuffer* fb __attribute( ( unused ) ), Dispatcher* dispatch )
+{
+  dispatch->terminal_to_host.append( "\033P>|" PACKAGE_STRING "\033\\" );
+}
+
+static Function func_CSI_XDA( CSI, ">q", CSI_XDA );
 
 /* screen alignment diagnostic */
 static void Esc_DECALN( Framebuffer* fb, Dispatcher* dispatch __attribute( ( unused ) ) )

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -27,6 +27,7 @@ displaytests = \
 	emulation-multiline-scroll.test \
 	emulation-scroll.test \
 	emulation-wrap-across-frames.test \
+	emulation-xda.test
 	network-no-diff.test \
 	prediction-unicode.test \
 	pty-deadlock.test \

--- a/src/tests/emulation-xda.test
+++ b/src/tests/emulation-xda.test
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+#
+# Test XDA CSI code.
+#
+
+# shellcheck source=e2e-test-subrs
+. "$(dirname "$0")/e2e-test-subrs"
+PATH=$PATH:.:$srcdir
+# Top-level wrapper.
+if [ $# -eq 0 ]; then
+    e2e-test "$0" baseline post
+    exit
+fi
+
+# OK, we have arguments, we're one of the test hooks.
+if [ $# -ne 1 ]; then
+    fail "bad arguments %s\n" "$@"
+fi
+
+baseline()
+{
+    # Clear
+    printf '\033[H\033[J'
+    # XDA
+    printf '\033[>q'
+
+}
+
+post()
+{
+    local capture
+    capture="$(basename "$0").d/baseline.capture"
+    # 'Bad line' should have been overwritten
+    if grep -q 'P>|mosh 1\.[0-9]' "$capture"; then
+	exit 0
+    fi
+    exit 1
+}
+
+case $1 in
+    baseline)
+	baseline;;
+    post)
+	post;;
+    *)
+	fail "unknown test argument %s\n" "$1";;
+esac


### PR DESCRIPTION
Adds CSI Extended Device Attribute, which returns mosh as the underlying shell. This is used by tmux for example to understand what features a terminal supports.