### PR TITLE
Limit terminal resize dimensions

### DIFF
--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -53,6 +53,7 @@
 #endif
 
 #include "src/statesync/completeterminal.h"
+#include "src/statesync/resize.h"
 #include "src/statesync/user.h"
 #include "src/util/fatal_assert.h"
 #include "src/util/locale_utils.h"
@@ -248,6 +249,11 @@ void STMClient::main_init( void )
     perror( "ioctl TIOCGWINSZ" );
     return;
   }
+  if ( !StateSync::resize_dimensions_are_valid( window_size.ws_col, window_size.ws_row ) ) {
+    memset( &window_size, 0, sizeof( window_size ) );
+    window_size.ws_col = 80;
+    window_size.ws_row = 24;
+  }
 
   /* local state */
   local_framebuffer = Terminal::Framebuffer( window_size.ws_col, window_size.ws_row );
@@ -413,6 +419,9 @@ bool STMClient::process_resize( void )
   if ( ioctl( STDIN_FILENO, TIOCGWINSZ, &window_size ) < 0 ) {
     perror( "ioctl TIOCGWINSZ" );
     return false;
+  }
+  if ( !StateSync::resize_dimensions_are_valid( window_size.ws_col, window_size.ws_row ) ) {
+    return true;
   }
 
   /* tell remote emulator */

--- a/src/statesync/Makefile.am
+++ b/src/statesync/Makefile.am
@@ -3,4 +3,4 @@ AM_CXXFLAGS = $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) $(HARDEN_CFLAGS) $(MISC_CXXF
 
 noinst_LIBRARIES = libmoshstatesync.a
 
-libmoshstatesync_a_SOURCES = completeterminal.cc completeterminal.h user.cc user.h
+libmoshstatesync_a_SOURCES = completeterminal.cc completeterminal.h resize.h user.cc user.h

--- a/src/statesync/completeterminal.cc
+++ b/src/statesync/completeterminal.cc
@@ -33,6 +33,7 @@
 #include <climits>
 
 #include "src/protobufs/hostinput.pb.h"
+#include "src/statesync/resize.h"
 #include "src/statesync/completeterminal.h"
 #include "src/util/fatal_assert.h"
 
@@ -108,8 +109,7 @@ void Complete::apply_string( const string& diff )
       string terminal_to_host = act( input.instruction( i ).GetExtension( hostbytes ).hoststring() );
       assert( terminal_to_host.empty() ); /* server never interrogates client terminal */
     } else if ( input.instruction( i ).HasExtension( resize ) ) {
-      act( Resize( input.instruction( i ).GetExtension( resize ).width(),
-                   input.instruction( i ).GetExtension( resize ).height() ) );
+      act( StateSync::checked_resize( input.instruction( i ).GetExtension( resize ) ) );
     } else if ( input.instruction( i ).HasExtension( echoack ) ) {
       uint64_t inst_echo_ack_num = input.instruction( i ).GetExtension( echoack ).echo_ack_num();
       assert( inst_echo_ack_num >= echo_ack );

--- a/src/statesync/resize.h
+++ b/src/statesync/resize.h
@@ -1,0 +1,73 @@
+/*
+    Mosh: the mobile shell
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    In addition, as a special exception, the copyright holders give
+    permission to link the code of portions of this program with the
+    OpenSSL library under certain conditions as described in each
+    individual source file, and distribute linked combinations including
+    the two.
+
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do
+    so, delete this exception statement from your version. If you delete
+    this exception statement from all source files in the program, then
+    also delete it here.
+*/
+
+#ifndef STATESYNC_RESIZE_HPP
+#define STATESYNC_RESIZE_HPP
+
+#include <cstddef>
+#include <cstdint>
+
+#include "src/terminal/parseraction.h"
+#include "src/util/dos_assert.h"
+
+namespace StateSync {
+/* Unix terminal window-size ioctls expose row and column counts as 16-bit fields. */
+static const int32_t MAX_TERMINAL_WIDTH = 65535;
+static const int32_t MAX_TERMINAL_HEIGHT = 65535;
+/* About one gigabyte of Terminal::Cell objects on systems with 64-bit pointers. */
+static const uint64_t MAX_TERMINAL_CELLS = uint64_t( 1 ) << 24;
+
+inline bool resize_dimensions_are_valid( const uint64_t width, const uint64_t height )
+{
+  return width > 0 && height > 0 && width <= MAX_TERMINAL_WIDTH && height <= MAX_TERMINAL_HEIGHT
+         && width * height <= MAX_TERMINAL_CELLS;
+}
+
+inline Parser::Resize checked_resize_dimensions( const int32_t width, const int32_t height )
+{
+  dos_assert( width > 0 );
+  dos_assert( height > 0 );
+  dos_assert( resize_dimensions_are_valid( static_cast<uint64_t>( width ), static_cast<uint64_t>( height ) ) );
+
+  return Parser::Resize( static_cast<size_t>( width ), static_cast<size_t>( height ) );
+}
+
+template<class ResizeMessage>
+Parser::Resize checked_resize( const ResizeMessage& resize )
+{
+  dos_assert( resize.has_width() );
+  dos_assert( resize.has_height() );
+
+  return checked_resize_dimensions( resize.width(), resize.height() );
+}
+} // namespace StateSync
+
+#endif

--- a/src/statesync/user.cc
+++ b/src/statesync/user.cc
@@ -34,6 +34,7 @@
 #include <typeinfo>
 
 #include "src/protobufs/userinput.pb.h"
+#include "src/statesync/resize.h"
 #include "src/statesync/user.h"
 #include "src/util/fatal_assert.h"
 
@@ -85,9 +86,10 @@ std::string UserStream::diff_from( const UserStream& existing ) const
         }
       } break;
       case ResizeType: {
+        dos_assert( StateSync::resize_dimensions_are_valid( my_it->resize.width, my_it->resize.height ) );
         Instruction* new_inst = output.add_instruction();
-        new_inst->MutableExtension( resize )->set_width( my_it->resize.width );
-        new_inst->MutableExtension( resize )->set_height( my_it->resize.height );
+        new_inst->MutableExtension( resize )->set_width( static_cast<int32_t>( my_it->resize.width ) );
+        new_inst->MutableExtension( resize )->set_height( static_cast<int32_t>( my_it->resize.height ) );
       } break;
       default:
         assert( !"unexpected event type" );
@@ -112,8 +114,7 @@ void UserStream::apply_string( const std::string& diff )
         actions.push_back( UserEvent( UserByte( the_bytes.at( loc ) ) ) );
       }
     } else if ( input.instruction( i ).HasExtension( resize ) ) {
-      actions.push_back( UserEvent( Resize( input.instruction( i ).GetExtension( resize ).width(),
-                                            input.instruction( i ).GetExtension( resize ).height() ) ) );
+      actions.push_back( UserEvent( StateSync::checked_resize( input.instruction( i ).GetExtension( resize ) ) ) );
     }
   }
 }

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -39,8 +39,8 @@ displaytests = \
 	unicode-later-combining.test \
 	window-resize.test
 
-check_PROGRAMS = ocb-aes encrypt-decrypt base64 nonce-incr inpty is-utf8-locale
-TESTS = ocb-aes encrypt-decrypt base64 nonce-incr local.test $(displaytests)
+check_PROGRAMS = ocb-aes encrypt-decrypt base64 nonce-incr resize inpty is-utf8-locale
+TESTS = ocb-aes encrypt-decrypt base64 nonce-incr resize local.test $(displaytests)
 XFAIL_TESTS = \
 	e2e-failure.test \
 	emulation-attributes-256color8.test
@@ -64,6 +64,10 @@ base64_LDADD = $(ocb_aes_LDADD)
 nonce_incr_SOURCES = nonce-incr.cc
 nonce_incr_CPPFLAGS = -I$(srcdir)/../network -I$(srcdir)/../crypto -I$(srcdir)/../util $(CRYPTO_CFLAGS)
 nonce_incr_LDADD = ../network/libmoshnetwork.a ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(CRYPTO_LIBS)
+
+resize_SOURCES = resize.cc
+resize_CPPFLAGS = -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I$(srcdir)/../crypto -I$(srcdir)/../util -I../protobufs $(protobuf_CFLAGS)
+resize_LDADD = ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../protobufs/libmoshprotos.a ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(TINFO_LIBS) $(protobuf_LIBS) $(CRYPTO_LIBS)
 
 inpty_SOURCES = inpty.cc
 inpty_CPPFLAGS = -I$(srcdir)/../util

--- a/src/tests/resize.cc
+++ b/src/tests/resize.cc
@@ -1,0 +1,225 @@
+/*
+    Mosh: the mobile shell
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    In addition, as a special exception, the copyright holders give
+    permission to link the code of portions of this program with the
+    OpenSSL library under certain conditions as described in each
+    individual source file, and distribute linked combinations including
+    the two.
+
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do
+    so, delete this exception statement from your version. If you delete
+    this exception statement from all source files in the program, then
+    also delete it here.
+*/
+
+#include <cstdio>
+#include <exception>
+#include <string>
+
+#include "src/crypto/crypto.h"
+#include "src/protobufs/hostinput.pb.h"
+#include "src/protobufs/userinput.pb.h"
+#include "src/statesync/completeterminal.h"
+#include "src/statesync/user.h"
+#include "src/util/fatal_assert.h"
+
+using Crypto::CryptoException;
+
+static std::string user_resize_diff( const bool set_width, const int width, const bool set_height, const int height )
+{
+  ClientBuffers::UserMessage msg;
+  ClientBuffers::Instruction* inst = msg.add_instruction();
+  ClientBuffers::ResizeMessage* resize = inst->MutableExtension( ClientBuffers::resize );
+  if ( set_width ) {
+    resize->set_width( width );
+  }
+  if ( set_height ) {
+    resize->set_height( height );
+  }
+  return msg.SerializeAsString();
+}
+
+static std::string host_resize_diff( const bool set_width, const int width, const bool set_height, const int height )
+{
+  HostBuffers::HostMessage msg;
+  HostBuffers::Instruction* inst = msg.add_instruction();
+  HostBuffers::ResizeMessage* resize = inst->MutableExtension( HostBuffers::resize );
+  if ( set_width ) {
+    resize->set_width( width );
+  }
+  if ( set_height ) {
+    resize->set_height( height );
+  }
+  return msg.SerializeAsString();
+}
+
+static void expect_user_resize_rejected( const std::string& diff )
+{
+  bool got_exception = false;
+  try {
+    Network::UserStream user;
+    user.apply_string( diff );
+  } catch ( const CryptoException& e ) {
+    got_exception = true;
+    fatal_assert( !e.fatal );
+  }
+  fatal_assert( got_exception );
+}
+
+static void expect_host_resize_rejected( const std::string& diff )
+{
+  bool got_exception = false;
+  try {
+    Terminal::Complete terminal( 80, 24 );
+    terminal.apply_string( diff );
+  } catch ( const CryptoException& e ) {
+    got_exception = true;
+    fatal_assert( !e.fatal );
+  }
+  fatal_assert( got_exception );
+}
+
+static void test_user_resize_validation( void )
+{
+  Network::UserStream valid;
+  valid.apply_string( user_resize_diff( true, 80, true, 24 ) );
+  fatal_assert( valid.size() == 1 );
+
+  Network::UserStream large_width;
+  large_width.apply_string( user_resize_diff( true, 10000, true, 100 ) );
+  fatal_assert( large_width.size() == 1 );
+
+  Network::UserStream max_width;
+  max_width.apply_string( user_resize_diff( true, 65535, true, 1 ) );
+  fatal_assert( max_width.size() == 1 );
+
+  Network::UserStream max_height;
+  max_height.apply_string( user_resize_diff( true, 1, true, 65535 ) );
+  fatal_assert( max_height.size() == 1 );
+
+  Network::UserStream max_cells;
+  max_cells.apply_string( user_resize_diff( true, 4096, true, 4096 ) );
+  fatal_assert( max_cells.size() == 1 );
+
+  expect_user_resize_rejected( user_resize_diff( false, 0, true, 24 ) );
+  expect_user_resize_rejected( user_resize_diff( true, 80, false, 0 ) );
+  expect_user_resize_rejected( user_resize_diff( true, 0, true, 24 ) );
+  expect_user_resize_rejected( user_resize_diff( true, 80, true, 0 ) );
+  expect_user_resize_rejected( user_resize_diff( true, 0, true, 0 ) );
+  expect_user_resize_rejected( user_resize_diff( true, -1, true, 24 ) );
+  expect_user_resize_rejected( user_resize_diff( true, 80, true, -1 ) );
+  expect_user_resize_rejected( user_resize_diff( true, 65536, true, 1 ) );
+  expect_user_resize_rejected( user_resize_diff( true, 1, true, 65536 ) );
+  expect_user_resize_rejected( user_resize_diff( true, 4097, true, 4096 ) );
+}
+
+static void test_user_resize_serialization_validation( void )
+{
+  Network::UserStream valid;
+  valid.push_back( Parser::Resize( 80, 24 ) );
+  fatal_assert( !valid.diff_from( Network::UserStream() ).empty() );
+
+  bool got_exception = false;
+  Network::UserStream zero_width;
+  zero_width.push_back( Parser::Resize( 0, 24 ) );
+  try {
+    zero_width.diff_from( Network::UserStream() );
+  } catch ( const CryptoException& e ) {
+    got_exception = true;
+    fatal_assert( !e.fatal );
+  }
+  fatal_assert( got_exception );
+
+  got_exception = false;
+  try {
+    Network::UserStream zero_size;
+    zero_size.push_back( Parser::Resize( 0, 0 ) );
+    zero_size.diff_from( Network::UserStream() );
+  } catch ( const CryptoException& e ) {
+    got_exception = true;
+    fatal_assert( !e.fatal );
+  }
+  fatal_assert( got_exception );
+
+  got_exception = false;
+  try {
+    Network::UserStream huge;
+    huge.push_back( Parser::Resize( 4097, 4096 ) );
+    huge.diff_from( Network::UserStream() );
+  } catch ( const CryptoException& e ) {
+    got_exception = true;
+    fatal_assert( !e.fatal );
+  }
+  fatal_assert( got_exception );
+}
+
+static void test_host_resize_validation( void )
+{
+  Terminal::Complete valid( 80, 24 );
+  valid.apply_string( host_resize_diff( true, 100, true, 30 ) );
+  fatal_assert( valid.get_fb().ds.get_width() == 100 );
+  fatal_assert( valid.get_fb().ds.get_height() == 30 );
+
+  Terminal::Complete large_width( 80, 24 );
+  large_width.apply_string( host_resize_diff( true, 10000, true, 100 ) );
+  fatal_assert( large_width.get_fb().ds.get_width() == 10000 );
+  fatal_assert( large_width.get_fb().ds.get_height() == 100 );
+
+  Terminal::Complete max_width( 80, 24 );
+  max_width.apply_string( host_resize_diff( true, 65535, true, 1 ) );
+  fatal_assert( max_width.get_fb().ds.get_width() == 65535 );
+  fatal_assert( max_width.get_fb().ds.get_height() == 1 );
+
+  Terminal::Complete max_height( 80, 24 );
+  max_height.apply_string( host_resize_diff( true, 1, true, 65535 ) );
+  fatal_assert( max_height.get_fb().ds.get_width() == 1 );
+  fatal_assert( max_height.get_fb().ds.get_height() == 65535 );
+
+  Terminal::Complete max_cells( 80, 24 );
+  max_cells.apply_string( host_resize_diff( true, 4096, true, 4096 ) );
+  fatal_assert( max_cells.get_fb().ds.get_width() == 4096 );
+  fatal_assert( max_cells.get_fb().ds.get_height() == 4096 );
+
+  expect_host_resize_rejected( host_resize_diff( false, 0, true, 24 ) );
+  expect_host_resize_rejected( host_resize_diff( true, 80, false, 0 ) );
+  expect_host_resize_rejected( host_resize_diff( true, 0, true, 24 ) );
+  expect_host_resize_rejected( host_resize_diff( true, 80, true, 0 ) );
+  expect_host_resize_rejected( host_resize_diff( true, 0, true, 0 ) );
+  expect_host_resize_rejected( host_resize_diff( true, -1, true, 24 ) );
+  expect_host_resize_rejected( host_resize_diff( true, 80, true, -1 ) );
+  expect_host_resize_rejected( host_resize_diff( true, 65536, true, 1 ) );
+  expect_host_resize_rejected( host_resize_diff( true, 1, true, 65536 ) );
+  expect_host_resize_rejected( host_resize_diff( true, 4097, true, 4096 ) );
+}
+
+int main( void )
+{
+  try {
+    test_user_resize_validation();
+    test_user_resize_serialization_validation();
+    test_host_resize_validation();
+  } catch ( const std::exception& e ) {
+    fprintf( stderr, "resize FAILED: %s\n", e.what() );
+    return 1;
+  }
+
+  printf( "resize PASSED\n" );
+  return 0;
+}


### PR DESCRIPTION
Currently a signed-in user can send really big `ResizeMessage.width/height` into the `mosh` server. That can be DoS issue.

A peer can send zero, negative (but then internally cast to unsigned), or enormous positive dimensions; causing Mosh's framebuffer to _try to_ allocate potentially exabytes of `Cell` vectors even though the `pty` `ioctl` path only has 16-bit `winsize` fields (e.g. max. 65535).

This patch adds a shared `StateSync` resize validator for client-to-server `UserStream` decoding, server-to-client `Complete` decoding, local `UserStream` serialization, and frontend `TIOCGWINSZ` handling. Invalid counterparty input now raises the existing nonfatal `dos_assert` `CryptoException` before `TIOCSWINSZ` or framebuffer resize can run.

Limits are configured in `src/statesync/resize.h`: `width` and `height` limits are `65535` to match the Unix `winsize` ABI, while `MAX_TERMINAL_CELLS` is `2^24`, about 1 GiB of `Terminal::Cell` storage on typical 64-bit systems. This preserves large legitimate terminal shapes but caps total allocation cost.

The patch also adds resize regression tests for missing, zero, negative, over-ABI, and over-cell-count dimensions in both UserMessage and HostMessage paths.

Fixes Issue #1386 

.. among other things around resizing.

This LLM assisted code, Codex with GPT 5.5 on Low / High.