### PR TITLE
terminal: answer OSC default color queries

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -391,14 +391,17 @@ if ( $pid == 0 ) { # child
     push @server, ( '-l', $_ );
   }
 
+  # Pass the local terminal's default colors using -@ so older servers consume
+  # the arguments quietly.
+  push @server, ( '-@', 'mosh-default-fg=' . $default_colors{ 'fg' } ) if defined $default_colors{ 'fg' };
+  push @server, ( '-@', 'mosh-default-bg=' . $default_colors{ 'bg' } ) if defined $default_colors{ 'bg' };
+
   if ( scalar @command > 0 ) {
     push @server, '--', @command;
   }
 
   if ( defined( $localhost )) {
     delete $ENV{ 'SSH_CONNECTION' };
-    local $ENV{ 'MOSH_DEFAULT_FG' } = $default_colors{ 'fg' } if defined $default_colors{ 'fg' };
-    local $ENV{ 'MOSH_DEFAULT_BG' } = $default_colors{ 'bg' } if defined $default_colors{ 'bg' };
     chdir; # $HOME
     print "MOSH IP ${userhost}\n";
     exec( "$server " . shell_quote( @server ) );
@@ -411,8 +414,7 @@ if ( $pid == 0 ) { # child
     my $quoted_proxy_command = shell_quote( $0, "--family=$family" );
     push @sshopts, ( '-S', 'none', '-o', "ProxyCommand=$quoted_proxy_command --fake-proxy -- %h %p" );
   }
-  my $server_environment = shell_quote_environment( %default_colors );
-  my @exec_argv = ( @ssh, @sshopts, $userhost, '--', $ssh_connection . $server_environment . "$server " . shell_quote( @server ) );
+  my @exec_argv = ( @ssh, @sshopts, $userhost, '--', $ssh_connection . "$server " . shell_quote( @server ) );
   exec @exec_argv;
   die "Cannot exec ssh: $!\n";
 } else { # parent
@@ -473,16 +475,6 @@ if ( $pid == 0 ) { # child
 
 sub shell_quote { join ' ', map {(my $a = $_) =~ s/'/'\\''/g; "'$a'"} @_ }
 
-sub shell_quote_environment {
-  my ( %colors ) = @_;
-  my @assignments;
-
-  push @assignments, "MOSH_DEFAULT_FG=" . shell_quote( $colors{ 'fg' } ) if defined $colors{ 'fg' };
-  push @assignments, "MOSH_DEFAULT_BG=" . shell_quote( $colors{ 'bg' } ) if defined $colors{ 'bg' };
-
-  return @assignments ? join( ' ', @assignments ) . ' ' : '';
-}
-
 sub query_terminal_default_colors {
   open my $tty, '+<', '/dev/tty' or return;
   binmode $tty;
@@ -528,7 +520,7 @@ sub parse_terminal_default_colors {
   my ( $response ) = @_;
   my %colors;
 
-  while ( $response =~ m{\033\](1[01]);rgb:([0-9A-Fa-f]{2,4}/[0-9A-Fa-f]{2,4}/[0-9A-Fa-f]{2,4})(?:\033\\|\007)}g ) {
+  while ( $response =~ m{\033\](1[01]);rgb:([0-9A-Fa-f]{1,4}/[0-9A-Fa-f]{1,4}/[0-9A-Fa-f]{1,4})(?:\033\\|\007)}g ) {
     if ( $1 eq '10' ) {
       $colors{ 'fg' } = $2;
     } elsif ( $1 eq '11' ) {

--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -39,7 +39,8 @@ use IO::Socket;
 use Text::ParseWords;
 use Socket qw(IPPROTO_TCP);
 use Errno qw(EINTR);
-use POSIX qw(_exit);
+use POSIX qw(_exit :termios_h);
+use Time::HiRes qw(time);
 
 BEGIN {
   my @gai_reqs = qw( getaddrinfo getnameinfo AI_CANONNAME AI_NUMERICHOST NI_NUMERICHOST );
@@ -327,6 +328,8 @@ if ( (not defined $colors)
   $colors = 0;
 }
 
+my %default_colors = query_terminal_default_colors();
+
 $ENV{ 'MOSH_CLIENT_PID' } = $$; # We don't support this, but it's useful for test and debug.
 
 # If we are using a locally-resolved address, we have to get it before we fork,
@@ -394,6 +397,8 @@ if ( $pid == 0 ) { # child
 
   if ( defined( $localhost )) {
     delete $ENV{ 'SSH_CONNECTION' };
+    local $ENV{ 'MOSH_DEFAULT_FG' } = $default_colors{ 'fg' } if defined $default_colors{ 'fg' };
+    local $ENV{ 'MOSH_DEFAULT_BG' } = $default_colors{ 'bg' } if defined $default_colors{ 'bg' };
     chdir; # $HOME
     print "MOSH IP ${userhost}\n";
     exec( "$server " . shell_quote( @server ) );
@@ -406,7 +411,8 @@ if ( $pid == 0 ) { # child
     my $quoted_proxy_command = shell_quote( $0, "--family=$family" );
     push @sshopts, ( '-S', 'none', '-o', "ProxyCommand=$quoted_proxy_command --fake-proxy -- %h %p" );
   }
-  my @exec_argv = ( @ssh, @sshopts, $userhost, '--', $ssh_connection . "$server " . shell_quote( @server ) );
+  my $server_environment = shell_quote_environment( %default_colors );
+  my @exec_argv = ( @ssh, @sshopts, $userhost, '--', $ssh_connection . $server_environment . "$server " . shell_quote( @server ) );
   exec @exec_argv;
   die "Cannot exec ssh: $!\n";
 } else { # parent
@@ -466,6 +472,72 @@ if ( $pid == 0 ) { # child
 }
 
 sub shell_quote { join ' ', map {(my $a = $_) =~ s/'/'\\''/g; "'$a'"} @_ }
+
+sub shell_quote_environment {
+  my ( %colors ) = @_;
+  my @assignments;
+
+  push @assignments, "MOSH_DEFAULT_FG=" . shell_quote( $colors{ 'fg' } ) if defined $colors{ 'fg' };
+  push @assignments, "MOSH_DEFAULT_BG=" . shell_quote( $colors{ 'bg' } ) if defined $colors{ 'bg' };
+
+  return @assignments ? join( ' ', @assignments ) . ' ' : '';
+}
+
+sub query_terminal_default_colors {
+  open my $tty, '+<', '/dev/tty' or return;
+  binmode $tty;
+
+  my $fd = fileno( $tty );
+  return if not defined $fd;
+
+  my $saved_termios = POSIX::Termios->new();
+  $saved_termios->getattr( $fd ) or return;
+
+  my $raw_termios = POSIX::Termios->new();
+  $raw_termios->getattr( $fd ) or return;
+  $raw_termios->setlflag( $raw_termios->getlflag() & ~( ECHO | ICANON ) );
+  $raw_termios->setcc( VMIN, 0 );
+  $raw_termios->setcc( VTIME, 1 );
+  $raw_termios->setattr( $fd, TCSANOW ) or return;
+
+  my $response = '';
+  eval {
+    syswrite( $tty, "\033]10;?\033\\\033]11;?\033\\" );
+
+    my $deadline = time() + 0.1;
+    while ( time() < $deadline ) {
+      my $read_fds = '';
+      vec( $read_fds, $fd, 1 ) = 1;
+      my $timeout = $deadline - time();
+      last if $timeout <= 0;
+      last if select( $read_fds, undef, undef, $timeout ) <= 0;
+
+      my $chunk = '';
+      my $bytes_read = sysread( $tty, $chunk, 4096 );
+      last if not defined $bytes_read or $bytes_read <= 0;
+      $response .= $chunk;
+    }
+  };
+
+  $saved_termios->setattr( $fd, TCSANOW );
+
+  return parse_terminal_default_colors( $response );
+}
+
+sub parse_terminal_default_colors {
+  my ( $response ) = @_;
+  my %colors;
+
+  while ( $response =~ m{\033\](1[01]);rgb:([0-9A-Fa-f]{2,4}/[0-9A-Fa-f]{2,4}/[0-9A-Fa-f]{2,4})(?:\033\\|\007)}g ) {
+    if ( $1 eq '10' ) {
+      $colors{ 'fg' } = $2;
+    } elsif ( $1 eq '11' ) {
+      $colors{ 'bg' } = $2;
+    }
+  }
+
+  return %colors;
+}
 
 sub locale_vars {
   my @names = qw[LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION LC_ALL];

--- a/src/frontend/mosh-server.cc
+++ b/src/frontend/mosh-server.cc
@@ -109,6 +109,8 @@ static int run_server( const char* desired_ip,
                        const std::string& command_path,
                        char* command_argv[],
                        const int colors,
+                       const std::string& default_fg,
+                       const std::string& default_bg,
                        unsigned int verbose,
                        bool with_motd );
 
@@ -189,9 +191,13 @@ int main( int argc, char* argv[] )
   std::string command_path;
   char** command_argv = NULL;
   int colors = 0;
+  std::string default_fg;
+  std::string default_bg;
   unsigned int verbose = 0; /* don't close stdin/stdout/stderr */
   /* Will cause mosh-server not to correctly detach on old versions of sshd. */
   std::list<std::string> locale_vars;
+  const char default_fg_arg[] = "mosh-default-fg=";
+  const char default_bg_arg[] = "mosh-default-bg=";
 
   /* strip off command */
   for ( int i = 1; i < argc; i++ ) {
@@ -219,14 +225,20 @@ int main( int argc, char* argv[] )
     while ( ( opt = getopt( argc - 1, argv + 1, "@:i:p:c:svl:" ) ) != -1 ) {
       switch ( opt ) {
           /*
-           * This undocumented option does nothing but eat its argument.
-           * Useful in scripting where you prepend something to a
-           * mosh-server argv, and might end up with something like
+           * This undocumented option eats its argument so newer wrappers can
+           * pass internal options that older servers consume quietly.  It is
+           * also useful in scripting where you prepend something to a
+           * mosh-server argv and might end up with something like
            * "mosh-server new -v new -c 256", now you can say
            * "mosh-server new -v -@ new -c 256" to discard the second
            * "new".
            */
         case '@':
+          if ( strncmp( optarg, default_fg_arg, strlen( default_fg_arg ) ) == 0 ) {
+            default_fg = optarg + strlen( default_fg_arg );
+          } else if ( strncmp( optarg, default_bg_arg, strlen( default_bg_arg ) ) == 0 ) {
+            default_bg = optarg + strlen( default_bg_arg );
+          }
           break;
         case 'i':
           desired_ip = optarg;
@@ -372,7 +384,8 @@ int main( int argc, char* argv[] )
   }
 
   try {
-    return run_server( desired_ip, desired_port, command_path, command_argv, colors, verbose, with_motd );
+    return run_server(
+      desired_ip, desired_port, command_path, command_argv, colors, default_fg, default_bg, verbose, with_motd );
   } catch ( const Network::NetworkException& e ) {
     fprintf( stderr, "Network exception: %s\n", e.what() );
     return 1;
@@ -387,6 +400,8 @@ static int run_server( const char* desired_ip,
                        const std::string& command_path,
                        char* command_argv[],
                        const int colors,
+                       const std::string& default_fg,
+                       const std::string& default_bg,
                        unsigned int verbose,
                        bool with_motd )
 {
@@ -429,7 +444,7 @@ static int run_server( const char* desired_ip,
   }
 
   /* open parser and terminal */
-  Terminal::Complete terminal( window_size.ws_col, window_size.ws_row );
+  Terminal::Complete terminal( window_size.ws_col, window_size.ws_row, default_fg, default_bg );
 
   /* open network */
   Network::UserStream blank;

--- a/src/statesync/completeterminal.h
+++ b/src/statesync/completeterminal.h
@@ -35,6 +35,7 @@
 
 #include <cstdint>
 #include <list>
+#include <string>
 
 #include "src/terminal/parser.h"
 #include "src/terminal/terminal.h"
@@ -61,8 +62,12 @@ private:
   static const int ECHO_TIMEOUT = 50; /* for late ack */
 
 public:
-  Complete( size_t width, size_t height )
-    : parser(), terminal( width, height ), display( false ), actions(), input_history(), echo_ack( 0 )
+  Complete( size_t width,
+            size_t height,
+            const std::string& default_fg = std::string(),
+            const std::string& default_bg = std::string() )
+    : parser(), terminal( width, height, default_fg, default_bg ), display( false ), actions(), input_history(),
+      echo_ack( 0 )
   {}
 
   std::string act( const std::string& str );

--- a/src/terminal/terminal.cc
+++ b/src/terminal/terminal.cc
@@ -41,7 +41,9 @@
 
 using namespace Terminal;
 
-Emulator::Emulator( size_t s_width, size_t s_height ) : fb( s_width, s_height ), dispatch(), user() {}
+Emulator::Emulator( size_t s_width, size_t s_height, const std::string& default_fg, const std::string& default_bg )
+  : fb( s_width, s_height ), dispatch( default_fg, default_bg ), user()
+{}
 
 std::string Emulator::read_octets_to_host( void )
 {

--- a/src/terminal/terminal.h
+++ b/src/terminal/terminal.h
@@ -36,6 +36,7 @@
 #include <cstdio>
 #include <cwchar>
 #include <deque>
+#include <string>
 #include <vector>
 
 #include "src/terminal/parseraction.h"
@@ -75,7 +76,10 @@ private:
   void resize( size_t s_width, size_t s_height );
 
 public:
-  Emulator( size_t s_width, size_t s_height );
+  Emulator( size_t s_width,
+            size_t s_height,
+            const std::string& default_fg = std::string(),
+            const std::string& default_bg = std::string() );
 
   std::string read_octets_to_host( void );
 

--- a/src/terminal/terminaldispatcher.cc
+++ b/src/terminal/terminaldispatcher.cc
@@ -44,8 +44,9 @@ using namespace Terminal;
 
 static const size_t MAXIMUM_CLIPBOARD_SIZE = 16 * 1024;
 
-Dispatcher::Dispatcher()
-  : params(), parsed_params(), parsed( false ), dispatch_chars(), OSC_string(), terminal_to_host()
+Dispatcher::Dispatcher( const std::string& s_default_fg, const std::string& s_default_bg )
+  : params(), parsed_params(), parsed( false ), dispatch_chars(), OSC_string(), default_fg( s_default_fg ),
+    default_bg( s_default_bg ), terminal_to_host()
 {}
 
 void Dispatcher::newparamchar( const Parser::Param* act )
@@ -254,5 +255,6 @@ bool Dispatcher::operator==( const Dispatcher& x ) const
 {
   return ( params == x.params ) && ( parsed_params == x.parsed_params ) && ( parsed == x.parsed )
          && ( dispatch_chars == x.dispatch_chars ) && ( OSC_string == x.OSC_string )
+         && ( default_fg == x.default_fg ) && ( default_bg == x.default_bg )
          && ( terminal_to_host == x.terminal_to_host );
 }

--- a/src/terminal/terminaldispatcher.h
+++ b/src/terminal/terminaldispatcher.h
@@ -97,6 +97,10 @@ private:
   std::string dispatch_chars;
   std::vector<wchar_t> OSC_string;
 
+  /* Terminal default colors, used to answer OSC 10/11 queries (server-side). */
+  std::string default_fg;
+  std::string default_bg;
+
   void parse_params( void );
 
 public:
@@ -105,8 +109,11 @@ public:
 
   std::string terminal_to_host; /* this is the reply string */
 
-  Dispatcher();
+  Dispatcher( const std::string& s_default_fg = std::string(), const std::string& s_default_bg = std::string() );
   int getparam( size_t N, int defaultval );
+
+  const std::string& get_default_fg( void ) const { return default_fg; }
+  const std::string& get_default_bg( void ) const { return default_bg; }
   int param_count( void );
 
   void newparamchar( const Parser::Param* act );

--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -33,7 +33,6 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
-#include <cstdlib>
 #include <string>
 #include <utility>
 #include <vector>
@@ -627,7 +626,7 @@ static void OSC_8( const std::string& OSC_string, Framebuffer* fb )
 
 static bool valid_default_color_component( const std::string& color, size_t start, size_t length )
 {
-  if ( length != 2 && length != 4 ) {
+  if ( length < 1 || length > 4 ) {
     return false;
   }
 
@@ -670,30 +669,24 @@ static bool OSC_string_matches( const std::vector<wchar_t>& OSC_string, const wc
   return i == OSC_string.size();
 }
 
+static void append_default_color_reply( Dispatcher* dispatch, const char* reply_prefix, const std::string& color )
+{
+  if ( !color.empty() && valid_default_color( color ) ) {
+    dispatch->terminal_to_host.append( reply_prefix );
+    dispatch->terminal_to_host.append( color );
+    dispatch->terminal_to_host.append( "\033\\" );
+  }
+}
+
 static bool answer_default_color_query( const std::vector<wchar_t>& OSC_string, Dispatcher* dispatch )
 {
-  struct DefaultColorQuery
-  {
-    const wchar_t* query;
-    const char* environment_variable;
-    const char* reply_prefix;
-  };
-
-  static const DefaultColorQuery queries[] = {
-    { L"10;?", "MOSH_DEFAULT_FG", "\033]10;rgb:" },
-    { L"11;?", "MOSH_DEFAULT_BG", "\033]11;rgb:" },
-  };
-
-  for ( const DefaultColorQuery& query : queries ) {
-    if ( OSC_string_matches( OSC_string, query.query ) ) {
-      const char* color = getenv( query.environment_variable );
-      if ( color != nullptr && valid_default_color( color ) ) {
-        dispatch->terminal_to_host.append( query.reply_prefix );
-        dispatch->terminal_to_host.append( color );
-        dispatch->terminal_to_host.append( "\033\\" );
-      }
-      return true;
-    }
+  if ( OSC_string_matches( OSC_string, L"10;?" ) ) {
+    append_default_color_reply( dispatch, "\033]10;rgb:", dispatch->get_default_fg() );
+    return true;
+  }
+  if ( OSC_string_matches( OSC_string, L"11;?" ) ) {
+    append_default_color_reply( dispatch, "\033]11;rgb:", dispatch->get_default_bg() );
+    return true;
   }
 
   return false;

--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -31,7 +31,9 @@
 */
 
 #include <algorithm>
+#include <cctype>
 #include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <utility>
 #include <vector>
@@ -623,9 +625,87 @@ static void OSC_8( const std::string& OSC_string, Framebuffer* fb )
   fb->ds.set_hyperlink( Hyperlink( OSC_string.substr( 2, second_semicolon - 2 ), std::move( url ) ) );
 }
 
+static bool valid_default_color_component( const std::string& color, size_t start, size_t length )
+{
+  if ( length != 2 && length != 4 ) {
+    return false;
+  }
+
+  for ( size_t i = start; i < start + length; i++ ) {
+    if ( !std::isxdigit( static_cast<unsigned char>( color[i] ) ) ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool valid_default_color( const std::string& color )
+{
+  const size_t first_slash = color.find( '/' );
+  if ( first_slash == std::string::npos ) {
+    return false;
+  }
+
+  const size_t second_slash = color.find( '/', first_slash + 1 );
+  if ( second_slash == std::string::npos || color.find( '/', second_slash + 1 ) != std::string::npos ) {
+    return false;
+  }
+
+  return valid_default_color_component( color, 0, first_slash )
+         && valid_default_color_component( color, first_slash + 1, second_slash - first_slash - 1 )
+         && valid_default_color_component( color, second_slash + 1, color.size() - second_slash - 1 );
+}
+
+static bool OSC_string_matches( const std::vector<wchar_t>& OSC_string, const wchar_t* query )
+{
+  size_t i = 0;
+  while ( query[i] != L'\0' ) {
+    if ( i >= OSC_string.size() || OSC_string[i] != query[i] ) {
+      return false;
+    }
+    i++;
+  }
+
+  return i == OSC_string.size();
+}
+
+static bool answer_default_color_query( const std::vector<wchar_t>& OSC_string, Dispatcher* dispatch )
+{
+  struct DefaultColorQuery
+  {
+    const wchar_t* query;
+    const char* environment_variable;
+    const char* reply_prefix;
+  };
+
+  static const DefaultColorQuery queries[] = {
+    { L"10;?", "MOSH_DEFAULT_FG", "\033]10;rgb:" },
+    { L"11;?", "MOSH_DEFAULT_BG", "\033]11;rgb:" },
+  };
+
+  for ( const DefaultColorQuery& query : queries ) {
+    if ( OSC_string_matches( OSC_string, query.query ) ) {
+      const char* color = getenv( query.environment_variable );
+      if ( color != nullptr && valid_default_color( color ) ) {
+        dispatch->terminal_to_host.append( query.reply_prefix );
+        dispatch->terminal_to_host.append( color );
+        dispatch->terminal_to_host.append( "\033\\" );
+      }
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /* xterm uses an Operating System Command to set the window title */
 void Dispatcher::OSC_dispatch( const Parser::OSC_End* act __attribute( ( unused ) ), Framebuffer* fb )
 {
+  if ( answer_default_color_query( OSC_string, this ) ) {
+    return;
+  }
+
   /* handle osc copy clipboard sequence 52;c; */
   if ( OSC_string.size() >= 5 && OSC_string[0] == L'5' && OSC_string[1] == L'2' && OSC_string[2] == L';'
        && OSC_string[3] == L'c' && OSC_string[4] == L';' ) {

--- a/src/tests/.gitignore
+++ b/src/tests/.gitignore
@@ -5,6 +5,7 @@
 /nonce-incr
 /inpty
 /is-utf8-locale
+/terminal-osc-default-colors
 /*.d/
 *.log
 *.trs

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -39,8 +39,8 @@ displaytests = \
 	unicode-later-combining.test \
 	window-resize.test
 
-check_PROGRAMS = ocb-aes encrypt-decrypt base64 nonce-incr inpty is-utf8-locale
-TESTS = ocb-aes encrypt-decrypt base64 nonce-incr local.test $(displaytests)
+check_PROGRAMS = ocb-aes encrypt-decrypt base64 nonce-incr inpty is-utf8-locale terminal-osc-default-colors
+TESTS = ocb-aes encrypt-decrypt base64 nonce-incr terminal-osc-default-colors local.test $(displaytests)
 XFAIL_TESTS = \
 	e2e-failure.test \
 	emulation-attributes-256color8.test
@@ -72,6 +72,10 @@ inpty_LDADD = ../util/libmoshutil.a
 is_utf8_locale_SOURCES = is-utf8-locale.cc
 is_utf8_locale_CPPFLAGS = -I$(srcdir)/../util
 is_utf8_locale_LDADD = ../util/libmoshutil.a $(LIBUTIL)
+
+terminal_osc_default_colors_SOURCES = terminal-osc-default-colors.cc
+terminal_osc_default_colors_CPPFLAGS = -I$(srcdir)/../statesync -I$(srcdir)/../terminal -I$(srcdir)/../protobufs $(protobuf_CFLAGS)
+terminal_osc_default_colors_LDADD = ../statesync/libmoshstatesync.a ../terminal/libmoshterminal.a ../protobufs/libmoshprotos.a ../util/libmoshutil.a $(protobuf_LIBS) $(TINFO_LIBS)
 
 clean-local: clean-local-check
 .PHONY: clean-local-check

--- a/src/tests/terminal-osc-default-colors.cc
+++ b/src/tests/terminal-osc-default-colors.cc
@@ -37,29 +37,37 @@
 
 #include "src/statesync/completeterminal.h"
 
-static bool expect_response( const std::string& input, const std::string& expected )
+static bool expect_response( const std::string& default_fg,
+                             const std::string& default_bg,
+                             const std::string& input,
+                             const std::string& expected )
 {
-  Terminal::Complete terminal( 80, 24 );
+  Terminal::Complete terminal( 80, 24, default_fg, default_bg );
   return terminal.act( input ) == expected;
 }
 
 int main()
 {
-  setenv( "MOSH_DEFAULT_FG", "eeee/eeee/eeee", 1 );
-  setenv( "MOSH_DEFAULT_BG", "1111/1111/1111", 1 );
-
-  if ( !expect_response( "\033]10;?\033\\\033]11;?\033\\",
+  /* Both default colors are answered. */
+  if ( !expect_response( "eeee/eeee/eeee",
+                         "1111/1111/1111",
+                         "\033]10;?\033\\\033]11;?\033\\",
                          "\033]10;rgb:eeee/eeee/eeee\033\\\033]11;rgb:1111/1111/1111\033\\" ) ) {
     return EXIT_FAILURE;
   }
 
-  unsetenv( "MOSH_DEFAULT_FG" );
-  if ( !expect_response( "\033]10;?\033\\", "" ) ) {
+  /* One-to-four digit XParseColor components are accepted. */
+  if ( !expect_response( "f/a/0", "", "\033]10;?\033\\", "\033]10;rgb:f/a/0\033\\" ) ) {
     return EXIT_FAILURE;
   }
 
-  setenv( "MOSH_DEFAULT_FG", "eeee/eeee/eeee\033]0;bad", 1 );
-  if ( !expect_response( "\033]10;?\033\\", "" ) ) {
+  /* An unset default color produces no reply. */
+  if ( !expect_response( "", "1111/1111/1111", "\033]10;?\033\\", "" ) ) {
+    return EXIT_FAILURE;
+  }
+
+  /* An invalid default color produces no reply. */
+  if ( !expect_response( "eeee/eeee/eeee\033]0;bad", "", "\033]10;?\033\\", "" ) ) {
     return EXIT_FAILURE;
   }
 

--- a/src/tests/terminal-osc-default-colors.cc
+++ b/src/tests/terminal-osc-default-colors.cc
@@ -1,0 +1,67 @@
+/*
+    Mosh: the mobile shell
+    Copyright 2026
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    In addition, as a special exception, the copyright holders give
+    permission to link the code of portions of this program with the
+    OpenSSL library under certain conditions as described in each
+    individual source file, and distribute linked combinations including
+    the two.
+
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do
+    so, delete this exception statement from your version. If you delete
+    this exception statement from all source files in the program, then
+    also delete it here.
+*/
+
+/* Tests terminal replies for OSC default foreground/background color queries. */
+
+#include <cstdlib>
+#include <string>
+
+#include "src/statesync/completeterminal.h"
+
+static bool expect_response( const std::string& input, const std::string& expected )
+{
+  Terminal::Complete terminal( 80, 24 );
+  return terminal.act( input ) == expected;
+}
+
+int main()
+{
+  setenv( "MOSH_DEFAULT_FG", "eeee/eeee/eeee", 1 );
+  setenv( "MOSH_DEFAULT_BG", "1111/1111/1111", 1 );
+
+  if ( !expect_response( "\033]10;?\033\\\033]11;?\033\\",
+                         "\033]10;rgb:eeee/eeee/eeee\033\\\033]11;rgb:1111/1111/1111\033\\" ) ) {
+    return EXIT_FAILURE;
+  }
+
+  unsetenv( "MOSH_DEFAULT_FG" );
+  if ( !expect_response( "\033]10;?\033\\", "" ) ) {
+    return EXIT_FAILURE;
+  }
+
+  setenv( "MOSH_DEFAULT_FG", "eeee/eeee/eeee\033]0;bad", 1 );
+  if ( !expect_response( "\033]10;?\033\\", "" ) ) {
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
terminal: Answer OSC default color queries

Fixes #1145.
Fixes #1351.
Related to #1350, but this PR intentionally does not implement OSC 4 indexed color queries.

Adds support for OSC 10/11 default foreground/background color queries through mosh. The wrapper probes the local terminal for default colors, forwards only sanitized rgb values to mosh-server, and the server terminal emulator answers remote application queries from those values.

Description:
- Probe the local controlling terminal for OSC 10/11 replies with a short timeout.
- Forward sanitized default foreground/background colors through internal `mosh-server new -@ mosh-default-fg=...` and `-@ mosh-default-bg=...` arguments.
- Reuse the existing `-@` compatibility sink: older servers consume and ignore these values, while newer servers store them as terminal startup state.
- Avoid environment variables and any protocol or Protobuf change.
- Answer OSC 10/11 `?` queries in the server emulator only when configured values are valid.
- Add a regression test for replies, missing values, invalid values, and valid 1-4 digit XParseColor components.

Validation:
- `perl -Mdiagnostics -c scripts/mosh.pl`
- `make -C src/tests check TESTS=terminal-osc-default-colors`
- PTY wrapper simulation confirmed parsed OSC replies are forwarded into the remote server command.
- `make -j4 check` passed the new regression but local `window-resize.test` errored in this macOS/tmux environment; the log showed the driver sent `qexit` to the shell instead of exiting `less`.