### PR TITLE
mosh: retry once without a pty when the server sends no startup message

### DIFF
--- a/scripts/mosh.pl
+++ b/scripts/mosh.pl
@@ -87,6 +87,8 @@ my $help = undef;
 my $version = undef;
 
 my @cmdline = @ARGV;
+# Kept whole so the no-pty retry below can start over with the same request.
+my @original_argv = @ARGV;
 
 my $usage =
 qq{Usage: $0 [options] [--] [user@]host [command...]
@@ -412,6 +414,7 @@ if ( $pid == 0 ) { # child
 } else { # parent
   my ( $sship, $port, $key );
   my $bad_udp_port_warning = 0;
+  my @deferred_output;
   LINE: while ( <$pipe> ) {
     chomp;
     if ( m{^MOSH IP } ) {
@@ -436,7 +439,7 @@ if ( $pid == 0 ) { # child
       if ( defined $port_request and $port_request =~ m{:} and m{Bad UDP port} ) {
 	$bad_udp_port_warning = 1;
       }
-      print "$_\n";
+      push @deferred_output, $_;
     }
   }
   close $pipe;
@@ -452,11 +455,43 @@ if ( $pid == 0 ) { # child
   }
 
   if ( not defined $key or not defined $port ) {
+    # Some servers do not answer when a pty is forced for a remote command.
+    # Windows OpenSSH is the case that prompted this: asking for a pty makes it
+    # run the command under a pseudoconsole, which renders a screen rather than
+    # forwarding bytes. Measured against OpenSSH_for_Windows_9.5p2, with the
+    # ssh client itself on a pty:
+    #
+    #   ssh -tt      the command runs, but its output arrives wrapped in the
+    #                escape sequences the renderer emits, so the anchored
+    #                MOSH CONNECT match above never fires
+    #   ssh -n -tt   the command does not run at all
+    #
+    # Either way the user is told the server has no mosh installed, which is
+    # not true and gives them nothing to act on. Retry once without the pty --
+    # re-running from the top rather than unpicking the failed attempt's state.
+    #
+    # This costs a second authentication, so say so before doing it, and carry
+    # the first attempt's output across in case the retry fails too.
+    if ( $ssh_pty and not $ENV{ 'MOSH_NO_PTY_RETRY' } ) {
+      warn "$0: no startup message; the server may not allow a pty for a remote\n"
+        . "$0: command. Retrying once with --no-ssh-pty (ssh will authenticate again).\n";
+      $ENV{ 'MOSH_NO_PTY_RETRY' } = 1;
+      $ENV{ 'MOSH_PTY_ATTEMPT_OUTPUT' } = join( "\n", @deferred_output );
+      exec { $0 } ( $0, '--no-ssh-pty', @original_argv );
+      die "$0: Cannot re-exec $0: $!\n";
+    }
+    if ( defined $ENV{ 'MOSH_PTY_ATTEMPT_OUTPUT' }
+         and length $ENV{ 'MOSH_PTY_ATTEMPT_OUTPUT' } ) {
+      warn "$0: the first attempt, with a pty, said:\n";
+      warn "$0:   $_\n" for split( /\n/, $ENV{ 'MOSH_PTY_ATTEMPT_OUTPUT' } );
+    }
+    print "$_\n" for @deferred_output;
     if ( $bad_udp_port_warning ) {
       die "$0: Server does not support UDP port range option.\n";
     }
     die "$0: Did not find mosh server startup message. (Have you installed mosh on your server?)\n";
   }
+  print "$_\n" for @deferred_output;
 
   # Now start real mosh client
   $ENV{ 'MOSH_KEY' } = $key;


### PR DESCRIPTION
## The problem

When a server does not answer a remote command run under a forced pty, mosh
reports

```
Did not find mosh server startup message. (Have you installed mosh on your server?)
```

which is wrong and gives the user nothing to act on. `--no-ssh-pty` already
fixes it; this just tries it once automatically instead of requiring every user
of such a server to find the flag.

## The case that prompted it

Windows OpenSSH. Asking for a pty makes it run the command under a
pseudoconsole, and a ConPTY renders a screen rather than forwarding bytes.
Measured against `OpenSSH_for_Windows_9.5p2`, with the ssh client itself on a
pty (this matters — from a pipe the far side gets a request no real user would
produce):

| | |
|---|---|
| `ssh -tt` | the command runs, output comes back wrapped in the renderer's escapes |
| `ssh -n -tt` | the command does not run at all |

The first is the nastier one. The line arrives as

```
\e[H\e]0;C:\WINDOWS\system32\conhost.exe\a\e[?25hMOSH CONNECT 60001 <key>
```

so `m{^MOSH CONNECT ...}` cannot match it, and mosh then echoes the unmatched
line back as part of the server's output. On a terminal those escapes are
invisible, so the user sees a clean-looking `MOSH CONNECT 60001 …` line
immediately above a message saying it was not found. That contradiction is what
makes it hard to diagnose.

I spent a while trying to fix this from the server side before concluding it
cannot be done: reformatting what `mosh-server` prints (a single `WriteFile`
does get the line to start at column 0, but it still ends `…<key>\e[4;1H`
because the renderer moves the cursor rather than emitting a newline),
`PermitTTY no` (with `-tt` the client aborts and the command never runs),
`RequestTTY no` in ssh_config (a command-line `-tt` wins), `ForceCommand`
(Win32-OpenSSH enforces it only for non-pty sessions). A screen renderer cannot
be made to guarantee a line's byte framing.

## What this changes

- Retry once with `--no-ssh-pty` if no startup message arrived and a pty was
  requested. `MOSH_NO_PTY_RETRY` guards against looping.
- Announce the retry. It re-execs, so ssh authenticates a second time — with a
  password or MFA that is a second prompt, and one appearing for no visible
  reason is worse than the failure it is recovering from.
- Defer unmatched server output rather than printing it as it arrives, and
  carry the first attempt's output across the exec, so if the retry also fails
  both attempts' evidence is shown. Today it is printed before the failure and
  then lost.

No OS test anywhere in the patch; it keys off the symptom.

## Costs, stated plainly

- A second authentication, as above.
- On a server that did run the command, the first attempt has started a
  `mosh-server` no client will reach. It exits by itself after 60 seconds.
- Remote startup files run twice.

If you would rather this were opt-in, or tried without a pty first and fell
back, I'm happy to rework it — the shape is the part I'd like your view on.

## Testing

- Against a Windows OpenSSH server: first attempt fails, retry connects, notice
  shown.
- Against an ordinary OpenSSH server on Linux: the pty attempt succeeds and the
  retry never fires. This is the regression that matters and I checked it
  specifically.
- `perl -c` clean.

## Disclosure

I maintain a fork that adds a native Windows port, which is where I hit this.
This patch is not part of that port — it is Perl in the launcher, it contains
no Windows-specific code, and it helps any server that mishandles a forced pty.
I am sending it here because carrying it downstream forever seemed like the
wrong answer.
