### PR TITLE
Add support for the faint (SGR 2) rendition

### DIFF
--- a/src/terminal/terminalframebuffer.cc
+++ b/src/terminal/terminalframebuffer.cc
@@ -492,8 +492,14 @@ void Renditions::set_rendition( color_type num )
   bool value = num < 9;
   switch ( num ) {
     case 1:
-    case 22:
       set_attribute( bold, value );
+      break;
+    case 2:
+      set_attribute( faint, value );
+      break;
+    case 22: /* normal intensity cancels both bold and faint */
+      set_attribute( bold, value );
+      set_attribute( faint, value );
       break;
     case 3:
     case 23:
@@ -546,6 +552,8 @@ std::string Renditions::sgr( void ) const
   ret.append( "\033[0" );
   if ( get_attribute( bold ) )
     ret.append( ";1" );
+  if ( get_attribute( faint ) )
+    ret.append( ";2" );
   if ( get_attribute( italic ) )
     ret.append( ";3" );
   if ( get_attribute( underlined ) )

--- a/src/tests/emulation-attributes.test
+++ b/src/tests/emulation-attributes.test
@@ -127,6 +127,8 @@ baseline()
             test_true_color
             echo "Bold:"
             test_true_color 1
+            echo "Faint:"
+            test_true_color 2
             echo "Italic:"
             test_true_color 3
             echo "Underline:"


### PR DESCRIPTION
The faint attribute was declared in `Renditions::attribute_type` but never read or written anywhere: `set_rendition()` had no case for SGR 2, so the parameter fell through to the "ignore unknown rendition" default, and `sgr()` had no branch to emit it. Faint text was therefore indistinguishable from normal text both on screen and on the wire, since `Display::new_frame` builds the network payload from `sgr()`.

This change gives SGR 2 its own case and emits `;2` alongside the other attributes. Per ECMA-48, SGR 22 selects normal intensity and cancels both bold and faint, so it is split out of the case it shared with SGR 1 and now clears both.

The truecolor attribute test is extended with a faint block; that test enumerates every attribute mosh supports and compares the rendering against tmux.