### PR TITLE
terminal: announce lower mouse tracking modes cumulatively

### DIFF
--- a/src/terminal/terminaldisplay.cc
+++ b/src/terminal/terminaldisplay.cc
@@ -292,6 +292,18 @@ std::string Display::new_frame( bool initialized, const Framebuffer& last, const
         snprintf( tmp, sizeof( tmp ), "\033[?%dl", frame.last_frame.ds.mouse_reporting_mode );
         frame.append( tmp );
       }
+      /* Announce the lower tracking modes as well. Terminals need not
+         implement every mode, and the common behaviour is to ignore an
+         unsupported one and keep the mode already in effect. Applications
+         set these cumulatively, so mirror that; otherwise a terminal that
+         lacks the highest requested mode is left with mouse reporting
+         entirely off. */
+      if ( f.ds.mouse_reporting_mode >= DrawState::MOUSE_REPORTING_BTN_EVENT ) {
+        frame.append( "\033[?1000h" );
+      }
+      if ( f.ds.mouse_reporting_mode >= DrawState::MOUSE_REPORTING_ANY_EVENT ) {
+        frame.append( "\033[?1002h" );
+      }
       snprintf( tmp, sizeof( tmp ), "\033[?%dh", f.ds.mouse_reporting_mode );
       frame.append( tmp );
     }


### PR DESCRIPTION
Fixes #1364.

Mouse tracking modes 1000, 1002 and 1003 are separate flags in xterm, and applications set them cumulatively. mosh stores them in a single `mouse_reporting_mode` and announces only the most recent one to the client terminal.

Terminals need not implement every mode; the usual behaviour is to ignore an unsupported request and keep the mode already in effect. Because mosh forwards only the final mode, that fallback never happens — a terminal without 1003 ends up with mouse reporting entirely off, even though it supports 1000 and 1002.

### Where we hit it

Android/Termux → mosh → tmux → a full-screen terminal application that requests `1000h 1002h 1003h 1006h` at startup. Scrolling produced arrow keys instead of mouse events. Same phone, same server, same tmux over plain ssh: works.

### Measurements

Raw bytes read from the tty in Termux while scrolling, one mode at a time, no mosh in the path:

| requested | received |
| --- | --- |
| `1000h` `1006h` | `\e[<65;39;37M` — SGR mouse |
| `1002h` `1006h` | `\e[<64;35;28M` — SGR mouse |
| `1003h` `1006h` | `\e[A` `\e[B` — arrow keys |

So Termux implements 1000 and 1002 but not 1003. Then, same client and server, application sending all four modes:

| transport | result |
| --- | --- |
| ssh | SGR mouse — every request reaches the terminal, 1003 is ignored harmlessly |
| mosh | arrow keys — only `1003h` reaches the terminal, so nothing is enabled |

### Fix

Announce the lower modes alongside the stored one, mirroring what applications send. Terminals that do support 1003 are unaffected, since the higher mode takes precedence.

### Scope

This is the minimal fix. #1364 also suggests recording every requested mode in order and replaying it, which would preserve exact ordering across arbitrary transitions; that is a larger change to the state model. The existing disable of the previous mode is left alone.

### Testing

Built and run as the client on Android/Termux (aarch64) against an unpatched mosh 1.4.0 server: mouse reporting works again through mosh → tmux. Also builds clean on Linux x86_64. Behaviour unchanged on terminals that support 1003.

Credit to @Imberflur for diagnosing the root cause in #1364.
