### PR TITLE
terminal: include parameter list in DA1 response

### DIFF
--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -139,7 +139,8 @@ static Function func_CSI_cursormove_f( CSI, "f", CSI_cursormove );
 /* device attributes */
 static void CSI_DA( Framebuffer* fb __attribute( ( unused ) ), Dispatcher* dispatch )
 {
-  dispatch->terminal_to_host.append( "\033[?62c" ); /* plain vt220 */
+  /* VT220 (62) with ANSI color (22); a bare CSI ? 62 c goes unrecognized */
+  dispatch->terminal_to_host.append( "\033[?62;22c" );
 }
 
 static Function func_CSI_DA( CSI, "c", CSI_DA );


### PR DESCRIPTION
Primary Device Attributes was answered with a bare "CSI ? 62 c". DEC specifies the VT220 form as CSI ? 6 2 ; Ps c, so a parameterless reply is not recognized as a DA1 response at all. This breaks programs that use DA1 to conclude terminal identification, such as notcurses apps.

Reply with "CSI ? 62 ; 22 c" -- VT220 with ANSI color, which mosh does support.

(Disclaimer: I used AI tools for this)