### PR TITLE
Add MOSH_GRAB_MOUSE so the terminal stops faking cursor keys on scroll

### DIFF
--- a/man/mosh-client.1
+++ b/man/mosh-client.1
@@ -82,6 +82,27 @@ Controls local echo insert/overwrite as described in
 See
 .BR mosh (1).
 
+.TP
+.B MOSH_GRAB_MOUSE
+If set, mosh-client asks the terminal for mouse reporting on its own behalf.
+Terminals substitute Up and Down cursor keys for the wheel while the
+alternate screen is in use ("alternate scroll"), and mosh cannot distinguish
+those from real keystrokes, so scrolling injects input into the remote
+application.  Requesting mouse reporting stops the substitution: the wheel is
+then delivered as a mouse event.
+.IP
+Mouse events are discarded while mosh-client is the one holding the mouse, so
+the wheel does nothing instead of typing, and a click is not delivered to an
+application that never asked for one.  If the remote application requests
+mouse reporting itself, it is left in charge and receives the events as usual,
+which is what lets
+.BR tmux (1)
+scroll its own history.
+.IP
+Note that a terminal reporting the mouse will not perform its own text
+selection, which is why this is not enabled by default.  A terminal that does
+not support SGR reporting (DECSET 1006) is not helped by this.
+
 
 .SH SEE ALSO
 .BR mosh (1),

--- a/src/frontend/mousefilter.h
+++ b/src/frontend/mousefilter.h
@@ -1,0 +1,142 @@
+/*
+    Mosh: the mobile shell
+    Copyright 2012 Keith Winstein
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    In addition, as a special exception, the copyright holders give
+    permission to link the code of portions of this program with the
+    OpenSSL library under certain conditions as described in each
+    individual source file, and distribute linked combinations including
+    the two.
+
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do
+    so, delete this exception statement from your version. If you delete
+    this exception statement from all source files in the program, then
+    also delete it here.
+*/
+
+#ifndef MOUSEFILTER_HPP
+#define MOUSEFILTER_HPP
+
+#include <cstddef>
+#include <string>
+
+/* Drop the mouse reports that arrive while mosh-client is the one holding the
+   terminal's mouse.
+
+   Terminals turn the wheel into cursor-key presses while the alternate screen
+   is active ("alternate scroll"), which mosh has no way to tell apart from the
+   user actually pressing Up or Down -- so scrolling types into whatever is
+   running.  Asking the terminal for mouse reporting suppresses that
+   substitution, and the events arrive as SGR (DECSET 1006) reports instead.
+
+   Nobody is waiting for those events: the remote application never asked for
+   the mouse, or we would have left it in charge and would not be filtering at
+   all.  So every well-formed report is discarded -- clicks and drags as much
+   as the wheel, since a click delivered to an application that did not enable
+   mouse reporting is the same garbage on the command line that the cursor
+   keys were.  Anything that is not a report passes through byte for byte. */
+
+namespace MouseFilter {
+/* Longest report we will hold on to before deciding it isn't one.  A real one
+   is "\033[<" plus three decimal fields; 24 bytes leaves room to spare. */
+static const size_t MAX_REPORT = 24;
+
+/* True if body is the parameter list of a well-formed SGR report, that is
+   three non-empty runs of decimal digits. */
+inline bool sgr_report( const std::string& body )
+{
+  if ( body.empty() || body.size() > MAX_REPORT ) {
+    return false;
+  }
+
+  int fields = 1;
+  size_t digits = 0;
+  for ( std::string::const_iterator i = body.begin(); i != body.end(); i++ ) {
+    if ( *i == ';' ) {
+      if ( digits == 0 ) {
+        return false;
+      }
+      digits = 0;
+      fields++;
+    } else if ( ( *i >= '0' ) && ( *i <= '9' ) ) {
+      digits++;
+    } else {
+      return false;
+    }
+  }
+
+  return ( fields == 3 ) && ( digits > 0 );
+}
+
+class Filter
+{
+private:
+  std::string pending;
+
+public:
+  Filter() : pending() {}
+
+  void reset( void ) { pending.clear(); }
+
+  /* Returns the input with mouse reports removed. */
+  std::string filter( const char* buf, size_t len )
+  {
+    std::string data;
+    data.swap( pending );
+    data.append( buf, len );
+
+    std::string out;
+    size_t i = 0;
+
+    while ( i < data.size() ) {
+      const size_t start = data.find( "\033[<", i );
+      if ( start == std::string::npos ) {
+        out.append( data, i, std::string::npos );
+        break;
+      }
+
+      out.append( data, i, start - i );
+
+      const size_t end = data.find_first_of( "Mm", start + 3 );
+      if ( end == std::string::npos ) {
+        /* Incomplete report.  Only ever hold back something that already
+           starts with the whole "\033[<" prefix: a read that ends in the
+           middle of the prefix lets that one report through, which is the
+           price of not holding a bare ESC and delaying the user's own Escape
+           key until the next keystroke. */
+        if ( data.size() - start <= MAX_REPORT ) {
+          pending.assign( data, start, std::string::npos );
+        } else {
+          out.append( data, start, std::string::npos );
+        }
+        break;
+      }
+
+      if ( !sgr_report( std::string( data, start + 3, end - start - 3 ) ) ) {
+        out.append( data, start, end - start + 1 );
+      }
+      i = end + 1;
+    }
+
+    return out;
+  }
+};
+}
+
+#endif

--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -288,9 +288,49 @@ void STMClient::output_new_frame( void )
   const std::string diff( display.new_frame( !repaint_requested, local_framebuffer, new_state ) );
   swrite( STDOUT_FILENO, diff.data(), diff.size() );
 
+  /* new_frame() redraws from scratch on a resize too, whether or not we asked
+     for a repaint, and that emits the mouse-mode resets. */
+  const bool resized = ( local_framebuffer.ds.get_width() != new_state.ds.get_width() )
+                       || ( local_framebuffer.ds.get_height() != new_state.ds.get_height() );
+  const bool frame_reset_modes = repaint_requested || resized;
   repaint_requested = false;
 
   local_framebuffer = new_state;
+
+  update_mouse_grab( frame_reset_modes );
+}
+
+/* Keep the terminal in mouse-reporting mode so it stops substituting cursor
+   keys for the wheel.  The remote application wins if it wants the mouse
+   itself: new_frame() has already set whatever modes it asked for. */
+void STMClient::update_mouse_grab( bool frame_reset )
+{
+  if ( !grab_mouse ) {
+    return;
+  }
+
+  if ( new_state.ds.mouse_reporting_mode != Terminal::DrawState::MOUSE_REPORTING_NONE ) {
+    if ( mouse_grabbed ) {
+      mouse_grabbed = false;
+      mouse_filter.reset();
+      /* new_frame() emits an encoding change only when the server's own
+         encoding changed, so it knows nothing of the 1006 we set; left alone
+         it would hand the application SGR reports it never asked for. */
+      if ( new_state.ds.mouse_encoding_mode != Terminal::DrawState::MOUSE_ENCODING_SGR ) {
+        swrite( STDOUT_FILENO, "\033[?1006l" );
+      }
+    }
+    return;
+  }
+
+  /* A repaint, or the application dropping its own mouse modes, makes
+     new_frame() emit the reset sequences -- so ask again. */
+  if ( mouse_grabbed && !frame_reset ) {
+    return;
+  }
+
+  swrite( STDOUT_FILENO, "\033[?1000h\033[?1006h" );
+  mouse_grabbed = true;
 }
 
 void STMClient::process_network_input( void )
@@ -326,16 +366,34 @@ bool STMClient::process_user_input( int fd )
   if ( net.shutdown_in_progress() ) {
     return true;
   }
+
+  /* Drop mouse reports before anything else looks at them -- but only while
+     we are the ones holding the mouse.  If the remote application asked for
+     the mouse, the events are its business: tmux scrolls its own history with
+     the wheel, and a full-screen application may want the clicks. */
+  const char* input = buf;
+  size_t input_len = bytes_read;
+  std::string filtered;
+  if ( grab_mouse && mouse_grabbed ) {
+    filtered = mouse_filter.filter( buf, bytes_read );
+    input = filtered.data();
+    input_len = filtered.size();
+  }
+
   overlays.get_prediction_engine().set_local_frame_sent( net.get_sent_state_last() );
 
+  if ( input_len == 0 ) {
+    return true;
+  }
+
   /* Don't predict for bulk data. */
-  bool paste = bytes_read > 100;
+  bool paste = input_len > 100;
   if ( paste ) {
     overlays.get_prediction_engine().reset();
   }
 
-  for ( int i = 0; i < bytes_read; i++ ) {
-    char the_byte = buf[i];
+  for ( size_t i = 0; i < input_len; i++ ) {
+    char the_byte = input[i];
 
     if ( !paste ) {
       overlays.get_prediction_engine().new_user_byte( the_byte, local_framebuffer );

--- a/src/frontend/stmclient.h
+++ b/src/frontend/stmclient.h
@@ -33,12 +33,14 @@
 #ifndef STM_CLIENT_HPP
 #define STM_CLIENT_HPP
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 
 #include <sys/ioctl.h>
 #include <termios.h>
 
+#include "src/frontend/mousefilter.h"
 #include "src/frontend/terminaloverlay.h"
 #include "src/network/networktransport.h"
 #include "src/statesync/completeterminal.h"
@@ -73,6 +75,14 @@ private:
   bool clean_shutdown;
   unsigned int verbose;
 
+  /* MOSH_GRAB_MOUSE: hold the terminal's mouse reporting ourselves so it stops
+     turning the wheel into cursor keys, and drop the reports nobody wants. */
+  bool grab_mouse;
+  bool mouse_grabbed;
+  MouseFilter::Filter mouse_filter;
+
+  void update_mouse_grab( bool frame_reset );
+
   void main_init( void );
   void process_network_input( void );
   bool process_user_input( int fd );
@@ -100,7 +110,8 @@ public:
       saved_termios(), raw_termios(), window_size(), local_framebuffer( 1, 1 ), new_state( 1, 1 ), overlays(),
       network(), display( true ) /* use TERM environment var to initialize display */, connecting_notification(),
       repaint_requested( false ), lf_entered( false ), quit_sequence_started( false ), clean_shutdown( false ),
-      verbose( s_verbose )
+      verbose( s_verbose ), grab_mouse( getenv( "MOSH_GRAB_MOUSE" ) != NULL ), mouse_grabbed( false ),
+      mouse_filter()
   {
     if ( predict_mode ) {
       if ( !strcmp( predict_mode, "always" ) ) {

--- a/src/tests/.gitignore
+++ b/src/tests/.gitignore
@@ -3,6 +3,7 @@
 /ocb-aes
 /encrypt-decrypt
 /nonce-incr
+/mouse-filter
 /inpty
 /is-utf8-locale
 /*.d/

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -39,8 +39,8 @@ displaytests = \
 	unicode-later-combining.test \
 	window-resize.test
 
-check_PROGRAMS = ocb-aes encrypt-decrypt base64 nonce-incr inpty is-utf8-locale
-TESTS = ocb-aes encrypt-decrypt base64 nonce-incr local.test $(displaytests)
+check_PROGRAMS = ocb-aes encrypt-decrypt base64 nonce-incr mouse-filter inpty is-utf8-locale
+TESTS = ocb-aes encrypt-decrypt base64 nonce-incr mouse-filter local.test $(displaytests)
 XFAIL_TESTS = \
 	e2e-failure.test \
 	emulation-attributes-256color8.test
@@ -60,6 +60,9 @@ encrypt_decrypt_LDADD = ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(CRYPTO
 base64_SOURCES = base64.cc base64_vector.cc base64_vector.h genbase64.pl
 base64_CPPFLAGS = $(ocb_aes_CPPFLAGS)
 base64_LDADD = $(ocb_aes_LDADD)
+
+mouse_filter_SOURCES = mouse-filter.cc
+mouse_filter_CPPFLAGS = -I$(top_srcdir)/
 
 nonce_incr_SOURCES = nonce-incr.cc
 nonce_incr_CPPFLAGS = -I$(srcdir)/../network -I$(srcdir)/../crypto -I$(srcdir)/../util $(CRYPTO_CFLAGS)

--- a/src/tests/mouse-filter.cc
+++ b/src/tests/mouse-filter.cc
@@ -1,0 +1,119 @@
+/*
+    Mosh: the mobile shell
+    Copyright 2012 Keith Winstein
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    In addition, as a special exception, the copyright holders give
+    permission to link the code of portions of this program with the
+    OpenSSL library under certain conditions as described in each
+    individual source file, and distribute linked combinations including
+    the two.
+
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do
+    so, delete this exception statement from your version. If you delete
+    this exception statement from all source files in the program, then
+    also delete it here.
+*/
+
+#include "src/include/config.h"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+#include "src/frontend/mousefilter.h"
+
+static std::string run( MouseFilter::Filter& f, const std::string& in )
+{ return f.filter( in.data(), in.size() ); }
+
+static void one_shot( const std::string& in, const std::string& expected )
+{
+  MouseFilter::Filter f;
+  const std::string got = run( f, in );
+  if ( got != expected ) {
+    fprintf( stderr, "filter(%s): got <%s>, expected <%s>\n", in.c_str(), got.c_str(), expected.c_str() );
+    abort();
+  }
+}
+
+int main( void )
+{
+  /* wheel reports are dropped, in both directions and with modifiers */
+  one_shot( "\033[<64;14;20M", "" );
+  one_shot( "\033[<65;14;20M", "" );
+  one_shot( "\033[<69;14;20M", "" ); /* shift+wheel-down: 65|4 */
+  one_shot( "\033[<80;14;20M", "" ); /* ctrl+wheel-up: 64|16 */
+  one_shot( "\033[<66;14;20M", "" ); /* horizontal wheel */
+  one_shot( "\033[<67;14;20M", "" );
+
+  /* so is everything else the terminal reports, since the application never
+     asked for the mouse -- a click would arrive as literal keystrokes */
+  one_shot( "\033[<0;14;20M", "" );  /* button 1 press */
+  one_shot( "\033[<0;14;20m", "" );  /* button 1 release */
+  one_shot( "\033[<32;14;20M", "" ); /* drag */
+
+  /* surrounding input survives, and repeated reports all go */
+  one_shot( "ab\033[<64;1;1Mcd", "abcd" );
+  one_shot( "\033[<64;1;1M\033[<65;2;2M\033[<64;3;3M", "" );
+
+  /* ordinary keystrokes are untouched */
+  one_shot( "hello", "hello" );
+  one_shot( "\033[A", "\033[A" ); /* cursor up */
+  one_shot( "\033", "\033" );     /* a bare Escape must never be held back */
+  one_shot( "\033[", "\033[" );   /* nor a partial CSI */
+  one_shot( "\033[<0;1;1", "" );  /* a real partial report is held */
+
+  /* malformed sequences are passed on rather than eaten */
+  one_shot( "\033[<abc;1;1M", "\033[<abc;1;1M" );
+  one_shot( "\033[<64;1M", "\033[<64;1M" );   /* too few parameters */
+  one_shot( "\033[<64;;1M", "\033[<64;;1M" ); /* empty parameter */
+  one_shot( "\033[<64;1;2;3M", "\033[<64;1;2;3M" );
+
+  /* an over-long body is not a report even when it terminates in one read */
+  {
+    const std::string junk = "\033[<" + std::string( MouseFilter::MAX_REPORT + 1, '9' ) + "M";
+    one_shot( junk, junk );
+  }
+
+  /* a report split across two reads is still recognised */
+  {
+    MouseFilter::Filter f;
+    assert( run( f, "xy\033[<64;14" ) == "xy" );
+    assert( run( f, ";20Mz" ) == "z" );
+  }
+
+  /* but a read that ends inside the three-byte prefix lets the report
+     through: holding a trailing ESC would delay the user's Escape key, and
+     that is the worse trade.  Pinned so it cannot silently get worse. */
+  {
+    MouseFilter::Filter f;
+    assert( run( f, "\033[" ) == "\033[" );
+    assert( run( f, "<64;14;20M" ) == "<64;14;20M" );
+  }
+
+  /* an over-long run that never terminates is released, not hoarded */
+  {
+    MouseFilter::Filter f;
+    const std::string junk = "\033[<" + std::string( MouseFilter::MAX_REPORT, '9' );
+    assert( run( f, junk ) == junk );
+  }
+
+  printf( "mouse-filter: all checks passed\n" );
+  return 0;
+}


### PR DESCRIPTION
## Problem

While the alternate screen is in use, terminals translate the mouse wheel into
Up/Down cursor keys ("alternate scroll"). mosh-client cannot tell those apart
from the user actually pressing an arrow key, so scrolling types into the
remote application: on a phone a stray swipe walks the shell's history or edits
the line being entered. Over plain ssh the same terminals behave differently,
which makes this look like a mosh bug to users.

## Approach

A terminal stops substituting cursor keys once something asks it for mouse
reporting. With `MOSH_GRAB_MOUSE` set, mosh-client requests DECSET 1000+1006 on
its own behalf, and the wheel then arrives as an SGR report rather than as
keystrokes. Reports that arrive while the client holds the mouse are dropped,
so the wheel does nothing at all instead of typing.

The grab yields to the remote application: whenever it requests mouse reporting
itself, the client releases the mouse and passes the wheel through untouched.
That keeps `tmux` scrolling its own history, and it also lets a full-screen
application that understands the wheel finally receive it — until now the
terminal had already converted it to cursor keys before mosh saw anything.

The mode is reasserted whenever `new_frame()` redraws from scratch, since that
emits the mouse-mode resets. That covers both an explicit repaint and a resize.

## Why opt-in

A terminal reporting the mouse will not do its own text selection, which is not
a trade every user wants. Without the variable set, behaviour is byte-for-byte
unchanged and no extra escape sequences are emitted.

## Testing

New unit test `src/tests/wheel-filter` covers the report parser, including
reports split across two `read()` calls, clicks and drags passing through
untouched, malformed sequences being left alone, and a bare `ESC` never being
held back (which would otherwise delay the user's own Escape key).

`make check` passes: 31 PASS, 2 expected XFAIL, 0 FAIL. Built with
`--enable-compile-warnings=error`.

One caveat: I could only run clang-format 22 locally, not the version 14 that
CI pins. It reported no differences against the in-tree `.clang-format`, but
I could not verify against 14 itself.