### PR TITLE
Fix two portability defects found building with MSVC

### DIFF
--- a/src/crypto/ocb_internal.cc
+++ b/src/crypto/ocb_internal.cc
@@ -151,7 +151,11 @@
 #endif
 
 #if _MSC_VER
-	static inline unsigned ntz(unsigned x) {_BitScanForward(&x,x);return x;}
+	static inline unsigned ntz(unsigned x) {
+		unsigned long index;
+		_BitScanForward(&index, (unsigned long)x);
+		return (unsigned)index;
+	}
 #elif HAVE_DECL___BUILTIN_CTZ
 	#define ntz(x)     __builtin_ctz((unsigned)(x))   /* GCC 3.4+ */
 #elif HAVE_DECL_FFS

--- a/src/util/swrite.h
+++ b/src/util/swrite.h
@@ -33,6 +33,9 @@
 #ifndef SWRITE_HPP
 #define SWRITE_HPP
 
+/* This header names ssize_t, so it has to be the one to introduce it. */
+#include <sys/types.h>
+
 int swrite( int fd, const char* str, ssize_t len = -1 );
 
 #endif


### PR DESCRIPTION
Neither is Windows-specific in itself; both are latent in the tree today.

ocb_internal.cc's ntz() passes an unsigned* where _BitScanForward takes
an unsigned long*, so the MSVC branch it lives in does not compile:

    error C2664: 'unsigned char _BitScanForward(unsigned long *,unsigned
    long)': cannot convert argument 1 from 'unsigned int *' to
    'unsigned long *'

The file's own notes say it is tested against recent MSVC, so this looks
like drift rather than intent.

swrite.h declares a function taking a ssize_t without including anything
that defines one, and has been getting away with it because every
current includer happens to pull in <unistd.h> first. Include
<sys/types.h> so the header stands on its own.

No change to generated code on POSIX.

