### PR TITLE
Give the Unicode code point a name of its own

### DIFF
--- a/src/frontend/stmclient.cc
+++ b/src/frontend/stmclient.cc
@@ -124,7 +124,7 @@ void STMClient::init( void )
 
   /* Add our name to window title */
   if ( !getenv( "MOSH_TITLE_NOPREFIX" ) ) {
-    overlays.set_title_prefix( std::wstring( L"[mosh] " ) );
+    overlays.set_title_prefix( mosh_wstring( MOSH_L( "[mosh] " ) ) );
   }
 
   /* Set terminal escape key. */
@@ -189,24 +189,24 @@ void STMClient::init( void )
     }
     std::string tmp;
     tmp = std::string( escape_pass_name_buf );
-    std::wstring escape_pass_name = std::wstring( tmp.begin(), tmp.end() );
+    mosh_wstring escape_pass_name = mosh_wstring( tmp.begin(), tmp.end() );
     tmp = std::string( escape_key_name_buf );
-    std::wstring escape_key_name = std::wstring( tmp.begin(), tmp.end() );
-    escape_key_help
-      = L"Commands: Ctrl-Z suspends, \".\" quits, " + escape_pass_name + L" gives literal " + escape_key_name;
+    mosh_wstring escape_key_name = mosh_wstring( tmp.begin(), tmp.end() );
+    escape_key_help = MOSH_L( "Commands: Ctrl-Z suspends, \".\" quits, " ) + escape_pass_name
+                      + MOSH_L( " gives literal " ) + escape_key_name;
     overlays.get_notification_engine().set_escape_key_string( tmp );
   }
-  wchar_t tmp[128];
-  swprintf( tmp, 128, L"Nothing received from server on UDP port %s.", port.c_str() );
-  connecting_notification = std::wstring( tmp );
+  char tmp[128];
+  snprintf( tmp, sizeof tmp, "Nothing received from server on UDP port %s.", port.c_str() );
+  connecting_notification = mosh_widen( tmp );
 }
 
 void STMClient::shutdown( void )
 {
   /* Restore screen state */
-  overlays.get_notification_engine().set_notification_string( std::wstring( L"" ) );
+  overlays.get_notification_engine().set_notification_string( mosh_wstring( MOSH_L( "" ) ) );
   overlays.get_notification_engine().server_heard( timestamp() );
-  overlays.set_title_prefix( std::wstring( L"" ) );
+  overlays.set_title_prefix( mosh_wstring( MOSH_L( "" ) ) );
   output_new_frame();
 
   /* Restore terminal and terminal-driver state */
@@ -344,8 +344,8 @@ bool STMClient::process_user_input( int fd )
     if ( quit_sequence_started ) {
       if ( the_byte == '.' ) { /* Quit sequence is Ctrl-^ . */
         if ( net.has_remote_addr() && ( !net.shutdown_in_progress() ) ) {
-          overlays.get_notification_engine().set_notification_string( std::wstring( L"Exiting on user request..." ),
-                                                                      true );
+          overlays.get_notification_engine().set_notification_string(
+            mosh_wstring( MOSH_L( "Exiting on user request..." ) ), true );
           net.start_shutdown();
           return true;
         }
@@ -380,7 +380,7 @@ bool STMClient::process_user_input( int fd )
       quit_sequence_started = false;
 
       if ( overlays.get_notification_engine().get_notification_string() == escape_key_help ) {
-        overlays.get_notification_engine().set_notification_string( L"" );
+        overlays.get_notification_engine().set_notification_string( MOSH_L( "" ) );
       }
 
       continue;
@@ -492,7 +492,8 @@ bool STMClient::main( void )
         if ( !network->has_remote_addr() ) {
           break;
         } else if ( !network->shutdown_in_progress() ) {
-          overlays.get_notification_engine().set_notification_string( std::wstring( L"Exiting..." ), true );
+          overlays.get_notification_engine().set_notification_string( mosh_wstring( MOSH_L( "Exiting..." ) ),
+                                                                      true );
           network->start_shutdown();
         }
       }
@@ -511,7 +512,7 @@ bool STMClient::main( void )
           break;
         } else if ( !network->shutdown_in_progress() ) {
           overlays.get_notification_engine().set_notification_string(
-            std::wstring( L"Signal received, shutting down..." ), true );
+            mosh_wstring( MOSH_L( "Signal received, shutting down..." ) ), true );
           network->start_shutdown();
         }
       }
@@ -539,7 +540,7 @@ bool STMClient::main( void )
         if ( timestamp() - network->get_latest_remote_state().timestamp > 15000 ) {
           if ( !network->shutdown_in_progress() ) {
             overlays.get_notification_engine().set_notification_string(
-              std::wstring( L"Timed out waiting for server..." ), true );
+              mosh_wstring( MOSH_L( "Timed out waiting for server..." ) ), true );
             network->start_shutdown();
           }
         } else {
@@ -547,7 +548,7 @@ bool STMClient::main( void )
         }
       } else if ( ( network->get_remote_state_num() != 0 )
                   && ( overlays.get_notification_engine().get_notification_string() == connecting_notification ) ) {
-        overlays.get_notification_engine().set_notification_string( L"" );
+        overlays.get_notification_engine().set_notification_string( MOSH_L( "" ) );
       }
 
       network->tick();
@@ -573,9 +574,9 @@ bool STMClient::main( void )
       if ( e.fatal ) {
         throw;
       } else {
-        wchar_t tmp[128];
-        swprintf( tmp, 128, L"Crypto exception: %s", e.what() );
-        overlays.get_notification_engine().set_notification_string( std::wstring( tmp ) );
+        char tmp[128];
+        snprintf( tmp, sizeof tmp, "Crypto exception: %s", e.what() );
+        overlays.get_notification_engine().set_notification_string( mosh_widen( tmp ) );
       }
     }
   }

--- a/src/frontend/stmclient.h
+++ b/src/frontend/stmclient.h
@@ -33,6 +33,8 @@
 #ifndef STM_CLIENT_HPP
 #define STM_CLIENT_HPP
 
+#include "src/util/unicode.h"
+
 #include <memory>
 #include <string>
 
@@ -55,7 +57,7 @@ private:
   int escape_pass_key;
   int escape_pass_key2;
   bool escape_requires_lf;
-  std::wstring escape_key_help;
+  mosh_wstring escape_key_help;
 
   struct termios saved_termios, raw_termios;
 
@@ -68,7 +70,7 @@ private:
   NetworkPointer network;
   Terminal::Display display;
 
-  std::wstring connecting_notification;
+  mosh_wstring connecting_notification;
   bool repaint_requested, lf_entered, quit_sequence_started;
   bool clean_shutdown;
   unsigned int verbose;
@@ -96,9 +98,10 @@ public:
              unsigned int s_verbose,
              const char* predict_overwrite )
     : ip( s_ip ? s_ip : "" ), port( s_port ? s_port : "" ), key( s_key ? s_key : "" ), escape_key( 0x1E ),
-      escape_pass_key( '^' ), escape_pass_key2( '^' ), escape_requires_lf( false ), escape_key_help( L"?" ),
-      saved_termios(), raw_termios(), window_size(), local_framebuffer( 1, 1 ), new_state( 1, 1 ), overlays(),
-      network(), display( true ) /* use TERM environment var to initialize display */, connecting_notification(),
+      escape_pass_key( '^' ), escape_pass_key2( '^' ), escape_requires_lf( false ),
+      escape_key_help( MOSH_L( "?" ) ), saved_termios(), raw_termios(), window_size(), local_framebuffer( 1, 1 ),
+      new_state( 1, 1 ), overlays(), network(),
+      display( true ) /* use TERM environment var to initialize display */, connecting_notification(),
       repaint_requested( false ), lf_entered( false ), quit_sequence_started( false ), clean_shutdown( false ),
       verbose( s_verbose )
   {

--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -199,8 +199,6 @@ void NotificationEngine::apply( Framebuffer& fb ) const
   }
 
   /* write message */
-  wchar_t tmp[128];
-
   /* We want to prefer the "last contact" message if we simply haven't
      heard from the server in a while, but print the "last reply" message
      if the problem is uplink-only. */
@@ -225,39 +223,43 @@ void NotificationEngine::apply( Framebuffer& fb ) const
   if ( message.empty() && ( !time_expired ) ) {
     return;
   }
+  /* Built as UTF-8 and widened once at the end: there is no portable
+     swprintf for the code-point string type, and mixing %ls with %s was
+     never pleasant anyway. */
+  char tmp[128];
   if ( message.empty() && time_expired ) {
-    swprintf( tmp,
-              128,
-              L"mosh: Last %s %s ago.%s",
+    snprintf( tmp,
+              sizeof tmp,
+              "mosh: Last %s %s ago.%s",
               explanation,
               human_readable_duration( static_cast<int>( time_elapsed ), "seconds" ).c_str(),
               keystroke_str );
   } else if ( ( !message.empty() ) && ( !time_expired ) ) {
-    swprintf( tmp, 128, L"mosh: %ls%s", message.c_str(), keystroke_str );
+    snprintf( tmp, sizeof tmp, "mosh: %s%s", mosh_narrow( message ).c_str(), keystroke_str );
   } else {
-    swprintf( tmp,
-              128,
-              L"mosh: %ls (%s without %s.)%s",
-              message.c_str(),
+    snprintf( tmp,
+              sizeof tmp,
+              "mosh: %s (%s without %s.)%s",
+              mosh_narrow( message ).c_str(),
               human_readable_duration( static_cast<int>( time_elapsed ), "s" ).c_str(),
               explanation,
               keystroke_str );
   }
 
-  std::wstring string_to_draw( tmp );
+  mosh_wstring string_to_draw( mosh_widen( tmp ) );
 
   int overlay_col = 0;
 
   Cell* combining_cell = fb.get_mutable_cell( 0, 0 );
 
   /* We unfortunately duplicate the terminal's logic for how to render a Unicode sequence into graphemes */
-  for ( std::wstring::const_iterator i = string_to_draw.begin(); i != string_to_draw.end(); i++ ) {
+  for ( mosh_wstring::const_iterator i = string_to_draw.begin(); i != string_to_draw.end(); i++ ) {
     if ( overlay_col >= fb.ds.get_width() ) {
       break;
     }
 
-    wchar_t ch = *i;
-    int chwidth = ch == L'\0' ? -1 : wcwidth( ch );
+    mosh_wchar_t ch = *i;
+    int chwidth = ch == MOSH_L( '\0' ) ? -1 : mosh_wcwidth( ch );
     Cell* this_cell = 0;
 
     switch ( chwidth ) {
@@ -293,7 +295,7 @@ void NotificationEngine::apply( Framebuffer& fb ) const
       case -1: /* unprintable character */
         break;
       default:
-        assert( !"unexpected character width from wcwidth()" );
+        assert( !"unexpected character width from mosh_wcwidth()" );
     }
   }
 }
@@ -335,7 +337,7 @@ void OverlayManager::apply( Framebuffer& fb )
   title.apply( fb );
 }
 
-void TitleEngine::set_prefix( const std::wstring& s )
+void TitleEngine::set_prefix( const mosh_wstring& s )
 {
   prefix = Terminal::Framebuffer::title_type( s.begin(), s.end() );
 }
@@ -645,7 +647,7 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
 
     /*
     fprintf( stderr, "Action: %s (%lc)\n",
-             act->name().c_str(), act->char_present ? act->ch : L'_' );
+             act->name().c_str(), act->char_present ? act->ch : MOSH_L( '_' ) );
     */
 
     const std::type_info& type_act = typeid( act );
@@ -656,7 +658,7 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
 
       assert( act.char_present );
 
-      wchar_t ch = act.ch;
+      mosh_wchar_t ch = act.ch;
       /* XXX handle wide characters */
 
       if ( ch == 0x7f ) { /* backspace */
@@ -709,7 +711,7 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
             }
           }
         }
-      } else if ( ( ch < 0x20 ) || ( wcwidth( ch ) != 1 ) ) {
+      } else if ( ( ch < 0x20 ) || ( mosh_wcwidth( ch ) != 1 ) ) {
         /* unknown print */
         become_tentative();
         //	fprintf( stderr, "Unknown print 0x%x\n", ch );
@@ -806,13 +808,13 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
       //      fprintf( stderr, "Escape sequence\n" );
       become_tentative();
     } else if ( type_act == typeid( Parser::CSI_Dispatch ) ) {
-      if ( act.char_present && ( act.ch == L'C' ) ) { /* right arrow */
+      if ( act.char_present && ( act.ch == MOSH_L( 'C' ) ) ) { /* right arrow */
         init_cursor( fb );
         if ( cursor().col < fb.ds.get_width() - 1 ) {
           cursor().col++;
           cursor().expire( local_frame_sent + 1, now );
         }
-      } else if ( act.char_present && ( act.ch == L'D' ) ) { /* left arrow */
+      } else if ( act.char_present && ( act.ch == MOSH_L( 'D' ) ) ) { /* left arrow */
         init_cursor( fb );
 
         if ( cursor().col > 0 ) {

--- a/src/frontend/terminaloverlay.h
+++ b/src/frontend/terminaloverlay.h
@@ -33,6 +33,8 @@
 #ifndef TERMINAL_OVERLAY_HPP
 #define TERMINAL_OVERLAY_HPP
 
+#include "src/util/unicode.h"
+
 #include "src/network/network.h"
 #include "src/network/transportsender.h"
 #include "src/terminal/parser.h"
@@ -151,7 +153,7 @@ private:
   uint64_t last_word_from_server;
   uint64_t last_acked_state;
   std::string escape_key_string;
-  std::wstring message;
+  mosh_wstring message;
   bool message_is_network_error;
   uint64_t message_expiration;
   bool show_quit_keystroke;
@@ -163,12 +165,12 @@ private:
 public:
   void adjust_message( void );
   void apply( Framebuffer& fb ) const;
-  const std::wstring& get_notification_string( void ) const { return message; }
+  const mosh_wstring& get_notification_string( void ) const { return message; }
   void server_heard( uint64_t s_last_word ) { last_word_from_server = s_last_word; }
   void server_acked( uint64_t s_last_acked ) { last_acked_state = s_last_acked; }
   int wait_time( void ) const;
 
-  void set_notification_string( const std::wstring& s_message,
+  void set_notification_string( const mosh_wstring& s_message,
                                 bool permanent = false,
                                 bool s_show_quit_keystroke = true )
   {
@@ -191,10 +193,7 @@ public:
 
   void set_network_error( const std::string& s )
   {
-    wchar_t tmp[128];
-    swprintf( tmp, 128, L"%s", s.c_str() );
-
-    message = tmp;
+    message = mosh_widen( s );
     message_is_network_error = true;
     message_expiration = timestamp() + Network::ACK_INTERVAL + 100;
   }
@@ -320,7 +319,7 @@ private:
 public:
   void apply( Framebuffer& fb ) const { fb.prefix_window_title( prefix ); }
   TitleEngine() : prefix() {}
-  void set_prefix( const std::wstring& s );
+  void set_prefix( const mosh_wstring& s );
 };
 
 /* the overlay manager */
@@ -337,7 +336,7 @@ public:
   NotificationEngine& get_notification_engine( void ) { return notifications; }
   PredictionEngine& get_prediction_engine( void ) { return predictions; }
 
-  void set_title_prefix( const std::wstring& s ) { title.set_prefix( s ); }
+  void set_title_prefix( const mosh_wstring& s ) { title.set_prefix( s ); }
 
   OverlayManager() : notifications(), predictions(), title() {}
 

--- a/src/terminal/parser.cc
+++ b/src/terminal/parser.cc
@@ -49,7 +49,7 @@ static void append_or_delete( Parser::ActionPointer act, Parser::Actions& vec )
   }
 }
 
-void Parser::Parser::input( wchar_t ch, Actions& ret )
+void Parser::Parser::input( mosh_wchar_t ch, Actions& ret )
 {
   Transition tx = state->input( ch );
 
@@ -77,14 +77,14 @@ void Parser::UTF8Parser::input( char c, Actions& ret )
 
   /* 1-byte UTF-8 character, aka ASCII?  Cheat. */
   if ( buf_len == 0 && static_cast<unsigned char>( c ) <= 0x7f ) {
-    parser.input( static_cast<wchar_t>( c ), ret );
+    parser.input( static_cast<mosh_wchar_t>( c ), ret );
     return;
   }
 
   buf[buf_len++] = c;
 
   /* This function will only work in a UTF-8 locale. */
-  wchar_t pwc;
+  mosh_wchar_t pwc;
   mbstate_t ps = mbstate_t();
 
   size_t total_bytes_parsed = 0;
@@ -96,7 +96,7 @@ void Parser::UTF8Parser::input( char c, Actions& ret )
   while ( total_bytes_parsed != orig_buf_len ) {
     assert( total_bytes_parsed < orig_buf_len );
     assert( buf_len > 0 );
-    size_t bytes_parsed = mbrtowc( &pwc, buf, buf_len, &ps );
+    size_t bytes_parsed = mosh_mbrtowc( &pwc, buf, buf_len, &ps );
 
     /* this returns 0 when n = 0! */
 
@@ -104,7 +104,7 @@ void Parser::UTF8Parser::input( char c, Actions& ret )
       /* character was NUL, accept and clear buffer */
       assert( buf_len == 1 );
       buf_len = 0;
-      pwc = L'\0';
+      pwc = MOSH_L( '\0' );
       bytes_parsed = 1;
     } else if ( bytes_parsed == (size_t)-1 ) {
       /* invalid sequence, use replacement character and try again with last char */
@@ -117,7 +117,7 @@ void Parser::UTF8Parser::input( char c, Actions& ret )
         buf_len = 0;
         bytes_parsed = 1;
       }
-      pwc = (wchar_t)0xFFFD;
+      pwc = (mosh_wchar_t)0xFFFD;
     } else if ( bytes_parsed == (size_t)-2 ) {
       /* can't parse incomplete multibyte character */
       total_bytes_parsed += buf_len;
@@ -130,12 +130,12 @@ void Parser::UTF8Parser::input( char c, Actions& ret )
     }
 
     /* Cast to unsigned for checks, because some
-       platforms (e.g. ARM) use uint32_t as wchar_t,
+       platforms (e.g. ARM) use uint32_t as mosh_wchar_t,
        causing compiler warning on "pwc > 0" check. */
     const uint32_t pwcheck = pwc;
 
     if ( pwcheck > 0x10FFFF ) { /* outside Unicode range */
-      pwc = (wchar_t)0xFFFD;
+      pwc = (mosh_wchar_t)0xFFFD;
     }
 
     if ( ( pwcheck >= 0xD800 ) && ( pwcheck <= 0xDFFF ) ) { /* surrogate code point */
@@ -144,7 +144,7 @@ void Parser::UTF8Parser::input( char c, Actions& ret )
         they are ill-formed UTF-8 and we shouldn't repeat them to the
         user's terminal.
       */
-      pwc = (wchar_t)0xFFFD;
+      pwc = (mosh_wchar_t)0xFFFD;
     }
 
     parser.input( pwc, ret );

--- a/src/terminal/parser.h
+++ b/src/terminal/parser.h
@@ -33,6 +33,8 @@
 #ifndef PARSER_HPP
 #define PARSER_HPP
 
+#include "src/util/unicode.h"
+
 /* Based on Paul Williams's parser,
    http://www.vt100.net/emu/dec_ansi_parser */
 
@@ -59,7 +61,7 @@ public:
   Parser& operator=( const Parser& );
   ~Parser() {}
 
-  void input( wchar_t ch, Actions& actions );
+  void input( mosh_wchar_t ch, Actions& actions );
 
   void reset_input( void ) { state = &family.s_Ground; }
 };

--- a/src/terminal/parseraction.h
+++ b/src/terminal/parseraction.h
@@ -33,6 +33,8 @@
 #ifndef PARSERACTION_HPP
 #define PARSERACTION_HPP
 
+#include "src/util/unicode.h"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -45,7 +47,7 @@ namespace Parser {
 class Action
 {
 public:
-  wchar_t ch;
+  mosh_wchar_t ch;
   bool char_present;
 
   virtual std::string name( void ) = 0;

--- a/src/terminal/parserstate.cc
+++ b/src/terminal/parserstate.cc
@@ -37,7 +37,7 @@
 
 using namespace Parser;
 
-Transition State::anywhere_rule( wchar_t ch ) const
+Transition State::anywhere_rule( mosh_wchar_t ch ) const
 {
   if ( ( ch == 0x18 ) || ( ch == 0x1A ) || ( ( 0x80 <= ch ) && ( ch <= 0x8F ) )
        || ( ( 0x91 <= ch ) && ( ch <= 0x97 ) ) || ( ch == 0x99 ) || ( ch == 0x9A ) ) {
@@ -59,7 +59,7 @@ Transition State::anywhere_rule( wchar_t ch ) const
   return Transition( (State*)NULL, ActionPointer() ); /* don't allocate an Ignore action */
 }
 
-Transition State::input( wchar_t ch ) const
+Transition State::input( mosh_wchar_t ch ) const
 {
   /* Check for immediate transitions. */
   Transition anywhere = anywhere_rule( ch );
@@ -76,18 +76,18 @@ Transition State::input( wchar_t ch ) const
   return ret;
 }
 
-static bool C0_prime( wchar_t ch )
+static bool C0_prime( mosh_wchar_t ch )
 {
   return ( ch <= 0x17 ) || ( ch == 0x19 ) || ( ( 0x1C <= ch ) && ( ch <= 0x1F ) );
 }
 
-static bool GLGR( wchar_t ch )
+static bool GLGR( mosh_wchar_t ch )
 {
   return ( ( 0x20 <= ch ) && ( ch <= 0x7F ) )     /* GL area */
          || ( ( 0xA0 <= ch ) && ( ch <= 0xFF ) ); /* GR area */
 }
 
-Transition Ground::input_state_rule( wchar_t ch ) const
+Transition Ground::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
     return Transition( std::make_shared<Execute>() );
@@ -105,7 +105,7 @@ ActionPointer Escape::enter( void ) const
   return std::make_shared<Clear>();
 }
 
-Transition Escape::input_state_rule( wchar_t ch ) const
+Transition Escape::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
     return Transition( std::make_shared<Execute>() );
@@ -139,7 +139,7 @@ Transition Escape::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Transition Escape_Intermediate::input_state_rule( wchar_t ch ) const
+Transition Escape_Intermediate::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
     return Transition( std::make_shared<Execute>() );
@@ -161,7 +161,7 @@ ActionPointer CSI_Entry::enter( void ) const
   return std::make_shared<Clear>();
 }
 
-Transition CSI_Entry::input_state_rule( wchar_t ch ) const
+Transition CSI_Entry::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
     return Transition( std::make_shared<Execute>() );
@@ -190,7 +190,7 @@ Transition CSI_Entry::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Transition CSI_Param::input_state_rule( wchar_t ch ) const
+Transition CSI_Param::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
     return Transition( std::make_shared<Execute>() );
@@ -215,7 +215,7 @@ Transition CSI_Param::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Transition CSI_Intermediate::input_state_rule( wchar_t ch ) const
+Transition CSI_Intermediate::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
     return Transition( std::make_shared<Execute>() );
@@ -236,7 +236,7 @@ Transition CSI_Intermediate::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Transition CSI_Ignore::input_state_rule( wchar_t ch ) const
+Transition CSI_Ignore::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( C0_prime( ch ) ) {
     return Transition( std::make_shared<Execute>() );
@@ -254,7 +254,7 @@ ActionPointer DCS_Entry::enter( void ) const
   return std::make_shared<Clear>();
 }
 
-Transition DCS_Entry::input_state_rule( wchar_t ch ) const
+Transition DCS_Entry::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( ( 0x20 <= ch ) && ( ch <= 0x2F ) ) {
     return Transition( std::make_shared<Collect>(), &family->s_DCS_Intermediate );
@@ -279,7 +279,7 @@ Transition DCS_Entry::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Transition DCS_Param::input_state_rule( wchar_t ch ) const
+Transition DCS_Param::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( ( ( 0x30 <= ch ) && ( ch <= 0x39 ) ) || ( ch == 0x3B ) ) {
     return Transition( std::make_shared<Param>() );
@@ -300,7 +300,7 @@ Transition DCS_Param::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Transition DCS_Intermediate::input_state_rule( wchar_t ch ) const
+Transition DCS_Intermediate::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( ( 0x20 <= ch ) && ( ch <= 0x2F ) ) {
     return Transition( std::make_shared<Collect>() );
@@ -327,7 +327,7 @@ ActionPointer DCS_Passthrough::exit( void ) const
   return std::make_shared<Unhook>();
 }
 
-Transition DCS_Passthrough::input_state_rule( wchar_t ch ) const
+Transition DCS_Passthrough::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( C0_prime( ch ) || ( ( 0x20 <= ch ) && ( ch <= 0x7E ) ) ) {
     return Transition( std::make_shared<Put>() );
@@ -340,7 +340,7 @@ Transition DCS_Passthrough::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Transition DCS_Ignore::input_state_rule( wchar_t ch ) const
+Transition DCS_Ignore::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( ch == 0x9C ) {
     return Transition( &family->s_Ground );
@@ -359,7 +359,7 @@ ActionPointer OSC_String::exit( void ) const
   return std::make_shared<OSC_End>();
 }
 
-Transition OSC_String::input_state_rule( wchar_t ch ) const
+Transition OSC_String::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( ( 0x20 <= ch ) && ( ch <= 0x7F ) ) {
     return Transition( std::make_shared<OSC_Put>() );
@@ -372,7 +372,7 @@ Transition OSC_String::input_state_rule( wchar_t ch ) const
   return Transition();
 }
 
-Transition SOS_PM_APC_String::input_state_rule( wchar_t ch ) const
+Transition SOS_PM_APC_String::input_state_rule( mosh_wchar_t ch ) const
 {
   if ( ch == 0x9C ) {
     return Transition( &family->s_Ground );

--- a/src/terminal/parserstate.h
+++ b/src/terminal/parserstate.h
@@ -33,6 +33,8 @@
 #ifndef PARSERSTATE_HPP
 #define PARSERSTATE_HPP
 
+#include "src/util/unicode.h"
+
 #include "parsertransition.h"
 
 namespace Parser {
@@ -41,15 +43,15 @@ class StateFamily;
 class State
 {
 protected:
-  virtual Transition input_state_rule( wchar_t ch ) const = 0;
+  virtual Transition input_state_rule( mosh_wchar_t ch ) const = 0;
   StateFamily* family;
 
 private:
-  Transition anywhere_rule( wchar_t ch ) const;
+  Transition anywhere_rule( mosh_wchar_t ch ) const;
 
 public:
   void setfamily( StateFamily* s_family ) { family = s_family; }
-  Transition input( wchar_t ch ) const;
+  Transition input( mosh_wchar_t ch ) const;
   virtual ActionPointer enter( void ) const { return std::make_shared<Ignore>(); }
   virtual ActionPointer exit( void ) const { return std::make_shared<Ignore>(); }
 
@@ -62,71 +64,71 @@ public:
 
 class Ground : public State
 {
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 
 class Escape : public State
 {
   ActionPointer enter( void ) const;
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 
 class Escape_Intermediate : public State
 {
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 
 class CSI_Entry : public State
 {
   ActionPointer enter( void ) const;
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 class CSI_Param : public State
 {
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 class CSI_Intermediate : public State
 {
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 class CSI_Ignore : public State
 {
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 
 class DCS_Entry : public State
 {
   ActionPointer enter( void ) const;
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 class DCS_Param : public State
 {
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 class DCS_Intermediate : public State
 {
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 class DCS_Passthrough : public State
 {
   ActionPointer enter( void ) const;
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
   ActionPointer exit( void ) const;
 };
 class DCS_Ignore : public State
 {
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 
 class OSC_String : public State
 {
   ActionPointer enter( void ) const;
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
   ActionPointer exit( void ) const;
 };
 class SOS_PM_APC_String : public State
 {
-  Transition input_state_rule( wchar_t ch ) const;
+  Transition input_state_rule( mosh_wchar_t ch ) const;
 };
 }
 

--- a/src/terminal/terminal.cc
+++ b/src/terminal/terminal.cc
@@ -59,13 +59,13 @@ void Emulator::print( const Parser::Print* act )
 {
   assert( act->char_present );
 
-  const wchar_t ch = act->ch;
+  const mosh_wchar_t ch = act->ch;
 
   /*
    * Check for printing ISO 8859-1 first, it's a cheap way to detect
    * some common narrow characters.
    */
-  const int chwidth = ch == L'\0' ? -1 : ( Cell::isprint_iso8859_1( ch ) ? 1 : wcwidth( ch ) );
+  const int chwidth = ch == MOSH_L( '\0' ) ? -1 : ( Cell::isprint_iso8859_1( ch ) ? 1 : mosh_wcwidth( ch ) );
 
   Cell* this_cell = fb.get_mutable_cell();
 
@@ -139,7 +139,7 @@ void Emulator::print( const Parser::Print* act )
     case -1: /* unprintable character */
       break;
     default:
-      assert( !"unexpected character width from wcwidth()" );
+      assert( !"unexpected character width from mosh_wcwidth()" );
       break;
   }
 }

--- a/src/terminal/terminaldispatcher.h
+++ b/src/terminal/terminaldispatcher.h
@@ -33,6 +33,8 @@
 #ifndef TERMINALDISPATCHER_HPP
 #define TERMINALDISPATCHER_HPP
 
+#include "src/util/unicode.h"
+
 #include <map>
 #include <string>
 #include <vector>
@@ -95,7 +97,7 @@ private:
   bool parsed;
 
   std::string dispatch_chars;
-  std::vector<wchar_t> OSC_string;
+  std::vector<mosh_wchar_t> OSC_string;
 
   void parse_params( void );
 
@@ -117,7 +119,7 @@ public:
 
   void dispatch( Function_Type type, const Parser::Action* act, Framebuffer* fb );
   std::string get_dispatch_chars( void ) const { return dispatch_chars; }
-  std::vector<wchar_t> get_OSC_string( void ) const { return OSC_string; }
+  std::vector<mosh_wchar_t> get_OSC_string( void ) const { return OSC_string; }
 
   void OSC_put( const Parser::OSC_Put* act );
   void OSC_start( const Parser::OSC_Start* act );

--- a/src/terminal/terminaldisplay.h
+++ b/src/terminal/terminaldisplay.h
@@ -33,6 +33,8 @@
 #ifndef TERMINALDISPLAY_HPP
 #define TERMINALDISPLAY_HPP
 
+#include "src/util/unicode.h"
+
 #include "src/terminal/terminalframebuffer.h"
 
 namespace Terminal {
@@ -53,7 +55,7 @@ public:
 
   void append( char c ) { str.append( 1, c ); }
   void append( size_t s, char c ) { str.append( s, c ); }
-  void append( wchar_t wc ) { Cell::append_to_str( str, wc ); }
+  void append( mosh_wchar_t wc ) { Cell::append_to_str( str, wc ); }
   void append( const char* s ) { str.append( s ); }
   void append_string( const std::string& append ) { str.append( append ); }
 

--- a/src/terminal/terminalframebuffer.h
+++ b/src/terminal/terminalframebuffer.h
@@ -33,6 +33,8 @@
 #ifndef TERMINALFB_HPP
 #define TERMINALFB_HPP
 
+#include "src/util/unicode.h"
+
 #include <cassert>
 #include <climits>
 #include <cstdint>
@@ -174,39 +176,29 @@ public:
   bool compare( const Cell& other ) const;
 
   // Is this a printing ISO 8859-1 character?
-  static bool isprint_iso8859_1( const wchar_t c )
+  static bool isprint_iso8859_1( const mosh_wchar_t c )
   {
     return ( c <= 0xff && c >= 0xa0 ) || ( c <= 0x7e && c >= 0x20 );
   }
 
-  static void append_to_str( std::string& dest, const wchar_t c )
+  static void append_to_str( std::string& dest, const mosh_wchar_t c )
   {
     /* ASCII?  Cheat. */
     if ( static_cast<uint32_t>( c ) <= 0x7f ) {
       dest.push_back( static_cast<char>( c ) );
       return;
     }
-    static mbstate_t ps = mbstate_t();
-    char tmp[MB_LEN_MAX];
-    size_t ignore = wcrtomb( NULL, 0, &ps );
-    (void)ignore;
-    size_t len = wcrtomb( tmp, c, &ps );
-    dest.append( tmp, len );
+    mosh_append_utf8( dest, c );
   }
 
-  void append( const wchar_t c )
+  void append( const mosh_wchar_t c )
   {
     /* ASCII?  Cheat. */
     if ( static_cast<uint32_t>( c ) <= 0x7f ) {
       contents.push_back( static_cast<char>( c ) );
       return;
     }
-    static mbstate_t ps = mbstate_t();
-    char tmp[MB_LEN_MAX];
-    size_t ignore = wcrtomb( NULL, 0, &ps );
-    (void)ignore;
-    size_t len = wcrtomb( tmp, c, &ps );
-    contents.insert( contents.end(), tmp, tmp + len );
+    mosh_append_utf8( contents, c );
   }
 
   void print_grapheme( std::string& output ) const
@@ -408,7 +400,7 @@ class Framebuffer
   // are equal, then the rows are obviously identical.
   // * If no row is shared, the frame has not been modified.
 public:
-  typedef std::vector<wchar_t> title_type;
+  typedef std::vector<mosh_wchar_t> title_type;
   typedef std::shared_ptr<Row> row_pointer;
   typedef std::vector<row_pointer> rows_type; /* can be either std::vector or std::deque */
 

--- a/src/terminal/terminalfunctions.cc
+++ b/src/terminal/terminalfunctions.cc
@@ -590,10 +590,10 @@ static void CSI_DECSTR( Framebuffer* fb, Dispatcher* dispatch __attribute( ( unu
 
 static Function func_CSI_DECSTR( CSI, "!p", CSI_DECSTR );
 
-static bool Parse_OSC_8( const std::vector<wchar_t>& osc8_vector, std::string& osc8_str )
+static bool Parse_OSC_8( const std::vector<mosh_wchar_t>& osc8_vector, std::string& osc8_str )
 {
   osc8_str.reserve( osc8_vector.size() );
-  for ( wchar_t wide_char : osc8_vector ) {
+  for ( mosh_wchar_t wide_char : osc8_vector ) {
     // Valid char range is 32-126, per
     // https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda#encodings
     if ( wide_char < 32 || wide_char > 126 ) {
@@ -627,24 +627,24 @@ static void OSC_8( const std::string& OSC_string, Framebuffer* fb )
 void Dispatcher::OSC_dispatch( const Parser::OSC_End* act __attribute( ( unused ) ), Framebuffer* fb )
 {
   /* handle osc copy clipboard sequence 52;c; */
-  if ( OSC_string.size() >= 5 && OSC_string[0] == L'5' && OSC_string[1] == L'2' && OSC_string[2] == L';'
-       && OSC_string[3] == L'c' && OSC_string[4] == L';' ) {
+  if ( OSC_string.size() >= 5 && OSC_string[0] == MOSH_L( '5' ) && OSC_string[1] == MOSH_L( '2' )
+       && OSC_string[2] == MOSH_L( ';' ) && OSC_string[3] == MOSH_L( 'c' ) && OSC_string[4] == MOSH_L( ';' ) ) {
     Terminal::Framebuffer::title_type clipboard( OSC_string.begin() + 5, OSC_string.end() );
     fb->set_clipboard( clipboard );
     /* handle osc terminal title sequence */
   } else if ( OSC_string.size() >= 1 ) {
     long cmd_num = -1;
     int offset = 0;
-    if ( OSC_string[0] == L';' ) {
+    if ( OSC_string[0] == MOSH_L( ';' ) ) {
       /* OSC of the form "\033];<title>\007" */
       cmd_num = 0; /* treat it as as a zero */
       offset = 1;
-    } else if ( ( OSC_string.size() >= 2 ) && ( OSC_string[1] == L';' ) ) {
+    } else if ( ( OSC_string.size() >= 2 ) && ( OSC_string[1] == MOSH_L( ';' ) ) ) {
       /* OSC of the form "\033]X;<title>\007" where X can be:
        * 0: set icon name and window title
        * 1: set icon name
        * 2: set window title */
-      cmd_num = OSC_string[0] - L'0';
+      cmd_num = OSC_string[0] - MOSH_L( '0' );
       offset = 2;
     }
     if ( cmd_num == 8 ) {

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -39,8 +39,8 @@ displaytests = \
 	unicode-later-combining.test \
 	window-resize.test
 
-check_PROGRAMS = ocb-aes encrypt-decrypt base64 nonce-incr inpty is-utf8-locale
-TESTS = ocb-aes encrypt-decrypt base64 nonce-incr local.test $(displaytests)
+check_PROGRAMS = ocb-aes encrypt-decrypt base64 nonce-incr inpty is-utf8-locale unicode
+TESTS = ocb-aes encrypt-decrypt base64 nonce-incr unicode local.test $(displaytests)
 XFAIL_TESTS = \
 	e2e-failure.test \
 	emulation-attributes-256color8.test
@@ -60,6 +60,10 @@ encrypt_decrypt_LDADD = ../crypto/libmoshcrypto.a ../util/libmoshutil.a $(CRYPTO
 base64_SOURCES = base64.cc base64_vector.cc base64_vector.h genbase64.pl
 base64_CPPFLAGS = $(ocb_aes_CPPFLAGS)
 base64_LDADD = $(ocb_aes_LDADD)
+
+unicode_SOURCES = unicode.cc
+unicode_CPPFLAGS = -I$(srcdir)/../util
+unicode_LDADD = ../util/libmoshutil.a
 
 nonce_incr_SOURCES = nonce-incr.cc
 nonce_incr_CPPFLAGS = -I$(srcdir)/../network -I$(srcdir)/../crypto -I$(srcdir)/../util $(CRYPTO_CFLAGS)

--- a/src/tests/unicode.cc
+++ b/src/tests/unicode.cc
@@ -1,0 +1,209 @@
+/*
+    Mosh: the mobile shell
+    Copyright 2012 Keith Winstein
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    In addition, as a special exception, the copyright holders give
+    permission to link the code of portions of this program with the
+    OpenSSL library under certain conditions as described in each
+    individual source file, and distribute linked combinations including
+    the two.
+
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do
+    so, delete this exception statement from your version. If you delete
+    this exception statement from all source files in the program, then
+    also delete it here.
+*/
+
+/* Exercises the UTF-8 codec and character-width table in src/util/unicode.cc.
+
+   On Windows both are mosh's own code rather than the C library's, and a
+   quiet mistake in either desynchronises the client's framebuffer from the
+   server's.  This runs on POSIX too, where it checks that the wrappers
+   around mbrtowc(3) and wcwidth(3) still behave the way the parser expects. */
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "src/util/fatal_assert.h"
+#include "src/util/locale_utils.h"
+#include "src/util/unicode.h"
+
+namespace {
+
+size_t decode( const std::string& bytes, mosh_wchar_t* out )
+{
+  mbstate_t ps = mbstate_t();
+  errno = 0;
+  return mosh_mbrtowc( out, bytes.data(), bytes.size(), &ps );
+}
+
+void expect_roundtrip( mosh_wchar_t cp, size_t expected_len )
+{
+  std::string encoded;
+  mosh_append_utf8( encoded, cp );
+  fatal_assert( encoded.size() == expected_len );
+
+  mosh_wchar_t decoded = 0;
+  const size_t consumed = decode( encoded, &decoded );
+  fatal_assert( consumed == expected_len );
+  fatal_assert( decoded == cp );
+}
+
+void describe( const char* what, const std::string& bytes, size_t consumed )
+{
+  fprintf( stderr, "%s: <", what );
+  for ( size_t i = 0; i < bytes.size(); i++ ) {
+    fprintf( stderr, "%s%02X", i ? " " : "", static_cast<unsigned char>( bytes[i] ) );
+  }
+  fprintf( stderr, "> returned %zd\n", static_cast<ssize_t>( consumed ) );
+}
+
+void expect_invalid( const std::string& bytes )
+{
+  mosh_wchar_t decoded = 0;
+  const size_t consumed = decode( bytes, &decoded );
+  if ( consumed != static_cast<size_t>( -1 ) || errno != EILSEQ ) {
+    describe( "expected invalid", bytes, consumed );
+    fatal_assert( consumed == static_cast<size_t>( -1 ) );
+    fatal_assert( errno == EILSEQ );
+  }
+}
+
+void expect_incomplete( const std::string& bytes )
+{
+  mosh_wchar_t decoded = 0;
+  const size_t consumed = decode( bytes, &decoded );
+  if ( consumed != static_cast<size_t>( -2 ) ) {
+    describe( "expected incomplete", bytes, consumed );
+    fatal_assert( consumed == static_cast<size_t>( -2 ) );
+  }
+}
+
+void expect_width( mosh_wchar_t cp, int expected )
+{
+  const int got = mosh_wcwidth( cp );
+  if ( got != expected ) {
+    fprintf( stderr, "wcwidth(U+%04X) = %d, expected %d\n", static_cast<unsigned>( cp ), got, expected );
+    fatal_assert( got == expected );
+  }
+}
+
+} /* namespace */
+
+int main( void )
+{
+#ifndef _WIN32
+  /* The POSIX side of unicode.cc delegates to mbrtowc/wcrtomb, which only
+     handle UTF-8 in a UTF-8 locale; mosh itself calls set_native_locale() on
+     startup.  Skip the way the other locale-dependent tests do when the
+     environment cannot provide one.  The Windows implementation does its own
+     conversion and does not consult the locale at all. */
+  set_native_locale();
+  if ( !is_utf8_locale() ) {
+    fprintf( stderr, "unicode: no UTF-8 locale available, skipping\n" );
+    return 77;
+  }
+#endif
+
+  /* ---- encode/decode round trips, one per UTF-8 length ---- */
+  expect_roundtrip( 'A', 1 );      /* ASCII                     */
+  expect_roundtrip( 0x00E9, 2 );   /* e with acute              */
+  expect_roundtrip( 0x0416, 2 );   /* Cyrillic ZHE              */
+  expect_roundtrip( 0x4E16, 3 );   /* CJK                       */
+  expect_roundtrip( 0x1F600, 4 );  /* grinning face             */
+  expect_roundtrip( 0x10FFFF, 4 ); /* last legal code point     */
+
+  /* A NUL is reported as zero bytes consumed, which parser.cc relies on. */
+  {
+    mosh_wchar_t decoded = 0xFFFF;
+    const std::string nul( 1, '\0' );
+    fatal_assert( decode( nul, &decoded ) == 0 );
+    fatal_assert( decoded == 0 );
+  }
+
+  /* ---- multi-character strings ---- */
+  {
+    const std::string mixed = "a\xD0\x96\xE4\xB8\x96\xF0\x9F\x98\x80";
+    const mosh_wstring wide = mosh_widen( mixed );
+    fatal_assert( wide.size() == 4 );
+    fatal_assert( wide[0] == 'a' );
+    fatal_assert( wide[1] == 0x0416 );
+    fatal_assert( wide[2] == 0x4E16 );
+    fatal_assert( wide[3] == 0x1F600 );
+    fatal_assert( mosh_narrow( wide ) == mixed );
+  }
+
+  /* ---- ill-formed input ---- */
+  expect_invalid( "\x80" );             /* stray continuation byte   */
+  expect_invalid( "\xC0\xAF" );         /* overlong '/'              */
+  expect_invalid( "\xE0\x80\xAF" );     /* overlong, three bytes     */
+  expect_invalid( "\xED\xA0\x80" );     /* UTF-16 surrogate D800     */
+  expect_invalid( "\xE4\x28\xB8" );     /* bad continuation byte     */
+  expect_invalid( "\xFE\x80\x80\x80" ); /* never a lead byte         */
+
+  /* ---- out of Unicode range, but still decoded ----
+
+     Client and server parse the same host bytes independently, so the
+     decoder has to accept exactly what the server's does.  glibc still
+     implements the original five- and six-byte UTF-8; the resulting code
+     points get width -1 and the emulator drops them, which is what makes
+     the two sides agree. Rejecting them here would draw U+FFFD on one side
+     and nothing on the other. */
+  {
+    mosh_wchar_t decoded = 0;
+    fatal_assert( decode( "\xF4\x90\x80\x80", &decoded ) == 4 ); /* U+110000 */
+    fatal_assert( decoded == 0x110000 );
+    fatal_assert( mosh_wcwidth( decoded ) == -1 );
+
+    fatal_assert( decode( "\xF7\xBF\xBF\xBF", &decoded ) == 4 ); /* U+1FFFFF */
+    fatal_assert( decoded == 0x1FFFFF );
+    fatal_assert( mosh_wcwidth( decoded ) == -1 );
+
+    fatal_assert( decode( "\xF8\x88\x80\x80\x80", &decoded ) == 5 ); /* U+200000 */
+    fatal_assert( decoded == 0x200000 );
+    fatal_assert( mosh_wcwidth( decoded ) == -1 );
+  }
+
+  /* ---- truncated but so far valid ---- */
+  expect_incomplete( "\xD0" );
+  expect_incomplete( "\xE4\xB8" );
+  expect_incomplete( "\xF0\x9F\x98" );
+  expect_incomplete( "\xF7\xBF" );
+
+  /* ---- widths ---- */
+  expect_width( 'A', 1 );
+  expect_width( 0x00E9, 1 );
+  expect_width( 0x0416, 1 );
+  expect_width( 0x4E16, 2 );  /* CJK ideograph             */
+  expect_width( 0xFF21, 2 );  /* fullwidth Latin A         */
+  expect_width( 0x3042, 2 );  /* hiragana A                */
+  expect_width( 0x0301, 0 );  /* combining acute accent    */
+  expect_width( 0x0483, 0 );  /* combining Cyrillic titlo  */
+  expect_width( 0x200B, 0 );  /* zero width space          */
+  expect_width( 0x11A8, 0 );  /* Hangul jongseong kiyeok   */
+  expect_width( 0x0000, 0 );  /* NUL                       */
+  expect_width( 0x0007, -1 ); /* BEL                       */
+  expect_width( 0x001B, -1 ); /* ESC                       */
+  expect_width( 0x007F, -1 ); /* DEL                       */
+
+  printf( "unicode: all checks passed\n" );
+  return 0;
+}

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -2,4 +2,4 @@ AM_CXXFLAGS = -I$(top_srcdir)/ $(WARNING_CXXFLAGS) $(PICKY_CXXFLAGS) $(HARDEN_CF
 
 noinst_LIBRARIES = libmoshutil.a
 
-libmoshutil_a_SOURCES = locale_utils.cc locale_utils.h swrite.cc swrite.h dos_assert.h fatal_assert.h select.h select.cc timestamp.h timestamp.cc pty_compat.cc pty_compat.h
+libmoshutil_a_SOURCES = locale_utils.cc locale_utils.h swrite.cc swrite.h dos_assert.h fatal_assert.h select.h select.cc timestamp.h timestamp.cc pty_compat.cc pty_compat.h unicode.cc unicode.h

--- a/src/util/unicode.cc
+++ b/src/util/unicode.cc
@@ -1,0 +1,271 @@
+/*
+    Mosh: the mobile shell
+    Copyright 2012 Keith Winstein
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    In addition, as a special exception, the copyright holders give
+    permission to link the code of portions of this program with the
+    OpenSSL library under certain conditions as described in each
+    individual source file, and distribute linked combinations including
+    the two.
+
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do
+    so, delete this exception statement from your version. If you delete
+    this exception statement from all source files in the program, then
+    also delete it here.
+*/
+
+#include "src/util/unicode.h"
+
+#include <cerrno>
+#include <cstdint>
+
+/* ---- shared between platforms ---- */
+
+mosh_wstring mosh_widen( const std::string& s )
+{
+  mosh_wstring ret;
+  mbstate_t ps = mbstate_t();
+
+  size_t i = 0;
+  while ( i < s.size() ) {
+    mosh_wchar_t wc = 0;
+    size_t consumed = mosh_mbrtowc( &wc, s.data() + i, s.size() - i, &ps );
+
+    if ( consumed == static_cast<size_t>( -1 ) || consumed == static_cast<size_t>( -2 ) ) {
+      wc = 0xFFFD;
+      consumed = 1;
+      ps = mbstate_t();
+    } else if ( consumed == 0 ) {
+      consumed = 1; /* embedded NUL */
+    }
+
+    ret.push_back( wc );
+    i += consumed;
+  }
+
+  return ret;
+}
+
+std::string mosh_narrow( const mosh_wstring& s )
+{
+  std::string ret;
+  for ( mosh_wstring::const_iterator it = s.begin(); it != s.end(); ++it ) {
+    mosh_append_utf8( ret, *it );
+  }
+  return ret;
+}
+
+#ifdef _WIN32
+
+/* Character width and general category come from the ICU that ships with
+   Windows itself (icu.dll, present since Windows 10 1703).  Using the OS
+   tables rather than a table compiled into mosh keeps the client agreeing
+   with the glibc wcwidth(3) on the server about how wide a character is --
+   and a disagreement there desynchronises the two framebuffers, which is
+   exactly the class of bug that is miserable to chase down. */
+#include <icu.h>
+
+size_t mosh_mbrtowc( mosh_wchar_t* pwc, const char* s, size_t n, mbstate_t* ps )
+{
+  /* This decoder is stateless: parser.cc always re-presents the whole
+     pending buffer, so there is nothing to carry between calls. */
+  (void)ps;
+
+  if ( n == 0 ) {
+    /* No input: by definition an incomplete character. */
+    return static_cast<size_t>( -2 );
+  }
+
+  const unsigned char* u = reinterpret_cast<const unsigned char*>( s );
+  const unsigned char lead = u[0];
+
+  size_t len;
+  mosh_wchar_t cp;
+
+  /* The acceptance range here deliberately matches glibc rather than the
+     restricted UTF-8 of the current standard.  Client and server each parse
+     the same host byte stream on their own -- hostinput.proto carries raw
+     bytes -- so a byte sequence one side accepts and the other rejects
+     desynchronises the two framebuffers.  glibc still decodes the original
+     five- and six-byte forms; everything it produces above U+10FFFF gets
+     width -1 from wcwidth(3) and is dropped by the emulator, and this
+     implementation reaches the same outcome by the same route. */
+  if ( lead < 0x80 ) {
+    len = 1;
+    cp = lead;
+  } else if ( lead < 0xC2 ) {
+    /* 0x80-0xBF is a stray continuation byte; 0xC0 and 0xC1 could only ever
+       introduce an overlong encoding of ASCII. */
+    errno = EILSEQ;
+    return static_cast<size_t>( -1 );
+  } else if ( lead < 0xE0 ) {
+    len = 2;
+    cp = lead & 0x1F;
+  } else if ( lead < 0xF0 ) {
+    len = 3;
+    cp = lead & 0x0F;
+  } else if ( lead < 0xF8 ) {
+    len = 4;
+    cp = lead & 0x07;
+  } else if ( lead < 0xFC ) {
+    len = 5;
+    cp = lead & 0x03;
+  } else if ( lead < 0xFE ) {
+    len = 6;
+    cp = lead & 0x01;
+  } else {
+    /* 0xFE and 0xFF are not lead bytes in any form of UTF-8. */
+    errno = EILSEQ;
+    return static_cast<size_t>( -1 );
+  }
+
+  /* Check the continuation bytes that are present before reporting a
+     truncated character, so an invalid sequence is never mistaken for one
+     that is merely incomplete. */
+  const size_t avail = ( n < len ) ? n : len;
+  for ( size_t i = 1; i < avail; i++ ) {
+    if ( ( u[i] & 0xC0 ) != 0x80 ) {
+      errno = EILSEQ;
+      return static_cast<size_t>( -1 );
+    }
+    cp = ( cp << 6 ) | ( u[i] & 0x3F );
+  }
+
+  if ( n < len ) {
+    return static_cast<size_t>( -2 );
+  }
+
+  /* Overlong forms and UTF-16 surrogates are rejected; values above
+     U+10FFFF are not, because glibc accepts them and the emulator discards
+     them later on width. */
+  static const mosh_wchar_t min_for_len[7] = { 0, 0, 0x80, 0x800, 0x10000, 0x200000, 0x4000000 };
+  if ( cp < min_for_len[len] || ( cp >= 0xD800 && cp <= 0xDFFF ) ) {
+    errno = EILSEQ;
+    return static_cast<size_t>( -1 );
+  }
+
+  if ( pwc ) {
+    *pwc = cp;
+  }
+
+  /* mbrtowc(3) reports a NUL character as zero bytes consumed, and
+     parser.cc depends on that. */
+  return ( cp == 0 ) ? 0 : len;
+}
+
+void mosh_append_utf8( std::string& dest, mosh_wchar_t c )
+{
+  if ( c > 0x10FFFF || ( c >= 0xD800 && c <= 0xDFFF ) ) {
+    return; /* not representable; drop it rather than emit invalid UTF-8 */
+  }
+
+  if ( c < 0x80 ) {
+    dest.push_back( static_cast<char>( c ) );
+  } else if ( c < 0x800 ) {
+    dest.push_back( static_cast<char>( 0xC0 | ( c >> 6 ) ) );
+    dest.push_back( static_cast<char>( 0x80 | ( c & 0x3F ) ) );
+  } else if ( c < 0x10000 ) {
+    dest.push_back( static_cast<char>( 0xE0 | ( c >> 12 ) ) );
+    dest.push_back( static_cast<char>( 0x80 | ( ( c >> 6 ) & 0x3F ) ) );
+    dest.push_back( static_cast<char>( 0x80 | ( c & 0x3F ) ) );
+  } else {
+    dest.push_back( static_cast<char>( 0xF0 | ( c >> 18 ) ) );
+    dest.push_back( static_cast<char>( 0x80 | ( ( c >> 12 ) & 0x3F ) ) );
+    dest.push_back( static_cast<char>( 0x80 | ( ( c >> 6 ) & 0x3F ) ) );
+    dest.push_back( static_cast<char>( 0x80 | ( c & 0x3F ) ) );
+  }
+}
+
+int mosh_wcwidth( mosh_wchar_t wc )
+{
+  const UChar32 c = static_cast<UChar32>( wc );
+
+  /* wcwidth(3) reports NUL as zero-width and every other control character
+     as -1. */
+  if ( c == 0 ) {
+    return 0;
+  }
+  if ( c < 0x20 || ( c >= 0x7F && c < 0xA0 ) ) {
+    return -1;
+  }
+  if ( c > 0x10FFFF || ( c >= 0xD800 && c <= 0xDFFF ) ) {
+    return -1;
+  }
+
+  /* Hangul Jamo medial vowels and final consonants compose onto the
+     preceding syllable.  ICU classifies them as ordinary letters of neutral
+     width, so they need calling out explicitly, as they do in glibc. */
+  if ( c >= 0x1160 && c <= 0x11FF ) {
+    return 0;
+  }
+  if ( c == 0x200B ) { /* ZERO WIDTH SPACE */
+    return 0;
+  }
+
+  switch ( u_charType( c ) ) {
+    case U_NON_SPACING_MARK:
+    case U_ENCLOSING_MARK:
+      return 0;
+    case U_FORMAT_CHAR:
+      /* SOFT HYPHEN is the one format character that occupies a column. */
+      return ( c == 0x00AD ) ? 1 : 0;
+    default:
+      break;
+  }
+
+  const int32_t eaw = u_getIntPropertyValue( c, UCHAR_EAST_ASIAN_WIDTH );
+  if ( eaw == U_EA_WIDE || eaw == U_EA_FULLWIDTH ) {
+    return 2;
+  }
+
+  return 1;
+}
+
+#else /* !_WIN32 */
+
+size_t mosh_mbrtowc( mosh_wchar_t* pwc, const char* s, size_t n, mbstate_t* ps )
+{
+  return mbrtowc( pwc, s, n, ps );
+}
+
+void mosh_append_utf8( std::string& dest, mosh_wchar_t c )
+{
+  /* ASCII?  Cheat. */
+  if ( static_cast<uint32_t>( c ) <= 0x7f ) {
+    dest.push_back( static_cast<char>( c ) );
+    return;
+  }
+
+  mbstate_t ps = mbstate_t();
+  char tmp[MOSH_MB_LEN_MAX];
+  size_t ignore = wcrtomb( NULL, 0, &ps );
+  (void)ignore;
+  size_t len = wcrtomb( tmp, c, &ps );
+  if ( len == static_cast<size_t>( -1 ) ) {
+    return;
+  }
+  dest.append( tmp, len );
+}
+
+int mosh_wcwidth( mosh_wchar_t wc )
+{
+  return wcwidth( wc );
+}
+
+#endif /* _WIN32 */

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -1,0 +1,98 @@
+/*
+    Mosh: the mobile shell
+    Copyright 2012 Keith Winstein
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    In addition, as a special exception, the copyright holders give
+    permission to link the code of portions of this program with the
+    OpenSSL library under certain conditions as described in each
+    individual source file, and distribute linked combinations including
+    the two.
+
+    You must obey the GNU General Public License in all respects for all
+    of the code used other than OpenSSL. If you modify file(s) with this
+    exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do
+    so, delete this exception statement from your version. If you delete
+    this exception statement from all source files in the program, then
+    also delete it here.
+*/
+
+#ifndef MOSH_UNICODE_HPP
+#define MOSH_UNICODE_HPP
+
+#include <cstddef>
+#include <cwchar>
+#include <string>
+
+/* Mosh passes a single Unicode code point around between the UTF-8 parser,
+   the terminal emulator and the display.  On POSIX that code point rides in a
+   wchar_t, which is 32 bits wide there.
+
+   On Windows wchar_t is 16 bits (UTF-16), so it cannot hold anything above
+   U+FFFF.  MSVC's mbrtowc() reports EILSEQ rather than producing a surrogate,
+   which would turn every astral character -- emoji above all -- into U+FFFD.
+   So on Windows the code point type is char32_t instead, and this header
+   supplies the conversions that go with it.
+
+   The three functions below have the same signature on both platforms, so
+   the terminal code that calls them needs no conditional compilation.  POSIX
+   builds keep the historical wchar_t path byte for byte. */
+
+#ifdef _WIN32
+
+using mosh_wchar_t = char32_t;
+using mosh_wstring = std::u32string;
+#define MOSH_L( x ) U##x
+#define MOSH_MB_LEN_MAX 4
+
+#else /* !_WIN32 */
+
+#include <climits>
+
+using mosh_wchar_t = wchar_t;
+using mosh_wstring = std::wstring;
+#define MOSH_L( x ) L##x
+#define MOSH_MB_LEN_MAX MB_LEN_MAX
+
+#endif /* _WIN32 */
+
+/* UTF-8 -> one code point.  Same contract as mbrtowc(3), including the
+   0 (NUL), (size_t)-1 (invalid sequence, errno=EILSEQ) and (size_t)-2
+   (incomplete) returns that src/terminal/parser.cc relies on to implement
+   Unicode 6.0 section 3.9, "Best Practices for using U+FFFD".
+
+   The conversion state is carried for the sake of the POSIX implementation;
+   the Windows one is stateless and ignores it. */
+size_t mosh_mbrtowc( mosh_wchar_t* pwc, const char* s, size_t n, mbstate_t* ps );
+
+/* Appends one code point to a string as UTF-8. */
+void mosh_append_utf8( std::string& dest, mosh_wchar_t c );
+
+/* Convert between UTF-8 bytes and the code-point string type.  Invalid input
+   is replaced with U+FFFD rather than rejected: these are used for status
+   messages, where losing a character beats losing the message. */
+mosh_wstring mosh_widen( const std::string& s );
+std::string mosh_narrow( const mosh_wstring& s );
+
+/* Number of terminal columns occupied by a code point: 0 for combining marks
+   and other zero-width characters, 1 for ordinary ones, 2 for East Asian Wide
+   and Fullwidth, and -1 for control characters.
+
+   On POSIX this is the system wcwidth(3).  On Windows the CRT has no such
+   function at all, so unicode.cc asks the ICU that ships with the OS. */
+int mosh_wcwidth( mosh_wchar_t wc );
+
+#endif


### PR DESCRIPTION
Mosh moves a single code point between the UTF-8 parser, the emulator
and the display in a wchar_t. That works wherever wchar_t is 32 bits
wide, which is everywhere mosh currently builds, but it is not portable:
on Windows wchar_t is 16 bits and cannot hold anything above U+FFFF, so
the type has to become char32_t there.

This introduces mosh_wchar_t, mosh_wstring and MOSH_L() in
src/util/unicode.h, and switches src/terminal and src/frontend over. On
POSIX all three resolve to exactly what the code says today, so the
generated code does not change; the only reason to land it separately is
that it is a wide mechanical diff and reviewing it alongside actual
Windows support would be unpleasant.

Two things come along that stand on their own:

  - Cell::append() and Cell::append_to_str() each carried an identical
    copy of the same wcrtomb() dance. Both now call mosh_append_utf8().

  - src/tests/unicode covers the UTF-8 round trip, ill-formed and
    truncated input, and the width of combining, wide and control
    characters. There was no test for any of that before. It skips, in
    the manner of the other locale-dependent tests, when the environment
    offers no UTF-8 locale.

The Windows halves of unicode.h and unicode.cc are included here rather
than held back, so the reason for the abstraction is visible in the same
patch that introduces it. They compile to nothing anywhere else.


---

This is groundwork for a native Windows build of mosh-client, which needs
char32_t where wchar_t is 16 bits wide. The remaining pieces are separate
branches and are not proposed here; this one stands on its own as a rename
plus a test, and changes nothing on POSIX.
