### PR TITLE
Predict wide characters in the local echo overlay

### DIFF
--- a/src/frontend/terminaloverlay.cc
+++ b/src/frontend/terminaloverlay.cc
@@ -618,6 +618,17 @@ ConditionalOverlayRow& PredictionEngine::get_or_make_row( int row_num, int num_c
   return overlays.back();
 }
 
+/* Whether the cell is occupied by a wide character, preferring an
+   active prediction over the framebuffer contents. */
+bool PredictionEngine::is_wide_cell( const Framebuffer& fb, int row, int col )
+{
+  const ConditionalOverlayCell& prediction = get_or_make_row( row, fb.ds.get_width() ).overlay_cells[col];
+  if ( prediction.active && !prediction.unknown ) {
+    return prediction.replacement.get_wide();
+  }
+  return fb.get_cell( row, col )->get_wide();
+}
+
 void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
 {
   if ( display_preference == Never ) {
@@ -657,13 +668,21 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
       assert( act.char_present );
 
       wchar_t ch = act.ch;
-      /* XXX handle wide characters */
+      /* must match the character width computed by Emulator::print() */
+      const int chwidth = ch == L'\0' ? -1 : ( Cell::isprint_iso8859_1( ch ) ? 1 : wcwidth( ch ) );
 
       if ( ch == 0x7f ) { /* backspace */
         //	fprintf( stderr, "Backspace.\n" );
         ConditionalOverlayRow& the_row = get_or_make_row( cursor().row, fb.ds.get_width() );
 
-        if ( cursor().col > 0 ) {
+        /* a backspace over a wide character erases two columns */
+        int erase_width = 1;
+        if ( ( cursor().col >= 2 ) && is_wide_cell( fb, cursor().row, cursor().col - 2 ) ) {
+          erase_width = 2;
+        }
+
+        while ( ( erase_width > 0 ) && ( cursor().col > 0 ) ) {
+          erase_width--;
           cursor().col--;
           cursor().expire( local_frame_sent + 1, now );
 
@@ -709,10 +728,13 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
             }
           }
         }
-      } else if ( ( ch < 0x20 ) || ( wcwidth( ch ) != 1 ) ) {
+      } else if ( ( ch < 0x20 ) || ( chwidth < 1 ) || ( chwidth > 2 ) ) {
         /* unknown print */
         become_tentative();
         //	fprintf( stderr, "Unknown print 0x%x\n", ch );
+      } else if ( ( chwidth == 2 ) && ( cursor().col + 2 >= fb.ds.get_width() ) ) {
+        /* terminals disagree on how a wide character wraps at the right edge */
+        become_tentative();
       } else {
         assert( cursor().row >= 0 );
         assert( cursor().col >= 0 );
@@ -727,9 +749,9 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
           become_tentative();
         }
 
-        /* do the insert */
+        /* do the insert; a wide character shifts the tail of the row by two columns */
         int rightmost_column = predict_overwrite ? cursor().col : fb.ds.get_width() - 1;
-        for ( int i = rightmost_column; i > cursor().col; i-- ) {
+        for ( int i = rightmost_column; i >= cursor().col + chwidth; i-- ) {
           ConditionalOverlayCell& cell = the_row.overlay_cells[i];
           cell.reset_with_orig();
           cell.active = true;
@@ -737,10 +759,10 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
           cell.expire( local_frame_sent + 1, now );
           cell.original_contents.push_back( *fb.get_cell( cursor().row, i ) );
 
-          ConditionalOverlayCell& prev_cell = the_row.overlay_cells[i - 1];
-          const Cell* prev_cell_actual = fb.get_cell( cursor().row, i - 1 );
+          ConditionalOverlayCell& prev_cell = the_row.overlay_cells[i - chwidth];
+          const Cell* prev_cell_actual = fb.get_cell( cursor().row, i - chwidth );
 
-          if ( i == fb.ds.get_width() - 1 ) {
+          if ( i >= fb.ds.get_width() - chwidth ) {
             cell.unknown = true;
           } else if ( prev_cell.active ) {
             if ( prev_cell.unknown ) {
@@ -775,7 +797,21 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
 
         cell.replacement.clear();
         cell.replacement.append( ch );
+        cell.replacement.set_wide( chwidth == 2 );
         cell.original_contents.push_back( *fb.get_cell( cursor().row, cursor().col ) );
+
+        if ( chwidth == 2 ) {
+          /* predict the overlapped cell blank, the way the emulator will draw it */
+          ConditionalOverlayCell& overlapped_cell = the_row.overlay_cells[cursor().col + 1];
+          overlapped_cell.reset_with_orig();
+          overlapped_cell.active = true;
+          overlapped_cell.tentative_until_epoch = prediction_epoch;
+          overlapped_cell.expire( local_frame_sent + 1, now );
+          overlapped_cell.original_contents.push_back( *fb.get_cell( cursor().row, cursor().col + 1 ) );
+          overlapped_cell.replacement.get_renditions() = cell.replacement.get_renditions();
+          overlapped_cell.replacement.clear();
+          overlapped_cell.replacement.set_wide( false );
+        }
 
         /*
         fprintf( stderr, "[%d=>%d] Predicting %lc in row %d, col %d [tue: %lu]\n",
@@ -787,8 +823,8 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
         cursor().expire( local_frame_sent + 1, now );
 
         /* do we need to wrap? */
-        if ( cursor().col < fb.ds.get_width() - 1 ) {
-          cursor().col++;
+        if ( cursor().col + chwidth < fb.ds.get_width() ) {
+          cursor().col += chwidth;
         } else {
           become_tentative();
           newline_carriage_return( fb );
@@ -808,15 +844,20 @@ void PredictionEngine::new_user_byte( char the_byte, const Framebuffer& fb )
     } else if ( type_act == typeid( Parser::CSI_Dispatch ) ) {
       if ( act.char_present && ( act.ch == L'C' ) ) { /* right arrow */
         init_cursor( fb );
-        if ( cursor().col < fb.ds.get_width() - 1 ) {
-          cursor().col++;
+        int step = is_wide_cell( fb, cursor().row, cursor().col ) ? 2 : 1;
+        if ( cursor().col + step < fb.ds.get_width() ) {
+          cursor().col += step;
           cursor().expire( local_frame_sent + 1, now );
         }
       } else if ( act.char_present && ( act.ch == L'D' ) ) { /* left arrow */
         init_cursor( fb );
 
-        if ( cursor().col > 0 ) {
-          cursor().col--;
+        int step = 1;
+        if ( ( cursor().col >= 2 ) && is_wide_cell( fb, cursor().row, cursor().col - 2 ) ) {
+          step = 2;
+        }
+        if ( cursor().col >= step ) {
+          cursor().col -= step;
           cursor().expire( local_frame_sent + 1, now );
         }
       } else {

--- a/src/frontend/terminaloverlay.h
+++ b/src/frontend/terminaloverlay.h
@@ -239,6 +239,8 @@ private:
 
   ConditionalOverlayRow& get_or_make_row( int row_num, int num_cols );
 
+  bool is_wide_cell( const Framebuffer& fb, int row, int col );
+
   uint64_t prediction_epoch;
   uint64_t confirmed_epoch;
 

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -29,6 +29,7 @@ displaytests = \
 	emulation-wrap-across-frames.test \
 	network-no-diff.test \
 	prediction-unicode.test \
+	prediction-wide.test \
 	pty-deadlock.test \
 	repeat.test \
 	repeat-with-input.test \

--- a/src/tests/prediction-wide.test
+++ b/src/tests/prediction-wide.test
@@ -1,0 +1,106 @@
+#!/bin/sh
+
+#
+# This tests predictive local echo of wide (two-column) characters,
+# e.g. CJK.  The server is stopped with SIGSTOP while a mixed
+# ASCII/CJK string is typed, so anything that appears on the client
+# screen during that window can only have come from the prediction
+# engine.  The narrow characters serve as a control: they have always
+# been predicted, so if they are missing, the harness (rather than
+# wide-character prediction) is broken.  After the server is resumed,
+# the final capture must contain the full line, confirming that the
+# predictions were validated rather than repaired.
+#
+# A priming string is typed and echoed before the server is stopped:
+# predictions stay tentative, and are not displayed, until one of them
+# has been confirmed by the server.  The priming string must not end
+# with a carriage return, which starts a new tentative epoch.
+#
+
+# shellcheck source=e2e-test-subrs
+. "$(dirname "$0")/e2e-test-subrs"
+PATH=$PATH:.:$srcdir
+# Top-level wrapper.
+if [ $# -eq 0 ]; then
+    if ! command -v pkill > /dev/null 2>&1; then
+	skip "pkill unavailable\n"
+    fi
+    e2e-test "$0" tmux baseline mosh-args post
+    exit
+fi
+
+tmux_commands()
+{
+    capture_dir="$PWD/$(basename "$0").d"
+    # Let mosh and the baseline action start up.
+    sleep 2
+    # Prime the prediction engine out of its tentative state.
+    printf "send-keys 'prime'\n"
+    sleep 1
+    pkill -STOP -f "frontend/mosh-server[ ]new"
+    sleepf
+    printf "send-keys 'AB一汉字宽字符CD'\n"
+    for x in $(seq 1 5); do
+	sleepf
+    done
+    printf "capture-pane\n"
+    printf "save-buffer '%s/stopped.capture'\n" "$capture_dir"
+    sleepf
+    pkill -CONT -f "frontend/mosh-server[ ]new"
+    sleep 1
+    printf "send-keys 0x0d\n"
+    sleep 1
+    printf "send-keys 0x04\n"
+    # Unreliable on Cygwin under load, it seems.
+    sleep 1
+    printf "send-keys 0x04\n"
+    # This will get killed by SIGPIPE.
+    while printf "show-options\n" && sleep 1; do
+	:
+    done
+}
+
+tmux_stdin()
+{
+    tmux_commands | "$@"
+    exit
+}
+
+baseline()
+{
+    # Just receive and toss input in canonical mode.
+    cat > /dev/null
+}
+
+post()
+{
+    dir="$(basename "$0").d"
+    if ! grep -q "AB" "$dir/stopped.capture"; then
+	# Narrow characters were not predicted either; the test setup
+	# is broken, so no conclusion about wide characters.
+	fail "no predictions at all in stopped-server capture\n"
+    fi
+    if ! grep -q "一汉字宽字符" "$dir/stopped.capture"; then
+	printf "wide characters were not predicted\n" >&2
+	return 1
+    fi
+    if ! grep -q "AB一汉字宽字符CD" "$dir/baseline.capture"; then
+	printf "typed line corrupted after server resumed\n" >&2
+	return 1
+    fi
+    return 0
+}
+
+case $1 in
+    tmux)
+	shift;
+	tmux_stdin "$@";;
+    baseline)
+	baseline;;
+    mosh-args)
+	printf "%s\n" "--predict=always";;
+    post)
+	post;;
+    *)
+	fail "unknown test argument %s\n" "$1";;
+esac


### PR DESCRIPTION
Mosh's predictive local echo covers only single-width characters: `PredictionEngine::new_user_byte()` gives up on anything with `wcwidth != 1` (the old `/* XXX handle wide characters */`). On a high-latency link, ASCII is echoed locally but every CJK character waits a full round trip for its echo. For users who type in Chinese, Japanese or Korean, this makes prediction — arguably mosh's best feature — inoperative for most of what they type.

### What this does

Width-2 characters are now predicted exactly the way `Emulator::print()` will render them:

* the cell under the cursor receives the character with its wide flag set;
* the overlapped neighbor cell is predicted blank, mirroring the emulator's erase of that cell;
* the cursor advances two columns, and the insert shift moves the tail of the row by two columns.

Backspace and left/right arrows now move by the width of the character they cross (an active prediction is consulted first, then the framebuffer).

### Why it is safe

* The prediction has to agree with the emulator exactly, so the width computation is copied verbatim from `Emulator::print()`.
* The overlapped-cell prediction is blank, and `ConditionalOverlayCell::get_validity()` never judges a blank replacement incorrect — that cell can lose credit, but cannot trigger a false invalidation.
* Wide characters within two columns of the right edge are not predicted: the emulator wraps a 2-cell character at column `width - 1` early, and downstream terminals disagree about that case, so those keystrokes just become tentative, as all wide characters did before.
* Combining characters (width 0) and other unprintables are unchanged: still `become_tentative()`.

### Test

`src/tests/prediction-wide.test` stops mosh-server with SIGSTOP while a mixed ASCII/CJK string is typed under `--predict=always`, so anything that reaches the client screen during that window can only have come from the prediction engine. The ASCII characters act as a control for the harness itself (they have always been predicted); the wide characters are the subject. A priming string is typed before the server is stopped, because predictions are not displayed until one of them has been confirmed — and it must not end in a carriage return, which starts a new tentative epoch.

Verified in both directions: the test fails on master (`wide characters were not predicted`) and passes with this change. The full `make check` passes (31 PASS, 2 XFAIL) on Linux/x86-64.

### Measurements

Typing into a fish shell over a ~190 ms RTT link (client on this branch, stock mosh 1.4.0 server), measuring from writing the bytes to the pty until the glyph appears in the terminal output, 12 keystrokes per run:

| | before | after |
| --- | --- | --- |
| CJK character | min 229 / median 269 / max 288 ms | min 0 / **median 0** / max 228 ms |
| ASCII (control) | median 0 ms | median 0 ms |

(The max in the "after" column is the first keystroke after a carriage return, which is tentative by design.)

Final screens were also compared against plain ssh after mixed CJK/ASCII editing — typing, backspacing over wide characters, arrow-key movement with insertion — and after force-wrapping a 64-CJK-character line in an 80-column window: identical in both cases.

### Not covered

Prediction of combining characters is unchanged, and input arriving in reads larger than 100 bytes is still treated as a paste and not predicted, as before.
