### PR TITLE
macosx: add relocatable private runtime packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,9 @@ jobs:
 
     - name: "test"
       run: make V=1 check
+
+    - name: "test macOS runtime packaging"
+      if: ${{ startsWith(matrix.os, 'macos') }}
+      run: |
+        python3 macosx/test-bundle-runtime.py
+        python3 macosx/bundle-runtime.py . "$RUNNER_TEMP/mosh-runtime"

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,8 @@ include $(top_srcdir)/aminclude_static.am
 
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = scripts src man conf
-EXTRA_DIST = autogen.sh ocb-license.html README.md COPYING.iOS
+EXTRA_DIST = autogen.sh ocb-license.html README.md COPYING.iOS \
+	macosx/bundle-runtime.py macosx/test-bundle-runtime.py macosx/README-bundle.md
 BUILT_SOURCES = VERSION.stamp
 AM_DISTCHECK_CONFIGURE_FLAGS += --enable-compile-warnings=distcheck --enable-examples --enable-syslog
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Getting Mosh
   packages for many operating systems, as well as instructions for building
   from source.
 
+  Native macOS source builds can optionally use a
+  [private runtime bundle](macosx/README-bundle.md) to keep their Homebrew
+  library dependencies available across Homebrew upgrades.
+
   Note that `mosh-client` receives an AES session key as an environment
   variable.  If you are porting Mosh to a new operating system, please make
   sure that a running process's environment variables are not readable by other

--- a/macosx/README-bundle.md
+++ b/macosx/README-bundle.md
@@ -1,0 +1,73 @@
+# Private runtime bundle for native macOS builds
+
+A Mosh binary compiled against Homebrew libraries can stop launching after
+`brew upgrade` replaces a versioned Protobuf or Abseil dylib. Unlinking the
+Homebrew Mosh formula does not solve that dependency failure.
+
+`bundle-runtime.py` packages an already compiled native Mosh build with private
+copies of its Homebrew dylibs. It rewrites the dependency graph to use paths
+relative to each binary, removes absolute Homebrew runtime search paths, and
+ad-hoc signs and verifies the modified Mach-O files. System libraries remain
+system dependencies. The generated Perl launcher selects its sibling
+`mosh-client`, including when invoked through a symlink, rather than relying
+on PATH to select a compatible client.
+
+The helper is an optional native-build path. It does not replace `build.sh`,
+produce a universal installer, notarize a release, or change the Mosh protocol.
+Python 3.9 or newer and Xcode command line tools are required for packaging;
+the resulting runtime uses macOS's Perl and does not require Python.
+
+## Build and package
+
+In a source checkout, install the normal build prerequisites documented in
+the main README. Then build with the installed Protobuf compiler and libraries:
+
+```sh
+./autogen.sh
+./configure CXXFLAGS='-O2 -std=c++17'
+make -j4
+make check
+python3 macosx/bundle-runtime.py . /absolute/path/to/new-mosh-bundle
+```
+
+For an existing configured build, clean old object files and regenerate
+Protobuf sources before rebuilding against a new Protobuf version. The
+destination must not exist; the helper will not overwrite an installation.
+A failed packaging operation can leave a partial destination for inspection.
+Use a new destination for a retry.
+
+Homebrew's prefix is discovered with `brew --prefix`, or can be supplied with
+`--brew-prefix`. Dependencies outside that prefix and Apple's system libraries
+are rejected rather than silently omitted. Ambiguous or unsupported runtime
+search paths are also rejected for manual review.
+
+Dependency license files are copied from the Homebrew formula directories.
+When a dependency supplies a terminfo database, it is included and the launcher
+adds it to `TERMINFO_DIRS`. The bundle records the original relative library
+paths in `manifest.json` for maintenance.
+
+Run `bin/mosh --version` and test a connection using the bundle's `bin/mosh`
+before installing it. Keep the complete bundle together when relocating it.
+Point a `mosh` symlink in your PATH at `bin/mosh`; optional `mosh-client` and
+`mosh-server` symlinks can point at their corresponding binaries. Check
+`command -v mosh` to ensure another installation is not shadowing it.
+
+If you are replacing a Homebrew Mosh installation, uninstall that formula
+only after validating the custom installation. Reconnect existing sessions to
+use the new client. Private libraries are intentionally insulated from
+Homebrew upgrades, so rebuild the bundle to receive dependency security fixes.
+This helper does not change any Homebrew package or shell configuration.
+
+## Packaging tests
+
+```sh
+python3 macosx/test-bundle-runtime.py
+```
+
+The tests compile small native libraries and an executable, package a
+transitive `@rpath` dependency graph, move the bundle to a path containing
+spaces, hide the original library prefix, and run the launcher through a
+symlink with a competing client on PATH. They also check signed binaries,
+license preservation, existing-destination protection, and rejection of
+external or ambiguous dependencies. These tests do not replace Mosh's own
+connection and terminal tests.

--- a/macosx/bundle-runtime.py
+++ b/macosx/bundle-runtime.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Bundle a native macOS Mosh build with private Homebrew runtime libraries."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+
+SYSTEM_PATHS = ("/usr/lib/", "/System/Library/")
+
+
+def run(*args):
+    return subprocess.check_output(args, text=True, stderr=subprocess.PIPE).strip()
+
+
+def dependencies(path):
+    return [line.strip().split(" (compatibility version", 1)[0]
+            for line in run("otool", "-L", str(path)).splitlines()[1:]]
+
+
+def rpaths(path):
+    return re.findall(r"cmd LC_RPATH\n\s+cmdsize \d+\n\s+path (.+?) \(offset",
+                      run("otool", "-l", str(path)))
+
+
+def resolve_dependency(dep, original, brew_prefix):
+    if dep.startswith("@rpath/"):
+        candidates = []
+        for entry in rpaths(original):
+            entry = entry.replace("@loader_path", str(original.parent))
+            if not entry.startswith("/"):
+                continue
+            candidate = Path(entry) / dep[len("@rpath/"):]
+            if candidate.is_file():
+                candidates.append(candidate.resolve())
+        if len(set(candidates)) != 1:
+            raise RuntimeError(f"Cannot unambiguously resolve {dep} in {original}")
+        resolved = candidates[0]
+    elif dep.startswith("@loader_path/"):
+        resolved = (original.parent / dep[len("@loader_path/"):]).resolve(strict=True)
+    elif dep.startswith("/"):
+        resolved = Path(dep).resolve(strict=True)
+    else:
+        raise RuntimeError(f"Unsupported dependency {dep} in {original}")
+    if brew_prefix not in resolved.parents:
+        raise RuntimeError(f"Non-Homebrew dependency requires review: {resolved}")
+    return resolved
+
+
+def package(source, destination, brew_prefix):
+    """Create a new bundle; never overwrite an existing installation."""
+    destination.mkdir(parents=True, exist_ok=False)
+    for directory in ("bin", "lib", "licenses"):
+        (destination / directory).mkdir()
+    queue = []
+    libraries = {}
+    formulas = set()
+    for name in ("mosh-client", "mosh-server"):
+        original = source / "src/frontend" / name
+        target = destination / "bin" / name
+        shutil.copy2(original, target)
+        queue.append((original, target))
+    launcher = (source / "scripts/mosh").read_text()
+    old = "my $client = 'mosh-client';"
+    if launcher.count(old) != 1:
+        raise RuntimeError("Unexpected launcher: cannot select the bundled client")
+    launcher = launcher.replace("#!/usr/bin/env perl", "#!/usr/bin/perl", 1)
+    launcher = launcher.replace(old, '''use FindBin qw($RealBin);
+my $client = "$RealBin/mosh-client";
+if (-d "$RealBin/../share/terminfo") {
+  $ENV{'TERMINFO_DIRS'} = "$RealBin/../share/terminfo:" . ($ENV{'TERMINFO_DIRS'} // '');
+}''')
+    (destination / "bin/mosh").write_text(launcher)
+    (destination / "bin/mosh").chmod(0o755)
+    processed = []
+    while queue:
+        original, target = queue.pop(0)
+        changes = []
+        identity = None
+        if target.parent.name == "lib":
+            identities = run("otool", "-D", str(original)).splitlines()[1:]
+            identity = identities[0] if identities else None
+        for dep in dependencies(original):
+            if dep == identity or dep.startswith(SYSTEM_PATHS):
+                continue
+            library = resolve_dependency(dep, original, brew_prefix)
+            previous = libraries.get(library.name)
+            if previous is not None and previous != library:
+                raise RuntimeError(f"Library filename collision: {previous} and {library}")
+            bundled = destination / "lib" / library.name
+            if previous is None:
+                libraries[library.name] = library
+                shutil.copy2(library, bundled)
+                bundled.chmod(0o755)
+                queue.append((library, bundled))
+                formula = next((p for p in library.parents
+                                if (p / "INSTALL_RECEIPT.json").is_file()), None)
+                if formula is not None:
+                    formulas.add(formula)
+            relative = os.path.relpath(bundled, target.parent)
+            changes.extend(["-change", dep, "@loader_path/" + relative])
+        if target.parent.name == "lib":
+            changes.extend(["-id", "@loader_path/" + target.name])
+        for entry in set(rpaths(original)):
+            if entry.startswith(str(brew_prefix) + "/"):
+                changes.extend(["-delete_rpath", entry])
+        if changes:
+            run("install_name_tool", *changes, str(target))
+        processed.append(target)
+    for formula in sorted(formulas):
+        licenses = destination / "licenses" / formula.parent.name
+        licenses.mkdir(exist_ok=True)
+        for path in formula.iterdir():
+            if path.is_file() and path.name.upper().startswith(("LICENSE", "COPYING", "NOTICE", "AUTHORS")):
+                shutil.copy2(path, licenses / path.name)
+        terminfo = formula / "share/terminfo"
+        if terminfo.is_dir():
+            shutil.copytree(terminfo, destination / "share/terminfo", symlinks=True)
+    shutil.copy2(source / "COPYING", destination / "COPYING")
+    for target in processed:
+        run("codesign", "--force", "--sign", "-", str(target))
+        run("codesign", "--verify", "--strict", str(target))
+        for dep in dependencies(target):
+            if dep.startswith("@loader_path/"):
+                resolved = (target.parent / dep[len("@loader_path/"):]).resolve(strict=True)
+                if destination not in resolved.parents:
+                    raise RuntimeError(f"Dependency escapes bundle: {dep}")
+            elif not dep.startswith(SYSTEM_PATHS):
+                raise RuntimeError(f"External runtime dependency remains: {dep}")
+    manifest = {"libraries": {name: str(path.relative_to(brew_prefix))
+                              for name, path in sorted(libraries.items())}}
+    (destination / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    for name in ("mosh-client", "mosh-server"):
+        print(run(str(destination / "bin" / name), "--version"))
+    print(f"Verified {len(processed)} Mach-O files; no external Homebrew runtime dependencies.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("build", type=Path, help="Configured and compiled native Mosh build directory")
+    parser.add_argument("destination", type=Path, help="New directory to create (must not exist)")
+    parser.add_argument("--brew-prefix", type=Path, help="Homebrew prefix (default: brew --prefix)")
+    args = parser.parse_args()
+    if sys.platform != "darwin":
+        parser.error("This tool requires macOS and Xcode command line tools")
+    prefix = args.brew_prefix or Path(run("brew", "--prefix"))
+    try:
+        package(args.build.resolve(), args.destination.resolve(), prefix.resolve())
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
+        parser.exit(1, f"Packaging failed: {error}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/macosx/test-bundle-runtime.py
+++ b/macosx/test-bundle-runtime.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Exercise packaging with real Mach-O dependency graphs on macOS."""
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location("bundle_runtime", Path(__file__).with_name("bundle-runtime.py"))
+bundle = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bundle)
+
+
+@unittest.skipUnless(sys.platform == "darwin", "requires Mach-O tools")
+class BundleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="mosh bundle test ")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve()
+        self.prefix = self.root / "brew"
+        self.formula = self.prefix / "Cellar/example/1.0"
+        self.lib = self.formula / "lib"
+        self.lib.mkdir(parents=True)
+        (self.formula / "INSTALL_RECEIPT.json").write_text("{}")
+        (self.formula / "LICENSE").write_text("fixture license\n")
+        self.source = self.root / "source"
+        (self.source / "src/frontend").mkdir(parents=True)
+        (self.source / "scripts").mkdir()
+        (self.source / "COPYING").write_text("fixture copying\n")
+        (self.source / "scripts/mosh").write_text(
+            "#!/usr/bin/env perl\nmy $client = 'mosh-client';\nexec $client, @ARGV;\n")
+        self.output = self.root / "output"
+
+    def compile(self, code, output, *flags):
+        subprocess.run(["clang", "-x", "c", "-", "-o", str(output),
+                        "-Wl,-headerpad_max_install_names", *flags],
+                       input=code, text=True, check=True, capture_output=True)
+
+    def build_graph(self):
+        self.compile("int answer(void) { return 42; }", self.lib / "libanswer.dylib",
+                     "-dynamiclib", "-Wl,-install_name,@rpath/libanswer.dylib")
+        self.compile("extern int answer(void); int indirect(void) { return answer(); }",
+                     self.lib / "libindirect.dylib", "-dynamiclib",
+                     "-Wl,-install_name," + str(self.lib / "libindirect.dylib"),
+                     "-Wl,-rpath,@loader_path", "-L" + str(self.lib), "-lanswer")
+        code = '#include <stdio.h>\nextern int indirect(void); int main(void) { printf("%d\\n", indirect()); return 0; }'
+        self.compile(code, self.source / "src/frontend/mosh-client",
+                     "-L" + str(self.lib), "-lindirect", "-Wl,-rpath," + str(self.lib))
+        shutil.copy2(self.source / "src/frontend/mosh-client", self.source / "src/frontend/mosh-server")
+
+    def test_relocation_without_original_libraries_and_path_shadowing(self):
+        self.build_graph()
+        bundle.package(self.source, self.output, self.prefix)
+        relocated = self.root / "relocated bundle"
+        self.output.rename(relocated)
+        self.prefix.rename(self.root / "unavailable-brew")
+        decoy = self.root / "decoy"
+        decoy.mkdir()
+        (decoy / "mosh-client").write_text("#!/bin/sh\nexit 99\n")
+        (decoy / "mosh-client").chmod(0o755)
+        entry = self.root / "mosh"
+        entry.symlink_to(relocated / "bin/mosh")
+        result = subprocess.check_output([str(entry), "--version"], text=True,
+                                         env={**os.environ, "PATH": str(decoy) + ":/usr/bin:/bin"})
+        self.assertEqual(result.strip(), "42")
+        self.assertEqual((relocated / "licenses/example/LICENSE").read_text(), "fixture license\n")
+        for binary in list((relocated / "lib").iterdir()) + [relocated / "bin/mosh-client"]:
+            self.assertTrue(all(not d.startswith(str(self.prefix)) for d in bundle.dependencies(binary)))
+            self.assertTrue(all(not r.startswith(str(self.prefix)) for r in bundle.rpaths(binary)))
+            bundle.run("codesign", "--verify", "--strict", str(binary))
+
+    def test_existing_destination_is_preserved(self):
+        self.output.mkdir()
+        sentinel = self.output / "keep"
+        sentinel.write_text("existing installation")
+        with self.assertRaises(FileExistsError):
+            bundle.package(self.source, self.output, self.prefix)
+        self.assertEqual(sentinel.read_text(), "existing installation")
+
+    def test_rejects_dependency_outside_selected_prefix(self):
+        external = self.root / "external.dylib"
+        external.write_bytes(b"not a bundled library")
+        with self.assertRaisesRegex(RuntimeError, "Non-Homebrew"):
+            bundle.resolve_dependency(str(external), self.root / "binary", self.prefix)
+
+    def test_rejects_ambiguous_rpath(self):
+        self.build_graph()
+        other = self.prefix / "other"
+        other.mkdir()
+        shutil.copy2(self.lib / "libanswer.dylib", other / "libanswer.dylib")
+        library = self.lib / "libindirect.dylib"
+        bundle.run("install_name_tool", "-add_rpath", str(other), str(library))
+        with self.assertRaisesRegex(RuntimeError, "unambiguously"):
+            bundle.resolve_dependency("@rpath/libanswer.dylib", library, self.prefix)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem and resulting behavior

A native macOS Mosh build can stop launching after a Homebrew upgrade removes a versioned Protobuf or Abseil dynamic library against which it was linked. Changing PATH or unlinking Homebrew's Mosh formula does not repair those missing runtime dependencies.

This PR adds an optional packaging helper that takes an already compiled Mosh build and creates a relocatable directory containing the client, server, launcher, and private copies of their Homebrew runtime libraries. The packaged launcher explicitly selects its sibling client, so another `mosh-client` on PATH cannot silently replace it.

## Implementation

- Discover the Homebrew prefix with `brew --prefix`, with an explicit `--brew-prefix` override. There are no hard-coded user directories, hostnames, network addresses, Homebrew versions, or CPU architecture selections.
- Traverse the Mach-O dependency graph, including supported `@rpath` and `@loader_path` dependencies. Rewrite bundled references to loader-relative paths and remove absolute Homebrew runtime search paths. Apple system libraries remain system dependencies.
- Reject dependencies outside the selected Homebrew prefix, ambiguous runtime search paths, and library filename collisions rather than producing a silently incomplete bundle.
- Copy dependency license notices and available terminfo data. Configure the packaged launcher to include its private terminfo database and write a manifest using paths relative to the Homebrew prefix.
- Ad-hoc sign and verify modified binaries, verify the rewritten dependency graph, and check both executables with `--version`.
- Refuse to overwrite an existing destination. Document partial-output handling, installation, reconnection, and dependency maintenance.

The documentation is linked from the main README, the new files are included in source distributions, and the macOS CI job runs the packaging tests and packages the real build.

## Validation

Local validation was performed on macOS arm64:

- Four packaging integration tests passed. A real, compiled transitive dylib graph is packaged, moved to a path containing spaces, and executed after the original library prefix is renamed away. The launcher is invoked through a symlink with a competing client on PATH. Tests also cover signature verification, license preservation, existing-destination protection, and rejection of external or ambiguous dependencies.
- Five upstream tests passed: `ocb-aes`, `encrypt-decrypt`, `base64`, `nonce-incr`, and `local.test`.
- The helper packaged a real build of current upstream Mosh; all 84 Mach-O files passed dependency/signature verification and both packaged executables started successfully.
- Source-distribution contents and `git diff --check` were checked.

Intel macOS has not been tested locally; prefix and path handling are discovered rather than architecture-specific. The full tmux-dependent terminal test suite was not run locally.

## Scope and maintenance

This is an optional helper for native macOS/Homebrew builds, not a universal-architecture installer or a cross-platform packaging system. It does not replace the existing macOS installer script, notarize artifacts, modify shell or Homebrew configuration, or change Mosh's terminal protocol and clipboard implementation.

Private dependencies intentionally survive Homebrew upgrades. Users must rebuild their bundles to incorporate dependency security fixes; this tradeoff is documented. No generated binaries, machine configuration, or local diagnostic logs are included in this PR.
